### PR TITLE
RFC: Signals redux

### DIFF
--- a/ffi/mod.rs
+++ b/ffi/mod.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::libc::{c_int, c_char, c_void, c_float, c_uint, c_double, c_long, c_short};
+use std::libc::{c_int, c_char, c_void, c_float, c_uint, c_double, c_long, c_ulong, c_short};
 
 use gtk::enums::*;
 use gdk;
@@ -75,6 +75,8 @@ pub struct C_GtkSeparatorToolItem;
 pub struct C_GtkMenu;
 pub struct C_GMenuModel;
 
+pub struct C_GClosure;
+
 pub struct C_GdkEvent;
 pub struct C_GdkWindow;
 
@@ -83,6 +85,14 @@ pub struct C_GdkEventAny {
     window: *C_GdkWindow,
     send_event: i8,
 }
+
+pub type gpointer = *c_void;
+pub type GCallback = Option<extern "C" fn()>;
+pub type GClosureNotify = Option<extern "C" fn(data: gpointer, closure: *C_GClosure)>;
+
+pub type GConnectFlags = c_int;
+pub static G_CONNECT_AFTER:   c_int = 1;
+pub static G_CONNECT_SWAPPED: c_int = 2;
 
 #[repr(C)]
 pub enum GdkEventType {
@@ -932,6 +942,11 @@ extern "C" {
     // pub fn gtk_menu_tool_button_get_menu       (button: *C_GtkMenuToolButton) -> *C_GtkWidget;
     pub fn gtk_menu_tool_button_set_arrow_tooltip_text(button: *C_GtkMenuToolButton, text: *c_char) -> ();
     pub fn gtk_menu_tool_button_set_arrow_tooltip_markup(button: *C_GtkMenuToolButton, markup: *c_char) -> ();
+
+    //=========================================================================
+    // GObject
+    //=========================================================================
+    pub fn g_signal_connect_data    (instance: gpointer, detailed_signal: *c_char, c_handler: GCallback, data: gpointer, destroy_data: GClosureNotify, connect_flags: GConnectFlags) -> c_ulong;
 
     //=========================================================================
     // Glu fixe code

--- a/ffi/mod.rs
+++ b/ffi/mod.rs
@@ -75,6 +75,60 @@ pub struct C_GtkSeparatorToolItem;
 pub struct C_GtkMenu;
 pub struct C_GMenuModel;
 
+pub struct C_GdkEvent;
+pub struct C_GdkWindow;
+
+pub struct C_GdkEventAny {
+    event_type: GdkEventType,
+    window: *C_GdkWindow,
+    send_event: i8,
+}
+
+#[repr(C)]
+pub enum GdkEventType {
+  GDK_NOTHING		= -1,
+  GDK_DELETE		= 0,
+  GDK_DESTROY		= 1,
+  GDK_EXPOSE		= 2,
+  GDK_MOTION_NOTIFY = 3,
+  GDK_BUTTON_PRESS = 4,
+  GDK_DOUBLE_BUTTON_PRESS = 5,
+  GDK_TRIPLE_BUTTON_PRESS = 6,
+  GDK_BUTTON_RELEASE = 7,
+  GDK_KEY_PRESS		= 8,
+  GDK_KEY_RELEASE = 9,
+  GDK_ENTER_NOTIFY = 10,
+  GDK_LEAVE_NOTIFY = 11,
+  GDK_FOCUS_CHANGE = 12,
+  GDK_CONFIGURE		= 13,
+  GDK_MAP		= 14,
+  GDK_UNMAP		= 15,
+  GDK_PROPERTY_NOTIFY = 16,
+  GDK_SELECTION_CLEAR = 17,
+  GDK_SELECTION_REQUEST = 18,
+  GDK_SELECTION_NOTIFY = 19,
+  GDK_PROXIMITY_IN = 20,
+  GDK_PROXIMITY_OUT = 21,
+  GDK_DRAG_ENTER        = 22,
+  GDK_DRAG_LEAVE        = 23,
+  GDK_DRAG_MOTION       = 24,
+  GDK_DRAG_STATUS       = 25,
+  GDK_DROP_START        = 26,
+  GDK_DROP_FINISHED     = 27,
+  GDK_CLIENT_EVENT = 28,
+  GDK_VISIBILITY_NOTIFY = 29,
+  GDK_SCROLL            = 31,
+  GDK_WINDOW_STATE      = 32,
+  GDK_SETTING           = 33,
+  GDK_OWNER_CHANGE      = 34,
+  GDK_GRAB_BROKEN       = 35,
+  GDK_DAMAGE            = 36,
+  GDK_TOUCH_BEGIN       = 37,
+  GDK_TOUCH_UPDATE      = 38,
+  GDK_TOUCH_END         = 39,
+  GDK_TOUCH_CANCEL      = 40,
+}
+
 extern "C" {
 
     //=========================================================================

--- a/gdk/event.rs
+++ b/gdk/event.rs
@@ -13,8 +13,28 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-pub use gdk::color::Color;
-pub use gdk::color::RGBA;
+use std::ptr;
 
-pub mod color;
-pub mod event;
+use ffi;
+
+pub struct Event {
+    priv pointer: *ffi::C_GdkEvent,
+}
+
+impl Event {
+    pub fn wrap(pointer: *ffi::C_GdkEvent) -> Event {
+        assert!(pointer != ptr::null());
+        Event {
+            pointer: pointer,
+        }
+    }
+
+    pub fn get_event_type(&self) -> ffi::GdkEventType {
+        let any = self.pointer as *ffi::C_GdkEventAny;
+        unsafe {
+            (*any).event_type
+        }
+    }
+
+    // TODO...
+}

--- a/gtk/alignment.rs
+++ b/gtk/alignment.rs
@@ -27,7 +27,6 @@ use ffi;
 pub struct Alignment {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl Alignment {
@@ -72,12 +71,6 @@ impl Alignment {
 }
 
 impl_GtkWidget!(Alignment)
-redirect_callback!(Alignment)
-redirect_callback_widget!(Alignment)
-struct_signal!(Alignment)
-impl_signals!(Alignment)
 
 impl GtkContainer for Alignment {}
 impl GtkBin for Alignment {}
-
-

--- a/gtk/arrow.rs
+++ b/gtk/arrow.rs
@@ -27,7 +27,6 @@ use ffi;
 pub struct Arrow {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl Arrow {
@@ -44,9 +43,5 @@ impl Arrow {
 }
 
 impl_GtkWidget!(Arrow)
-redirect_callback!(Arrow)
-redirect_callback_widget!(Arrow)
-struct_signal!(Arrow)
-impl_signals!(Arrow)
 
 impl GtkMisc for Arrow {}

--- a/gtk/aspectframe.rs
+++ b/gtk/aspectframe.rs
@@ -26,7 +26,6 @@ use ffi;
 pub struct AspectFrame {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl AspectFrame {
@@ -57,10 +56,6 @@ impl AspectFrame {
 }
 
 impl_GtkWidget!(AspectFrame)
-redirect_callback!(AspectFrame)
-redirect_callback_widget!(AspectFrame)
-struct_signal!(AspectFrame)
-impl_signals!(AspectFrame)
 
 impl GtkFrame for AspectFrame {}
 impl GtkContainer for AspectFrame {}

--- a/gtk/box.rs
+++ b/gtk/box.rs
@@ -26,7 +26,6 @@ use ffi;
 pub struct Box {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl Box {
@@ -37,10 +36,6 @@ impl Box {
 }
 
 impl_GtkWidget!(Box)
-redirect_callback!(Box)
-redirect_callback_widget!(Box)
-struct_signal!(Box)
-impl_signals!(Box)
 
 impl GtkContainer for Box {}
 impl GtkBox for Box {}

--- a/gtk/button.rs
+++ b/gtk/button.rs
@@ -36,7 +36,6 @@ use gtk::enums::GtkIconSize;
 pub struct Button {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl Button {
@@ -83,10 +82,6 @@ impl Button {
 }
 
 impl_GtkWidget!(Button)
-redirect_callback!(Button)
-redirect_callback_widget!(Button)
-struct_signal!(Button)
-impl_signals!(Button)
 
 impl GtkContainer for Button {}
 impl GtkButton for Button {}

--- a/gtk/buttonbox.rs
+++ b/gtk/buttonbox.rs
@@ -27,7 +27,6 @@ use ffi;
 pub struct ButtonBox {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl ButtonBox {
@@ -78,13 +77,7 @@ impl ButtonBox {
 }
 
 impl_GtkWidget!(ButtonBox)
-redirect_callback!(ButtonBox)
-redirect_callback_widget!(ButtonBox)
-struct_signal!(ButtonBox)
-impl_signals!(ButtonBox)
 
 impl GtkContainer for ButtonBox {}
 impl GtkBox for ButtonBox {}
 impl GtkOrientable for ButtonBox {}
-
-

--- a/gtk/calendar.rs
+++ b/gtk/calendar.rs
@@ -38,7 +38,6 @@ use ffi;
 pub struct Calendar {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl Calendar {
@@ -133,11 +132,3 @@ impl Calendar {
 }
 
 impl_GtkWidget!(Calendar)
-redirect_callback!(Calendar)
-redirect_callback_widget!(Calendar)
-struct_signal!(Calendar)
-impl_signals!(Calendar)
-
-
-
-

--- a/gtk/checkbutton.rs
+++ b/gtk/checkbutton.rs
@@ -25,7 +25,6 @@ use ffi;
 pub struct CheckButton {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl CheckButton {
@@ -55,11 +54,6 @@ impl CheckButton {
 }
 
 impl_GtkWidget!(CheckButton)
-redirect_callback!(CheckButton)
-redirect_callback_widget!(CheckButton)
-struct_signal!(CheckButton)
-impl_signals!(CheckButton)
-
 
 impl GtkContainer for CheckButton {}
 impl GtkButton for CheckButton {}

--- a/gtk/colorbutton.rs
+++ b/gtk/colorbutton.rs
@@ -32,7 +32,6 @@ use gdk;
 pub struct ColorButton {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl ColorButton {
@@ -120,11 +119,6 @@ impl ColorButton {
 }
 
 impl_GtkWidget!(ColorButton)
-redirect_callback!(ColorButton)
-redirect_callback_widget!(ColorButton)
-struct_signal!(ColorButton)
-impl_signals!(ColorButton)
 
 impl GtkContainer for ColorButton {}
 impl GtkButton for ColorButton {}
-

--- a/gtk/entry.rs
+++ b/gtk/entry.rs
@@ -43,7 +43,6 @@ use ffi;
 pub struct Entry {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl Entry {
@@ -59,9 +58,5 @@ impl Entry {
 }
 
 impl_GtkWidget!(Entry)
-redirect_callback!(Entry)
-redirect_callback_widget!(Entry)
-struct_signal!(Entry)
-impl_signals!(Entry)
 
 impl GtkEntry for Entry {}

--- a/gtk/expander.rs
+++ b/gtk/expander.rs
@@ -27,7 +27,6 @@ use ffi;
 pub struct Expander {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl Expander {
@@ -162,11 +161,6 @@ impl Expander {
 }
 
 impl_GtkWidget!(Expander)
-redirect_callback!(Expander)
-redirect_callback_widget!(Expander)
-struct_signal!(Expander)
-impl_signals!(Expander)
 
 impl GtkContainer for Expander {}
 impl GtkBin for Expander {}
-

--- a/gtk/fixed.rs
+++ b/gtk/fixed.rs
@@ -26,7 +26,6 @@ use ffi;
 pub struct Fixed {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl Fixed {
@@ -55,9 +54,5 @@ impl Fixed {
 }
 
 impl_GtkWidget!(Fixed)
-redirect_callback!(Fixed)
-redirect_callback_widget!(Fixed)
-struct_signal!(Fixed)
-impl_signals!(Fixed)
 
 impl GtkContainer for Fixed {}

--- a/gtk/fontbutton.rs
+++ b/gtk/fontbutton.rs
@@ -31,7 +31,6 @@ use utils::cast::GTK_FONTBUTTON;
 pub struct FontButton {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl FontButton {
@@ -133,11 +132,6 @@ impl FontButton {
 
 
 impl_GtkWidget!(FontButton)
-redirect_callback!(FontButton)
-redirect_callback_widget!(FontButton)
-struct_signal!(FontButton)
-impl_signals!(FontButton)
 
 impl GtkContainer for FontButton {}
 impl GtkButton for FontButton {}
-

--- a/gtk/frame.rs
+++ b/gtk/frame.rs
@@ -25,7 +25,6 @@ use ffi;
 pub struct Frame {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl Frame {
@@ -39,10 +38,6 @@ impl Frame {
 }
 
 impl_GtkWidget!(Frame)
-redirect_callback!(Frame)
-redirect_callback_widget!(Frame)
-struct_signal!(Frame)
-impl_signals!(Frame)
 
 impl GtkFrame for Frame {}
 impl GtkContainer for Frame {}

--- a/gtk/grid.rs
+++ b/gtk/grid.rs
@@ -27,7 +27,6 @@ use ffi;
 pub struct Grid {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl Grid {
@@ -165,15 +164,6 @@ impl Grid {
 
 
 impl_GtkWidget!(Grid)
-redirect_callback!(Grid)
-redirect_callback_widget!(Grid)
-struct_signal!(Grid)
-impl_signals!(Grid)
 
 impl GtkContainer for Grid {}
 impl GtkOrientable for Grid {}
-
-   
-    
-    
-   

--- a/gtk/image.rs
+++ b/gtk/image.rs
@@ -25,7 +25,6 @@ use ffi;
 pub struct Image {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl Image {
@@ -40,9 +39,5 @@ impl Image {
 }
 
 impl_GtkWidget!(Image)
-redirect_callback!(Image)
-redirect_callback_widget!(Image)
-struct_signal!(Image)
-impl_signals!(Image)
 
 impl GtkMisc for Image {}

--- a/gtk/infobar.rs
+++ b/gtk/infobar.rs
@@ -28,7 +28,6 @@ use ffi;
 pub struct InfoBar {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl InfoBar {
@@ -99,10 +98,6 @@ impl InfoBar {
 }
 
 impl_GtkWidget!(InfoBar)
-// redirect_callback!(InfoBar)
-// redirect_callback_widget!(InfoBar)
-struct_signal!(InfoBar)
-// impl_signals!(InfoBar)
 
 impl GtkContainer for InfoBar {}
 impl GtkBox for InfoBar {}

--- a/gtk/label.rs
+++ b/gtk/label.rs
@@ -34,7 +34,6 @@ use ffi;
 pub struct Label {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl Label {
@@ -58,10 +57,6 @@ impl Label {
 }
 
 impl_GtkWidget!(Label)
-redirect_callback!(Label)
-redirect_callback_widget!(Label)
-struct_signal!(Label)
-impl_signals!(Label)
 
 impl GtkMisc for Label {}
 impl GtkLabel for Label {}

--- a/gtk/levelbar.rs
+++ b/gtk/levelbar.rs
@@ -32,7 +32,6 @@ use ffi;
 pub struct LevelBar {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl LevelBar {
@@ -134,9 +133,5 @@ impl LevelBar {
 }
 
 impl_GtkWidget!(LevelBar)
-redirect_callback!(LevelBar)
-redirect_callback_widget!(LevelBar)
-struct_signal!(LevelBar)
-impl_signals!(LevelBar)
 
 impl GtkOrientable for LevelBar {}

--- a/gtk/linkbutton.rs
+++ b/gtk/linkbutton.rs
@@ -31,7 +31,6 @@ use ffi;
 pub struct LinkButton {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl LinkButton {
@@ -84,11 +83,6 @@ impl LinkButton {
 }
 
 impl_GtkWidget!(LinkButton)
-redirect_callback!(LinkButton)
-redirect_callback_widget!(LinkButton)
-struct_signal!(LinkButton)
-impl_signals!(LinkButton)
 
 impl GtkContainer for LinkButton {}
 impl GtkButton for LinkButton {}
-

--- a/gtk/menubutton.rs
+++ b/gtk/menubutton.rs
@@ -27,7 +27,6 @@ use gtk::enums::GtkArrowType;
 pub struct MenuButton {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl MenuButton {
@@ -62,12 +61,7 @@ impl MenuButton {
 }
 
 impl_GtkWidget!(MenuButton)
-redirect_callback!(MenuButton)
-redirect_callback_widget!(MenuButton)
-struct_signal!(MenuButton)
-impl_signals!(MenuButton)
 
 impl GtkContainer for MenuButton {}
 impl GtkButton for MenuButton {}
 impl GtkToggleButton for MenuButton {}
-

--- a/gtk/menutoolbutton.rs
+++ b/gtk/menutoolbutton.rs
@@ -26,7 +26,6 @@ use ffi;
 pub struct MenuToolButton {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl MenuToolButton {
@@ -77,13 +76,8 @@ impl MenuToolButton {
 }
 
 impl_GtkWidget!(MenuToolButton)
-redirect_callback!(MenuToolButton)
-redirect_callback_widget!(MenuToolButton)
-struct_signal!(MenuToolButton)
-impl_signals!(MenuToolButton)
 
 impl GtkContainer for MenuToolButton {}
 impl GtkBin for MenuToolButton {}
 impl GtkToolItem for MenuToolButton {}
 impl GtkToolButton for MenuToolButton {}
-

--- a/gtk/mod.rs
+++ b/gtk/mod.rs
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
+pub use gtk::widget::Widget;
 pub use gtk::window::Window;
 pub use gtk::label::Label;
 pub use gtk::button::Button;
@@ -58,6 +59,7 @@ pub use gtk::menutoolbutton::MenuToolButton;
 
 pub mod enums;
 pub mod version;
+pub mod widget;
 pub mod window;
 pub mod label;
 pub mod button;
@@ -102,5 +104,3 @@ pub mod toggletoolbutton;
 pub mod menutoolbutton;
 
 pub mod cast;
-
-

--- a/gtk/paned.rs
+++ b/gtk/paned.rs
@@ -38,7 +38,6 @@ use gtk;
 pub struct Paned {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl Paned {
@@ -95,10 +94,5 @@ impl Paned {
 }
 
 impl_GtkWidget!(Paned)
-redirect_callback!(Paned)
-redirect_callback_widget!(Paned)
-struct_signal!(Paned)
-impl_signals!(Paned)
 
 impl GtkContainer for Paned {}
-

--- a/gtk/progressbar.rs
+++ b/gtk/progressbar.rs
@@ -27,7 +27,6 @@ use utils::cast::GTK_PROGRESSBAR;
 pub struct ProgressBar {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl ProgressBar {
@@ -111,10 +110,5 @@ impl ProgressBar {
 }
 
 impl_GtkWidget!(ProgressBar)
-redirect_callback!(ProgressBar)
-redirect_callback_widget!(ProgressBar)
-struct_signal!(ProgressBar)
-impl_signals!(ProgressBar)
 
 impl GtkOrientable for ProgressBar {}
-

--- a/gtk/scale.rs
+++ b/gtk/scale.rs
@@ -35,7 +35,6 @@ use ffi;
 pub struct Scale {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl Scale {
@@ -130,9 +129,5 @@ impl Scale {
 }
 
 impl_GtkWidget!(Scale)
-redirect_callback!(Scale)
-redirect_callback_widget!(Scale)
-struct_signal!(Scale)
-impl_signals!(Scale)
 
 impl GtkOrientable for Scale {}

--- a/gtk/scalebutton.rs
+++ b/gtk/scalebutton.rs
@@ -33,7 +33,6 @@ use gtk::enums::GtkIconSize;
 pub struct ScaleButton {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl ScaleButton {
@@ -47,10 +46,6 @@ impl ScaleButton {
 
 
 impl_GtkWidget!(ScaleButton)
-redirect_callback!(ScaleButton)
-redirect_callback_widget!(ScaleButton)
-struct_signal!(ScaleButton)
-impl_signals!(ScaleButton)
 
 impl GtkContainer for ScaleButton {}
 impl GtkButton for ScaleButton {}

--- a/gtk/searchbar.rs
+++ b/gtk/searchbar.rs
@@ -28,7 +28,6 @@ use ffi;
 pub struct SearchBar {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl SearchBar {
@@ -73,10 +72,6 @@ impl SearchBar {
 }
 
 impl_GtkWidget!(SearchBar)
-redirect_callback!(SearchBar)
-redirect_callback_widget!(SearchBar)
-struct_signal!(SearchBar)
-impl_signals!(SearchBar)
 
 impl GtkContainer for SearchBar {}
 impl GtkBin for SearchBar {}

--- a/gtk/searchentry.rs
+++ b/gtk/searchentry.rs
@@ -30,7 +30,6 @@ use ffi;
 pub struct SearchEntry {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl SearchEntry {
@@ -41,9 +40,5 @@ impl SearchEntry {
 }
 
 impl_GtkWidget!(SearchEntry)
-redirect_callback!(SearchEntry)
-redirect_callback_widget!(SearchEntry)
-struct_signal!(SearchEntry)
-impl_signals!(SearchEntry)
 
 impl GtkEntry for SearchEntry {}

--- a/gtk/separator.rs
+++ b/gtk/separator.rs
@@ -26,7 +26,6 @@ use gtk::enums::GtkOrientation;
 pub struct Separator {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl Separator {
@@ -37,9 +36,5 @@ impl Separator {
 }
 
 impl_GtkWidget!(Separator)
-redirect_callback!(Separator)
-redirect_callback_widget!(Separator)
-struct_signal!(Separator)
-impl_signals!(Separator)
 
 impl GtkOrientable for Separator {}

--- a/gtk/separatortoolitem.rs
+++ b/gtk/separatortoolitem.rs
@@ -26,7 +26,6 @@ use utils::cast::GTK_SEPARATORTOOLITEM;
 pub struct SeparatorToolItem {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl SeparatorToolItem {
@@ -51,10 +50,6 @@ impl SeparatorToolItem {
 }
 
 impl_GtkWidget!(SeparatorToolItem)
-redirect_callback!(SeparatorToolItem)
-redirect_callback_widget!(SeparatorToolItem)
-struct_signal!(SeparatorToolItem)
-impl_signals!(SeparatorToolItem)
 
 impl GtkContainer for SeparatorToolItem {}
 impl GtkBin for SeparatorToolItem {}

--- a/gtk/spinbutton.rs
+++ b/gtk/spinbutton.rs
@@ -38,7 +38,6 @@ use ffi;
 pub struct SpinButton {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl SpinButton {
@@ -203,10 +202,6 @@ impl SpinButton {
 // pub fn gtk_spin_button_get_value           (spin_button: *C_GtkSpinButton) -> c_double;
 
 impl_GtkWidget!(SpinButton)
-redirect_callback!(SpinButton)
-redirect_callback_widget!(SpinButton)
-struct_signal!(SpinButton)
-impl_signals!(SpinButton)
 
 impl GtkEntry for SpinButton {}
 impl GtkOrientable for SpinButton {}

--- a/gtk/spinner.rs
+++ b/gtk/spinner.rs
@@ -26,7 +26,6 @@ use ffi;
 pub struct Spinner {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl Spinner {
@@ -50,7 +49,3 @@ impl Spinner {
 }
 
 impl_GtkWidget!(Spinner)
-redirect_callback!(Spinner)
-redirect_callback_widget!(Spinner)
-struct_signal!(Spinner)
-impl_signals!(Spinner)

--- a/gtk/switch.rs
+++ b/gtk/switch.rs
@@ -31,7 +31,6 @@ use ffi;
 pub struct Switch {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl Switch {
@@ -56,7 +55,3 @@ impl Switch {
 }
 
 impl_GtkWidget!(Switch)
-redirect_callback!(Switch)
-redirect_callback_widget!(Switch)
-struct_signal!(Switch)
-impl_signals!(Switch)

--- a/gtk/togglebutton.rs
+++ b/gtk/togglebutton.rs
@@ -30,7 +30,6 @@ use ffi;
 pub struct ToggleButton {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl ToggleButton {
@@ -60,10 +59,6 @@ impl ToggleButton {
 }
 
 impl_GtkWidget!(ToggleButton)
-redirect_callback!(ToggleButton)
-redirect_callback_widget!(ToggleButton)
-struct_signal!(ToggleButton)
-impl_signals!(ToggleButton)
 
 impl GtkContainer for ToggleButton {}
 impl GtkButton for ToggleButton {}

--- a/gtk/toggletoolbutton.rs
+++ b/gtk/toggletoolbutton.rs
@@ -25,7 +25,6 @@ use ffi;
 pub struct ToggleToolButton {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl ToggleToolButton {
@@ -43,10 +42,6 @@ impl ToggleToolButton {
 }
 
 impl_GtkWidget!(ToggleToolButton)
-redirect_callback!(ToggleToolButton)
-redirect_callback_widget!(ToggleToolButton)
-struct_signal!(ToggleToolButton)
-impl_signals!(ToggleToolButton)
 
 impl GtkContainer for ToggleToolButton {}
 impl GtkBin for ToggleToolButton {}

--- a/gtk/toolbar.rs
+++ b/gtk/toolbar.rs
@@ -36,7 +36,6 @@ use gtk::enums::{GtkIconSize, GtkReliefStyle, GtkToolbarStyle};
 pub struct Toolbar {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl Toolbar {
@@ -146,12 +145,7 @@ impl Toolbar {
 }
 
 impl_GtkWidget!(Toolbar)
-redirect_callback!(Toolbar)
-redirect_callback_widget!(Toolbar)
-struct_signal!(Toolbar)
-impl_signals!(Toolbar)
 
 impl GtkContainer for Toolbar {}
 impl GtkToolShell for Toolbar {}
 impl GtkOrientable for Toolbar {}
-

--- a/gtk/toolbutton.rs
+++ b/gtk/toolbutton.rs
@@ -25,7 +25,6 @@ use ffi;
 pub struct ToolButton {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl ToolButton {
@@ -60,10 +59,6 @@ impl ToolButton {
 }
 
 impl_GtkWidget!(ToolButton)
-redirect_callback!(ToolButton)
-redirect_callback_widget!(ToolButton)
-struct_signal!(ToolButton)
-impl_signals!(ToolButton)
 
 impl GtkContainer for ToolButton {}
 impl GtkBin for ToolButton {}

--- a/gtk/toolitem.rs
+++ b/gtk/toolitem.rs
@@ -25,7 +25,6 @@ use ffi;
 pub struct ToolItem {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl ToolItem {
@@ -36,10 +35,6 @@ impl ToolItem {
 }
 
 impl_GtkWidget!(ToolItem)
-redirect_callback!(ToolItem)
-redirect_callback_widget!(ToolItem)
-struct_signal!(ToolItem)
-impl_signals!(ToolItem)
 
 impl GtkContainer for ToolItem {}
 impl GtkBin for ToolItem {}

--- a/gtk/volumebutton.rs
+++ b/gtk/volumebutton.rs
@@ -25,7 +25,6 @@ use ffi;
 pub struct VolumeButton {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl VolumeButton {
@@ -36,10 +35,6 @@ impl VolumeButton {
 }
 
 impl_GtkWidget!(VolumeButton)
-redirect_callback!(VolumeButton)
-redirect_callback_widget!(VolumeButton)
-struct_signal!(VolumeButton)
-impl_signals!(VolumeButton)
 
 impl GtkContainer for VolumeButton {}
 impl GtkButton for VolumeButton {}

--- a/gtk/widget.rs
+++ b/gtk/widget.rs
@@ -17,18 +17,10 @@ use traits::{GtkWidget};
 use ffi;
 use gtk;
 
+/// Can not be explicitly instantiated
 pub struct Widget {
-    priv pointer:           *ffi::C_GtkWidget
+    priv pointer:           *ffi::C_GtkWidget,
+    priv can_drop:          bool,
 }
 
-impl Widget {
-    pub fn wrap(pointer: *ffi::C_GtkWidget) -> Widget {
-        Widget {
-            pointer: pointer
-        }
-    }
-
-    pub fn to_entry(self) -> gtk::Entry {
-        GtkWidget::wrap_widget(self.pointer)
-    }
-}
+impl_GtkWidget!(Widget)

--- a/gtk/window.rs
+++ b/gtk/window.rs
@@ -21,6 +21,8 @@ use std::libc::c_void;
 use traits::{GtkWidget, GtkWindow, GtkContainer, GtkBin, Signal};
 use ffi;
 use gtk::enums::GtkWindowType;
+use gtk::Widget;
+use gdk::event::Event;
 
 /**
 * Window — Toplevel which can contain other widgets
@@ -48,3 +50,176 @@ impl_GtkWidget!(Window)
 impl GtkContainer for Window {}
 impl GtkWindow for Window {}
 impl GtkBin for Window {}
+
+///// All the default signals
+
+pub trait WindowDefaultHandler {
+    fn callback(&mut self, window: &Window);
+}
+
+extern_drop_handler!(drop_window_default_handler, WindowDefaultHandler)
+extern_default_callback!(window_default_callback, WindowDefaultHandler)
+
+// GtkWindow
+impl_connect_signal!(Window, drop_window_default_handler, window_default_callback, WindowDefaultHandler, connect_active_default_signal, "activate-default")
+impl_connect_signal!(Window, drop_window_default_handler, window_default_callback, WindowDefaultHandler, connect_active_focus_signal, "activate-focus")
+impl_connect_signal!(Window, drop_window_default_handler, window_default_callback, WindowDefaultHandler, connect_keys_changed_signal, "activate-focus")
+
+// GtkContainer
+impl_connect_signal!(Window, drop_window_default_handler, window_default_callback, WindowDefaultHandler, connect_check_resize_signal, "check-resize")
+
+// GtkWidget
+impl_connect_signal!(Window, drop_window_default_handler, window_default_callback, WindowDefaultHandler, connect_accel_closure_changed_signal, "accel-closure-changed")
+impl_connect_signal!(Window, drop_window_default_handler, window_default_callback, WindowDefaultHandler, connect_composited_changed_signal, "composited-changed")
+impl_connect_signal!(Window, drop_window_default_handler, window_default_callback, WindowDefaultHandler, connect_destroy_signal, "destroy")
+impl_connect_signal!(Window, drop_window_default_handler, window_default_callback, WindowDefaultHandler, connect_grab_focus_signal, "grab-focus")
+impl_connect_signal!(Window, drop_window_default_handler, window_default_callback, WindowDefaultHandler, connect_hide_signal, "hide")
+impl_connect_signal!(Window, drop_window_default_handler, window_default_callback, WindowDefaultHandler, connect_map_signal, "map")
+impl_connect_signal!(Window, drop_window_default_handler, window_default_callback, WindowDefaultHandler, connect_realize_signal, "realize")
+impl_connect_signal!(Window, drop_window_default_handler, window_default_callback, WindowDefaultHandler, connect_show_signal, "show")
+impl_connect_signal!(Window, drop_window_default_handler, window_default_callback, WindowDefaultHandler, connect_style_updated_signal, "style-updated")
+impl_connect_signal!(Window, drop_window_default_handler, window_default_callback, WindowDefaultHandler, connect_unmap_signal, "unmap")
+impl_connect_signal!(Window, drop_window_default_handler, window_default_callback, WindowDefaultHandler, connect_unrealize_signal, "unrealize")
+
+///// Custom signals
+
+pub trait WindowWidgetHandler {
+    fn callback(&mut self, window: &Window, widget: &Widget);
+}
+
+extern_drop_handler!(drop_window_widget_handler, WindowWidgetHandler)
+
+extern "C" fn window_widget_callback(object: *ffi::C_GtkWidget, widget: *ffi::C_GtkWidget, user_data: ffi::gpointer) {
+    let mut handler = unsafe { cast::transmute::<ffi::gpointer, ~~WindowWidgetHandler>(user_data) };
+
+    let window = GtkWidget::wrap_widget(object);
+    let widget = GtkWidget::wrap_widget(widget);
+    handler.callback(&window, &widget);
+
+    unsafe {
+        cast::forget(handler);
+    }
+}
+
+pub trait WindowBoolEventHandler {
+    fn callback(&mut self, window: &Window, event: &Event) -> bool;
+}
+
+extern_drop_handler!(drop_window_bool_event_handler, WindowBoolEventHandler)
+
+extern "C" fn window_bool_event_callback(object: *ffi::C_GtkWidget, event: *ffi::C_GdkEvent, user_data: ffi::gpointer) -> ffi::Gboolean {
+    let mut handler = unsafe { cast::transmute::<ffi::gpointer, ~~WindowBoolEventHandler>(user_data) };
+
+    let window = GtkWidget::wrap_widget(object);
+    let event = Event::wrap(event);
+    let res = handler.callback(&window, &event);
+
+    unsafe {
+        cast::forget(handler);
+    }
+
+    if res { ffi::Gtrue } else { ffi::Gfalse }
+}
+
+pub trait WindowBoolUintHandler {
+    fn callback(&mut self, window: &Window, x: u32) -> bool;
+}
+
+extern_drop_handler!(drop_window_bool_uint_handler, WindowBoolUintHandler)
+
+extern "C" fn window_bool_uint_callback(object: *ffi::C_GtkWidget, x: u32, user_data: ffi::gpointer) -> ffi::Gboolean {
+    let mut handler = unsafe { cast::transmute::<ffi::gpointer, ~~WindowBoolUintHandler>(user_data) };
+
+    let window = GtkWidget::wrap_widget(object);
+    let res = handler.callback(&window, x);
+
+    unsafe {
+        cast::forget(handler);
+    }
+
+    if res { ffi::Gtrue } else { ffi::Gfalse }
+}
+
+pub trait WindowBoolHandler {
+    fn callback(&mut self, window: &Window, x: bool);
+}
+
+extern_drop_handler!(drop_window_bool_handler, WindowBoolHandler)
+
+extern "C" fn window_bool_callback(object: *ffi::C_GtkWidget, x: ffi::Gboolean, user_data: ffi::gpointer) {
+    let mut handler = unsafe { cast::transmute::<ffi::gpointer, ~~WindowBoolHandler>(user_data) };
+
+    let window = GtkWidget::wrap_widget(object);
+    let b = x != ffi::Gfalse;
+    handler.callback(&window, b);
+
+    unsafe {
+        cast::forget(handler);
+    }
+}
+
+// GtkWindow
+impl_connect_signal!(Window, drop_window_widget_handler, window_widget_callback, WindowWidgetHandler, connect_window_set_focus_signal, "set-focus")
+
+// GtkContainer
+impl_connect_signal!(Window, drop_window_widget_handler, window_widget_callback, WindowWidgetHandler, connect_window_add_signal, "add")
+impl_connect_signal!(Window, drop_window_widget_handler, window_widget_callback, WindowWidgetHandler, connect_window_remove_signal, "remove")
+impl_connect_signal!(Window, drop_window_widget_handler, window_widget_callback, WindowWidgetHandler, connect_window_set_focus_child_signal, "set-focus-child")
+
+// GtkWidget
+impl_connect_signal!(Window, drop_window_bool_event_handler, window_bool_event_callback, WindowBoolEventHandler, connect_window_button_press_event_signal, "button-press-event")
+impl_connect_signal!(Window, drop_window_bool_event_handler, window_bool_event_callback, WindowBoolEventHandler, connect_window_button_release_event_signal, "button-release-event")
+impl_connect_signal!(Window, drop_window_bool_uint_handler, window_bool_uint_callback, WindowBoolUintHandler, connect_can_activate_accel_signal, "can-activate-accel")
+// TODO child-notify
+impl_connect_signal!(Window, drop_window_bool_event_handler, window_bool_event_callback, WindowBoolEventHandler, connect_window_configure_event_signal, "configure-event")
+impl_connect_signal!(Window, drop_window_bool_event_handler, window_bool_event_callback, WindowBoolEventHandler, connect_window_damage_event_signal, "damage-event")
+impl_connect_signal!(Window, drop_window_bool_event_handler, window_bool_event_callback, WindowBoolEventHandler, connect_window_delete_event_signal, "delete-event")
+impl_connect_signal!(Window, drop_window_bool_event_handler, window_bool_event_callback, WindowBoolEventHandler, connect_window_destroy_event_signal, "destroy-event")
+// TODO direction-chaned
+// TODO drag-begin
+// TODO drag-data-delete
+// TODO drag-data-get
+// TODO drag-data-received
+// TODO drag-drop
+// TODO drag-end
+// TODO drag-failed
+// TODO drag-leave
+// TODO drag-motion
+// TODO draw
+impl_connect_signal!(Window, drop_window_bool_event_handler, window_bool_event_callback, WindowBoolEventHandler, connect_window_enter_notify_event_signal, "enter-notify-event")
+impl_connect_signal!(Window, drop_window_bool_event_handler, window_bool_event_callback, WindowBoolEventHandler, connect_window_event_signal, "event")
+impl_connect_signal!(Window, drop_window_bool_event_handler, window_bool_event_callback, WindowBoolEventHandler, connect_window_event_after_signal, "event-after")
+// TODO focus
+impl_connect_signal!(Window, drop_window_bool_event_handler, window_bool_event_callback, WindowBoolEventHandler, connect_window_focus_in_event_signal, "focus-in-event")
+impl_connect_signal!(Window, drop_window_bool_event_handler, window_bool_event_callback, WindowBoolEventHandler, connect_window_focus_out_event_signal, "focus-out-event")
+impl_connect_signal!(Window, drop_window_bool_event_handler, window_bool_event_callback, WindowBoolEventHandler, connect_window_grab_broken_event_signal, "grab-broken-event")
+impl_connect_signal!(Window, drop_window_bool_handler, window_bool_callback, WindowBoolHandler, connect_window_grab_notify_signal, "grab-notify")
+// TODO hierarchy-changed
+impl_connect_signal!(Window, drop_window_bool_event_handler, window_bool_event_callback, WindowBoolEventHandler, connect_window_key_press_event_signal, "key-press-event")
+impl_connect_signal!(Window, drop_window_bool_event_handler, window_bool_event_callback, WindowBoolEventHandler, connect_window_key_release_event_signal, "key-release-event")
+// TODO keynav-failed
+impl_connect_signal!(Window, drop_window_bool_event_handler, window_bool_event_callback, WindowBoolEventHandler, connect_window_leave_notify_event_signal, "leave-notify-event")
+impl_connect_signal!(Window, drop_window_bool_event_handler, window_bool_event_callback, WindowBoolEventHandler, connect_window_map_event_signal, "map-event")
+// TODO mnemonic-activate
+impl_connect_signal!(Window, drop_window_bool_event_handler, window_bool_event_callback, WindowBoolEventHandler, connect_window_motion_notify_event_signal, "motion-notify-event")
+// TODO move-focus
+impl_connect_signal!(Window, drop_window_widget_handler, window_widget_callback, WindowWidgetHandler, connect_parent_set_signal, "parent-set")
+// TODO popup-menu
+impl_connect_signal!(Window, drop_window_bool_event_handler, window_bool_event_callback, WindowBoolEventHandler, connect_window_property_notify_event_signal, "property-notify-event")
+impl_connect_signal!(Window, drop_window_bool_event_handler, window_bool_event_callback, WindowBoolEventHandler, connect_window_proximity_in_event_signal, "proximity-in-event")
+impl_connect_signal!(Window, drop_window_bool_event_handler, window_bool_event_callback, WindowBoolEventHandler, connect_window_proximity_out_event_signal, "proximity-out-event")
+// TODO query-tooltip
+// TODO screen-changed
+impl_connect_signal!(Window, drop_window_bool_event_handler, window_bool_event_callback, WindowBoolEventHandler, connect_window_scroll_event_signal, "scroll-event")
+impl_connect_signal!(Window, drop_window_bool_event_handler, window_bool_event_callback, WindowBoolEventHandler, connect_window_selection_clear_event_signal, "selection-clear-event")
+// TODO selection-get
+impl_connect_signal!(Window, drop_window_bool_event_handler, window_bool_event_callback, WindowBoolEventHandler, connect_window_selection_notify_event_signal, "selection-notify-event")
+// TODO selection-received
+impl_connect_signal!(Window, drop_window_bool_event_handler, window_bool_event_callback, WindowBoolEventHandler, connect_window_selection_request_event_signal, "selection-request-event")
+// TODO show-help
+// TODO size-allocate
+// TODO state-flags-changed
+impl_connect_signal!(Window, drop_window_bool_event_handler, window_bool_event_callback, WindowBoolEventHandler, connect_window_touch_event_signal, "touch-event")
+impl_connect_signal!(Window, drop_window_bool_event_handler, window_bool_event_callback, WindowBoolEventHandler, connect_window_unmap_event_signal, "unmap-event")
+impl_connect_signal!(Window, drop_window_bool_event_handler, window_bool_event_callback, WindowBoolEventHandler, connect_window_visibility_notify_event_signal, "visibility-notify-event")
+impl_connect_signal!(Window, drop_window_bool_event_handler, window_bool_event_callback, WindowBoolEventHandler, connect_window_window_state_event_signal, "window-state-event")

--- a/gtk/window.rs
+++ b/gtk/window.rs
@@ -34,7 +34,6 @@ use gtk::enums::GtkWindowType;
 pub struct Window {
     priv pointer:           *ffi::C_GtkWidget,
     priv can_drop:          bool,
-    priv signal_handlers:   ~[~SignalHandler]
 }
 
 impl Window {
@@ -45,10 +44,6 @@ impl Window {
 }
 
 impl_GtkWidget!(Window)
-redirect_callback!(Window)
-redirect_callback_widget!(Window)
-struct_signal!(Window)
-impl_signals!(Window)
 
 impl GtkContainer for Window {}
 impl GtkWindow for Window {}

--- a/utils/macros.rs
+++ b/utils/macros.rs
@@ -44,3 +44,49 @@ macro_rules! impl_GtkWidget(
         }
     );
 )
+
+macro_rules! extern_drop_handler(
+    ($extern_name:ident, $handler_type:ident) => (
+        extern "C" fn $extern_name(data: ffi::gpointer, _closure: *ffi::C_GClosure) {
+            unsafe {
+                let handler = cast::transmute::<ffi::gpointer, ~~$handler_type>(data);
+                drop(handler);
+            }
+        }
+    )
+)
+
+macro_rules! extern_default_callback(
+    ($extern_name:ident, $handler_name:ident) => (
+        extern "C" fn $extern_name(object: *ffi::C_GtkWidget, user_data: ffi::gpointer) {
+            let mut handler = unsafe { cast::transmute::<ffi::gpointer, ~~$handler_name>(user_data) };
+
+            let window = GtkWidget::wrap_widget(object);
+            handler.callback(&window);
+
+            unsafe {
+                cast::forget(handler);
+            }
+        }
+    )
+)
+
+macro_rules! impl_connect_signal(
+    ($type_name:ident, $handler_drop_fn:ident, $handler_callback_fn:ident, $handler_name:ident, $method_name:ident, $signal_name:expr) => (
+        impl $type_name {
+            pub fn $method_name(&self, handler: ~$handler_name) {
+                let data = unsafe { cast::transmute::<~~$handler_name, ffi::gpointer>(~handler) };
+                $signal_name.with_c_str(|cstr| {
+                    unsafe {
+                        ffi::g_signal_connect_data(self.pointer as ffi::gpointer,
+                            cstr,
+                            Some(cast::transmute($handler_callback_fn)),
+                            data,
+                            Some($handler_drop_fn),
+                            0);
+                    }
+                });
+            }
+        }
+    )
+)

--- a/utils/macros.rs
+++ b/utils/macros.rs
@@ -23,7 +23,6 @@ macro_rules! check_pointer(
             Some($gtk_struct {
                 pointer:            $tmp_pointer,
                 can_drop:           true,
-                signal_handlers:    ~[]
             })
         }
     );
@@ -40,103 +39,8 @@ macro_rules! impl_GtkWidget(
                 $gtk_struct {
                     pointer:         widget,
                     can_drop:        false,
-                    signal_handlers: ~[]
                 }
             }
-        }
-    );
-)
-
-macro_rules! redirect_callback(
-    ($gtk_struct:ident) => (
-        extern fn redirect_callback(widget: *ffi::C_GtkWidget, user_data: *c_void) -> () {
-            let mut button = $gtk_struct { pointer: widget, can_drop: false, signal_handlers: ~[]};
-            let sighandler = unsafe {(user_data as *SignalHandler).to_option().unwrap()};
-            let func = sighandler.function.unwrap();
-            func(&mut button, sighandler.user_data);
-        }
-    );
-)
-
-macro_rules! redirect_callback_widget(
-    ($gtk_struct:ident) => (
-        extern fn redirect_callback_widget(widget: *ffi::C_GtkWidget, user_data: *c_void) -> () {
-            let mut button = $gtk_struct { pointer: widget, can_drop: false, signal_handlers: ~[]};
-            let sighandler = unsafe {(user_data as *SignalHandler).to_option().unwrap()};
-            let user_data = if !user_data.is_null() { 
-                Some(unsafe { cast::transmute_mut((sighandler.user_data  as *$gtk_struct).to_option().unwrap())  as &mut GtkWidget})
-            }  else {
-                None
-            };
-            let func = sighandler.function_widget.unwrap();
-            func(&mut button, user_data);
-        }
-    );
-)
-
-macro_rules! struct_signal(
-    ($gtk_struct:ident) => (
-        #[doc(hidden)]
-        pub struct SignalHandler {
-            function: Option<fn(&mut $gtk_struct, *c_void)>,
-            function_widget: Option<fn(&mut $gtk_struct, Option<&mut GtkWidget>)>,
-            user_data: *c_void
-        }
-    );
-)
-
-
-macro_rules! impl_signals(
-    ($gtk_struct:ident) => (
-        impl Signal for $gtk_struct {
-            fn connect(&mut self, signal: &str, function: fn()) -> () {
-                unsafe { 
-                    signal.with_c_str(|c_str| {
-                        ffi::signal_connect(self.pointer, c_str, Some(function))
-                    })
-                }
-            }
-
-            fn connect_2p<B>(&mut self, 
-                             signal: &str, 
-                             function: fn(&mut $gtk_struct, *c_void), 
-                             user_data: Option<&B>) -> () {
-                let tmp_sighandler = ~SignalHandler {
-                    function: Some(function),
-                    function_widget: None,
-                    user_data: ptr::to_unsafe_ptr(user_data.unwrap()) as *c_void
-                };
-                unsafe{ 
-                    signal.with_c_str(|c_str| {
-                        ffi::signal_connect_2params(self.pointer, 
-                                                    c_str, 
-                                                    Some(redirect_callback), 
-                                                    ptr::to_unsafe_ptr(tmp_sighandler) as *c_void) 
-                    });
-                }
-                self.signal_handlers.push(tmp_sighandler);
-            }
-
-            fn connect_2p_widget<B: GtkWidget>(&mut self, 
-                                               signal: &str, 
-                                               function: fn(&mut $gtk_struct, Option<&mut GtkWidget>), 
-                                               user_data: Option<&B>) -> () {
-                let tmp_sighandler = ~SignalHandler {
-                    function: None, 
-                    function_widget: Some(function),
-                    user_data: if user_data.is_some() {ptr::to_unsafe_ptr(user_data.unwrap()) as *c_void } else { ptr::null() }
-                };
-                unsafe{ 
-                    signal.with_c_str(|c_str| {
-                        ffi::signal_connect_2params(self.pointer, 
-                                                    c_str, 
-                                                    Some(redirect_callback_widget), 
-                                                    ptr::to_unsafe_ptr(tmp_sighandler) as *c_void) 
-                    });
-                }
-                self.signal_handlers.push(tmp_sighandler);
-            }
-
         }
     );
 )


### PR DESCRIPTION
First off: this is an RFC, not the final implementation. I don't expect this to be merged in its current state.

I've tried to implement the proposed signal handling method for the Window type. As you can see, this requires dozens upon dozens of signals with different signal handler traits. And because most of them are actually in GtkWidget, these functions/methods and traits will have to be duplicated for dozens upon dozens of types... You were right, I'm no longer sure if this will work out, i.e. if it is worth the effort and at least somewhat maintainable.

IMO there are 4 ways to go forward with this:
- Scrap it and think of a better way to handle signals
- Keep on adding stuff as has been done with Window, try to find some clever macros to make it a bit faster
- Make it at least a bit easier to write and maintain by moving these signals and traits to the GtkWidget trait instead. This will mean that the handler methods won't have exact information about the types they are passed though (they will always get a Widget for signal that are defined on GtkWidget). This would mean that some kind of casting operations would have to be added, e.g. something like `trait GtkWidget { fn as_window(&self) -> Window { GtkWidget::wrap_widget(cast_GtkWindow(self.ptr)).unwrap() } }` (I think some kind of casting will be needed if we take this option or not, as some of the signals have GtkWidget pointers as data where we can't statically know the actual type, but the user might).
- Instead of writing everything ourselves, use the GObject introspection XML files and write some code generation tool

I really don't know which way is the best here... What do you think?
