### PR TITLE
Suggestion: Favour `fail!` over `Option<T>` for error states

### DIFF
--- a/src/gtk/macros.rs
+++ b/src/gtk/macros.rs
@@ -18,12 +18,12 @@
 macro_rules! check_pointer(
     ($tmp_pointer:ident, $gtk_struct:ident) => (
         if $tmp_pointer.is_null() {
-            None
+            fail!("Fatal error: Gtk didn't return a valid pointer")
         } else {
-            Some($gtk_struct {
+            $gtk_struct {
                 pointer:            $tmp_pointer,
                 can_drop:           true
-            })
+            }
         }
     );
 )

--- a/src/gtk/widgets/_box.rs
+++ b/src/gtk/widgets/_box.rs
@@ -24,7 +24,7 @@ use gtk::traits;
 struct_Widget!(_Box)
 
 impl _Box {
-    pub fn new(orientation: Orientation, spacing: i32) -> Option<_Box> {
+    pub fn new(orientation: Orientation, spacing: i32) -> _Box {
         let tmp_pointer = unsafe { ffi::gtk_box_new(orientation, spacing as c_int) };
         check_pointer!(tmp_pointer, _Box)
     }

--- a/src/gtk/widgets/aboutdialog.rs
+++ b/src/gtk/widgets/aboutdialog.rs
@@ -23,14 +23,10 @@ use gtk::enums;
 struct_Widget!(AboutDialog)
 
 impl AboutDialog {
-    pub fn new() -> Option<AboutDialog> {
+    pub fn new() -> AboutDialog {
         let tmp_pointer = unsafe { ffi::gtk_about_dialog_new() };
 
-        if tmp_pointer.is_null() {
-            None
-        } else {
-            Some(traits::Widget::wrap(tmp_pointer))
-        }
+        check_pointer!(tmp_pointer, AboutDialog)
     }
 
     pub fn get_program_name(&self) -> Option<String> {

--- a/src/gtk/widgets/adjustment.rs
+++ b/src/gtk/widgets/adjustment.rs
@@ -38,18 +38,11 @@ impl Adjustment {
                upper: f64,
                step_increment: f64,
                page_increment: f64,
-               page_size: f64) -> Option<Adjustment> {
+               page_size: f64) -> Adjustment {
         let tmp_pointer = unsafe { ffi::gtk_adjustment_new(value as c_double, lower as c_double,
                                                            upper as c_double, step_increment as c_double,
                                                            page_increment as c_double, page_size as c_double) };
-        if tmp_pointer.is_null() {
-            None
-        } else {
-            Some(Adjustment {
-                pointer:    tmp_pointer,
-                can_drop:   true
-            })
-        }
+        check_pointer!(tmp_pointer, Adjustment)
     }
 
     pub fn get_value(&self) -> f64 {

--- a/src/gtk/widgets/alignment.rs
+++ b/src/gtk/widgets/alignment.rs
@@ -28,7 +28,7 @@ impl Alignment {
     pub fn new(x_align: f32,
                y_align: f32,
                x_scale: f32,
-               y_scale: f32) -> Option<Alignment> {
+               y_scale: f32) -> Alignment {
         let tmp_pointer = unsafe { ffi::gtk_alignment_new(x_align as c_float, y_align as c_float, x_scale as c_float, y_scale as c_float) };
         check_pointer!(tmp_pointer, Alignment)
     }

--- a/src/gtk/widgets/arrow.rs
+++ b/src/gtk/widgets/arrow.rs
@@ -25,7 +25,7 @@ use gtk::traits;
 struct_Widget!(Arrow)
 
 impl Arrow {
-    pub fn new(arrow_type: ArrowType, shadow_type: ShadowType) -> Option<Arrow> {
+    pub fn new(arrow_type: ArrowType, shadow_type: ShadowType) -> Arrow {
         let tmp_pointer = unsafe { ffi::gtk_arrow_new(arrow_type, shadow_type) };
         check_pointer!(tmp_pointer, Arrow)
     }

--- a/src/gtk/widgets/aspectframe.rs
+++ b/src/gtk/widgets/aspectframe.rs
@@ -31,7 +31,7 @@ impl AspectFrame {
                y_align: f32,
                ratio: f32,
                obey_child: bool)
-               -> Option<AspectFrame> {
+               -> AspectFrame {
         let c_obey_child = if obey_child { ffi::Gtrue } else { ffi::Gfalse };
         let tmp_pointer = match label {
             Some(l) => unsafe { l.with_c_str(|c_str| { ffi::gtk_aspect_frame_new(c_str, x_align as c_float, y_align as c_float, ratio as c_float, c_obey_child) }) },

--- a/src/gtk/widgets/button.rs
+++ b/src/gtk/widgets/button.rs
@@ -36,12 +36,12 @@ struct_Widget!(Button)
 
 
 impl Button {
-    pub fn new() -> Option<Button> {
+    pub fn new() -> Button {
         let tmp_pointer = unsafe { ffi::gtk_button_new() };
         check_pointer!(tmp_pointer, Button)
     }
 
-    pub fn new_with_label(label: &str) -> Option<Button> {
+    pub fn new_with_label(label: &str) -> Button {
         let tmp_pointer = unsafe {
             label.with_c_str(|c_str| {
                 ffi::gtk_button_new_with_label(c_str)
@@ -50,7 +50,7 @@ impl Button {
         check_pointer!(tmp_pointer, Button)
     }
 
-    pub fn new_with_menmonic(mnemonic: &str) -> Option<Button> {
+    pub fn new_with_menmonic(mnemonic: &str) -> Button {
         let tmp_pointer = unsafe {
             mnemonic.with_c_str(|c_str| {
                 ffi::gtk_button_new_with_mnemonic(c_str)
@@ -59,7 +59,7 @@ impl Button {
         check_pointer!(tmp_pointer, Button)
     }
 
-    pub fn new_from_icon_name(icon_name: &str, size: IconSize) -> Option<Button> {
+    pub fn new_from_icon_name(icon_name: &str, size: IconSize) -> Button {
         let tmp_pointer = unsafe {
             icon_name.with_c_str(|c_str| {
                 ffi::gtk_button_new_from_icon_name(c_str, size)
@@ -68,7 +68,7 @@ impl Button {
         check_pointer!(tmp_pointer, Button)
     }
 
-    pub fn new_from_stock(stock_id: &str) -> Option<Button> {
+    pub fn new_from_stock(stock_id: &str) -> Button {
         let tmp_pointer = unsafe {
             stock_id.with_c_str(|c_str| {
                 ffi::gtk_button_new_from_stock(c_str)

--- a/src/gtk/widgets/buttonbox.rs
+++ b/src/gtk/widgets/buttonbox.rs
@@ -24,7 +24,7 @@ use gtk::traits;
 struct_Widget!(ButtonBox)
 
 impl ButtonBox {
-    pub fn new(orientation: Orientation) -> Option<ButtonBox> {
+    pub fn new(orientation: Orientation) -> ButtonBox {
         let tmp_pointer = unsafe { ffi::gtk_button_box_new(orientation) };
         check_pointer!(tmp_pointer, ButtonBox)
     }

--- a/src/gtk/widgets/calendar.rs
+++ b/src/gtk/widgets/calendar.rs
@@ -36,7 +36,7 @@ use gtk::ffi;
 struct_Widget!(Calendar)
 
 impl Calendar {
-    pub fn new() -> Option<Calendar> {
+    pub fn new() -> Calendar {
         let tmp_pointer = unsafe { ffi::gtk_calendar_new() };
         check_pointer!(tmp_pointer, Calendar)
     }

--- a/src/gtk/widgets/checkbutton.rs
+++ b/src/gtk/widgets/checkbutton.rs
@@ -23,12 +23,12 @@ struct_Widget!(CheckButton)
 
 
 impl CheckButton {
-    pub fn new() -> Option<CheckButton> {
+    pub fn new() -> CheckButton {
         let tmp_pointer = unsafe { ffi::gtk_check_button_new() };
         check_pointer!(tmp_pointer, CheckButton)
     }
 
-    pub fn new_with_label(label: &str) -> Option<CheckButton> {
+    pub fn new_with_label(label: &str) -> CheckButton {
         let tmp_pointer = unsafe {
             label.with_c_str(|c_str| {
                 ffi::gtk_check_button_new_with_label(c_str)
@@ -37,7 +37,7 @@ impl CheckButton {
         check_pointer!(tmp_pointer, CheckButton)
     }
 
-    pub fn new_with_mnemonic(mnemonic: &str) -> Option<CheckButton> {
+    pub fn new_with_mnemonic(mnemonic: &str) -> CheckButton {
         let tmp_pointer = unsafe {
             mnemonic.with_c_str(|c_str| {
                 ffi::gtk_check_button_new_with_mnemonic(c_str)

--- a/src/gtk/widgets/colorbutton.rs
+++ b/src/gtk/widgets/colorbutton.rs
@@ -33,17 +33,17 @@ struct_Widget!(ColorButton)
 
 
 impl ColorButton {
-    pub fn new() -> Option<ColorButton> {
+    pub fn new() -> ColorButton {
         let tmp_pointer = unsafe { ffi::gtk_color_button_new() };
         check_pointer!(tmp_pointer, ColorButton)
     }
 
-    pub fn new_with_color(color: &gdk::Color) -> Option<ColorButton> {
+    pub fn new_with_color(color: &gdk::Color) -> ColorButton {
         let tmp_pointer = unsafe { ffi::gtk_color_button_new_with_color(color) };
         check_pointer!(tmp_pointer, ColorButton)
     }
 
-    pub fn new_with_rgba(rgba: &gdk::RGBA) -> Option<ColorButton> {
+    pub fn new_with_rgba(rgba: &gdk::RGBA) -> ColorButton {
         let tmp_pointer = unsafe { ffi::gtk_color_button_new_with_rgba(rgba) };
         check_pointer!(tmp_pointer, ColorButton)
     }

--- a/src/gtk/widgets/colorchooserdialog.rs
+++ b/src/gtk/widgets/colorchooserdialog.rs
@@ -22,7 +22,7 @@ use gtk;
 struct_Widget!(ColorChooserDialog)
 
 impl ColorChooserDialog {
-    pub fn new(title: &str, parent: Option<gtk::Window>) -> Option<ColorChooserDialog> {
+    pub fn new(title: &str, parent: Option<gtk::Window>) -> ColorChooserDialog {
         let tmp_pointer = unsafe {
             title.with_c_str(|c_str|{
                 ffi::gtk_color_chooser_dialog_new(c_str, match parent {
@@ -32,11 +32,7 @@ impl ColorChooserDialog {
             })
         };
 
-        if tmp_pointer.is_null() {
-            None
-        } else {
-            Some(traits::Widget::wrap(tmp_pointer))
-        }
+        check_pointer!(tmp_pointer, ColorChooserDialog)
     }
 }
 

--- a/src/gtk/widgets/entry.rs
+++ b/src/gtk/widgets/entry.rs
@@ -42,12 +42,12 @@ use gtk::traits;
 struct_Widget!(Entry)
 
 impl Entry {
-    pub fn new() -> Option<Entry> {
+    pub fn new() -> Entry {
         let tmp_pointer = unsafe { ffi::gtk_entry_new() };
         check_pointer!(tmp_pointer, Entry)
     }
 
-    pub fn new_with_buffer(buffer: &gtk::EntryBuffer) -> Option<Entry> {
+    pub fn new_with_buffer(buffer: &gtk::EntryBuffer) -> Entry {
         let tmp_pointer = unsafe { ffi::gtk_entry_new_with_buffer(buffer.get_pointer()) };
         check_pointer!(tmp_pointer, Entry)
     }

--- a/src/gtk/widgets/entrybuffer.rs
+++ b/src/gtk/widgets/entrybuffer.rs
@@ -38,20 +38,13 @@ pub struct EntryBuffer {
 }
 
 impl EntryBuffer {
-    pub fn new(initial_chars: &str) -> Option<EntryBuffer> {
+    pub fn new(initial_chars: &str) -> EntryBuffer {
         let tmp_pointer = unsafe {
             initial_chars.with_c_str(|c_str| {
                 ffi::gtk_entry_buffer_new(c_str, initial_chars.len() as c_int)
             })
         };
-        if tmp_pointer.is_null() {
-            None
-        } else {
-            Some(EntryBuffer {
-                pointer: tmp_pointer,
-                can_drop: true
-            })
-        }
+        check_pointer!(tmp_pointer, EntryBuffer)
     }
 
     pub fn get_text(&self) -> String {

--- a/src/gtk/widgets/expander.rs
+++ b/src/gtk/widgets/expander.rs
@@ -29,7 +29,7 @@ struct_Widget!(Expander)
 
 
 impl Expander {
-    pub fn new(label: &str) -> Option<Expander> {
+    pub fn new(label: &str) -> Expander {
         let tmp_pointer = unsafe {
             label.with_c_str(|c_str| {
                 ffi::gtk_expander_new(c_str)
@@ -38,7 +38,7 @@ impl Expander {
         check_pointer!(tmp_pointer, Expander)
     }
 
-    pub fn new_with_mnemonic(mnemonic: &str) -> Option<Expander> {
+    pub fn new_with_mnemonic(mnemonic: &str) -> Expander {
         let tmp_pointer = unsafe {
             mnemonic.with_c_str(|c_str| {
                 ffi::gtk_expander_new_with_mnemonic(c_str)

--- a/src/gtk/widgets/fixed.rs
+++ b/src/gtk/widgets/fixed.rs
@@ -26,7 +26,7 @@ struct_Widget!(Fixed)
 
 
 impl Fixed {
-    pub fn new() -> Option<Fixed> {
+    pub fn new() -> Fixed {
         let tmp_pointer = unsafe { ffi::gtk_fixed_new() };
         check_pointer!(tmp_pointer, Fixed)
     }

--- a/src/gtk/widgets/fontbutton.rs
+++ b/src/gtk/widgets/fontbutton.rs
@@ -31,12 +31,12 @@ struct_Widget!(FontButton)
 
 
 impl FontButton {
-    pub fn new() -> Option<FontButton> {
+    pub fn new() -> FontButton {
         let tmp_pointer = unsafe { ffi::gtk_font_button_new() };
         check_pointer!(tmp_pointer, FontButton)
     }
 
-    pub fn new_with_font(font_name: &str) -> Option<FontButton> {
+    pub fn new_with_font(font_name: &str) -> FontButton {
         let tmp_pointer = unsafe {
             font_name.with_c_str(|c_str| {
                 ffi::gtk_font_button_new_with_font(c_str)

--- a/src/gtk/widgets/frame.rs
+++ b/src/gtk/widgets/frame.rs
@@ -25,7 +25,7 @@ use gtk::traits;
 struct_Widget!(Frame)
 
 impl Frame {
-    pub fn new(label: Option<&str>) -> Option<Frame> {
+    pub fn new(label: Option<&str>) -> Frame {
         let tmp_pointer = match label {
             Some(l) => unsafe { l.with_c_str(|c_str| { ffi::gtk_frame_new(c_str) }) },
             None    => unsafe { ffi::gtk_frame_new(ptr::null()) }

--- a/src/gtk/widgets/grid.rs
+++ b/src/gtk/widgets/grid.rs
@@ -26,7 +26,7 @@ use gtk::traits;
 struct_Widget!(Grid)
 
 impl Grid {
-    pub fn new() -> Option<Grid> {
+    pub fn new() -> Grid {
         let tmp_pointer = unsafe { ffi::gtk_grid_new() };
         check_pointer!(tmp_pointer, Grid)
     }

--- a/src/gtk/widgets/image.rs
+++ b/src/gtk/widgets/image.rs
@@ -23,7 +23,7 @@ struct_Widget!(Image)
 
 
 impl Image {
-    pub fn new_from_file(filename: &str) -> Option<Image> {
+    pub fn new_from_file(filename: &str) -> Image {
         let tmp_pointer = unsafe {
             filename.with_c_str(|c_str| {
                 ffi::gtk_image_new_from_file(c_str)

--- a/src/gtk/widgets/infobar.rs
+++ b/src/gtk/widgets/infobar.rs
@@ -27,7 +27,7 @@ use gtk::traits;
 struct_Widget!(InfoBar)
 
 impl InfoBar {
-    pub fn new() -> Option<InfoBar> {
+    pub fn new() -> InfoBar {
         let tmp_pointer = unsafe { ffi::gtk_info_bar_new() };
         check_pointer!(tmp_pointer, InfoBar)
     }

--- a/src/gtk/widgets/label.rs
+++ b/src/gtk/widgets/label.rs
@@ -34,7 +34,7 @@ struct_Widget!(Label)
 
 
 impl Label {
-    pub fn new(text: &str) -> Option<Label> {
+    pub fn new(text: &str) -> Label {
         let tmp_pointer = unsafe {
             text.with_c_str(|c_str| {
                 ffi::gtk_label_new(c_str)
@@ -43,7 +43,7 @@ impl Label {
         check_pointer!(tmp_pointer, Label)
     }
 
-    pub fn new_with_mnemonic(text: &str) -> Option<Label> {
+    pub fn new_with_mnemonic(text: &str) -> Label {
         let tmp_pointer = unsafe {
             text.with_c_str(|c_str| {
                 ffi::gtk_label_new_with_mnemonic(c_str)

--- a/src/gtk/widgets/levelbar.rs
+++ b/src/gtk/widgets/levelbar.rs
@@ -31,12 +31,12 @@ use gtk::traits;
 struct_Widget!(LevelBar)
 
 impl LevelBar {
-    pub fn new() -> Option<LevelBar> {
+    pub fn new() -> LevelBar {
         let tmp_pointer = unsafe { ffi::gtk_level_bar_new() };
         check_pointer!(tmp_pointer, LevelBar)
     }
 
-    pub fn new_for_interval(min: f64, max: f64) -> Option<LevelBar> {
+    pub fn new_for_interval(min: f64, max: f64) -> LevelBar {
         let tmp_pointer = unsafe { ffi::gtk_level_bar_new_for_interval(min as c_double, max as c_double) };
         check_pointer!(tmp_pointer, LevelBar)
     }

--- a/src/gtk/widgets/linkbutton.rs
+++ b/src/gtk/widgets/linkbutton.rs
@@ -31,7 +31,7 @@ struct_Widget!(LinkButton)
 
 
 impl LinkButton {
-    pub fn new(uri: &str) -> Option<LinkButton> {
+    pub fn new(uri: &str) -> LinkButton {
         let tmp_pointer = unsafe {
             uri.with_c_str(|c_str| {
                 ffi::gtk_link_button_new(c_str)
@@ -40,7 +40,7 @@ impl LinkButton {
         check_pointer!(tmp_pointer, LinkButton)
     }
 
-    pub fn new_with_label(uri: &str, label: &str) -> Option<LinkButton> {
+    pub fn new_with_label(uri: &str, label: &str) -> LinkButton {
         let tmp_pointer = unsafe {
             uri.with_c_str(|c_uri| {
                 label.with_c_str(|c_label| {

--- a/src/gtk/widgets/menubutton.rs
+++ b/src/gtk/widgets/menubutton.rs
@@ -26,7 +26,7 @@ use gtk::ArrowType;
 struct_Widget!(MenuButton)
 
 impl MenuButton {
-    pub fn new() -> Option<MenuButton> {
+    pub fn new() -> MenuButton {
         let tmp_pointer = unsafe { ffi::gtk_menu_button_new() };
         check_pointer!(tmp_pointer, MenuButton)
     }

--- a/src/gtk/widgets/menutoolbutton.rs
+++ b/src/gtk/widgets/menutoolbutton.rs
@@ -26,7 +26,7 @@ struct_Widget!(MenuToolButton)
 
 
 impl MenuToolButton {
-    pub fn new<T: traits::Widget>(icon_widget: Option<&T>, label: Option<&str>) -> Option<MenuToolButton> {
+    pub fn new<T: traits::Widget>(icon_widget: Option<&T>, label: Option<&str>) -> MenuToolButton {
         let tmp_pointer: *ffi::C_GtkWidget = unsafe {
             match label {
                 Some(l) => {
@@ -48,7 +48,7 @@ impl MenuToolButton {
         check_pointer!(tmp_pointer, MenuToolButton)
     }
 
-    pub fn new_from_stock(stock_id: &str) -> Option<MenuToolButton> {
+    pub fn new_from_stock(stock_id: &str) -> MenuToolButton {
         let tmp_pointer = stock_id.with_c_str(|c_str| {
             unsafe { ffi::gtk_menu_tool_button_new_from_stock(c_str) }
         });

--- a/src/gtk/widgets/messagedialog.rs
+++ b/src/gtk/widgets/messagedialog.rs
@@ -22,29 +22,21 @@ use gtk;
 struct_Widget!(MessageDialog)
 
 impl MessageDialog {
-    pub fn new(parent: Option<gtk::Window>, flags: gtk::DialogFlags, _type: gtk::MessageType, buttons: gtk::ButtonsType) -> Option<MessageDialog> {
+    pub fn new(parent: Option<gtk::Window>, flags: gtk::DialogFlags, _type: gtk::MessageType, buttons: gtk::ButtonsType) -> MessageDialog {
         let tmp_pointer = unsafe { ffi::gtk_message_dialog_new(match parent {
                 Some(ref p) => GTK_WINDOW(p.get_widget()),
                 None => ::std::ptr::null()
             }, flags, _type, buttons, ::std::ptr::null())
         };
 
-        if tmp_pointer.is_null() {
-            None
-        } else {
-            Some(traits::Widget::wrap(tmp_pointer))
-        }
+        check_pointer!(tmp_pointer, MessageDialog)
     }
 
-    pub fn new_with_markup(parent: Option<gtk::Window>, flags: gtk::DialogFlags, _type: gtk::MessageType, buttons: gtk::ButtonsType, markup: &str) -> Option<MessageDialog> {
+    pub fn new_with_markup(parent: Option<gtk::Window>, flags: gtk::DialogFlags, _type: gtk::MessageType, buttons: gtk::ButtonsType, markup: &str) -> MessageDialog {
         //gtk_message_dialog_new_with_markup
-        match MessageDialog::new(parent, flags, _type, buttons) {
-            Some(m) => {
-                m.set_markup(markup);
-                Some(m)
-            }
-            None => None
-        }
+        let m = MessageDialog::new(parent, flags, _type, buttons);
+        m.set_markup(markup);
+        m
     }
 
     pub fn set_markup(&self, markup: &str) -> () {

--- a/src/gtk/widgets/paned.rs
+++ b/src/gtk/widgets/paned.rs
@@ -37,7 +37,7 @@ use gtk;
 struct_Widget!(Paned)
 
 impl Paned {
-    pub fn new(orientation: Orientation) -> Option<Paned> {
+    pub fn new(orientation: Orientation) -> Paned {
         let tmp_pointer = unsafe { ffi::gtk_paned_new(orientation) };
         check_pointer!(tmp_pointer, Paned)
     }

--- a/src/gtk/widgets/progressbar.rs
+++ b/src/gtk/widgets/progressbar.rs
@@ -27,7 +27,7 @@ struct_Widget!(ProgressBar)
 
 
 impl ProgressBar {
-    pub fn new() -> Option<ProgressBar> {
+    pub fn new() -> ProgressBar {
         let tmp_pointer = unsafe { ffi::gtk_progress_bar_new() };
         check_pointer!(tmp_pointer, ProgressBar)
     }

--- a/src/gtk/widgets/scale.rs
+++ b/src/gtk/widgets/scale.rs
@@ -34,7 +34,7 @@ struct_Widget!(Scale)
 
 impl Scale {
     pub fn new(orientation: Orientation,
-               adjustment: &gtk::Adjustment) -> Option<Scale> {
+               adjustment: &gtk::Adjustment) -> Scale {
         let tmp_pointer = unsafe { ffi::gtk_scale_new(orientation, adjustment.get_pointer()) };
         check_pointer!(tmp_pointer, Scale)
     }
@@ -42,7 +42,7 @@ impl Scale {
     pub fn new_with_range(orientation: Orientation,
                           min: f64,
                           max: f64,
-                          step: f64) -> Option<Scale> {
+                          step: f64) -> Scale {
         let tmp_pointer = unsafe { ffi::gtk_scale_new_with_range(orientation, min as c_double, max as c_double, step as c_double) };
         check_pointer!(tmp_pointer, Scale)
     }

--- a/src/gtk/widgets/scalebutton.rs
+++ b/src/gtk/widgets/scalebutton.rs
@@ -34,7 +34,7 @@ struct_Widget!(ScaleButton)
 
 impl ScaleButton {
     // FIXME: icons -> last parameter
-    pub fn new(size: IconSize, min: f64, max: f64, step: f64) -> Option<ScaleButton> {
+    pub fn new(size: IconSize, min: f64, max: f64, step: f64) -> ScaleButton {
         let tmp_pointer = unsafe { ffi::gtk_scale_button_new(size, min as c_double, max as c_double, step as c_double, ptr::null()) };
         check_pointer!(tmp_pointer, ScaleButton)
     }

--- a/src/gtk/widgets/searchbar.rs
+++ b/src/gtk/widgets/searchbar.rs
@@ -28,7 +28,7 @@ use gtk::traits::Widget;
 struct_Widget!(SearchBar)
 
 impl SearchBar {
-    pub fn new() -> Option<SearchBar> {
+    pub fn new() -> SearchBar {
         let tmp_pointer = unsafe { ffi::gtk_search_bar_new() };
         check_pointer!(tmp_pointer, SearchBar)
     }

--- a/src/gtk/widgets/searchentry.rs
+++ b/src/gtk/widgets/searchentry.rs
@@ -27,7 +27,7 @@ use gtk::traits;
 struct_Widget!(SearchEntry)
 
 impl SearchEntry {
-    pub fn new() -> Option<SearchEntry> {
+    pub fn new() -> SearchEntry {
         let tmp_pointer = unsafe { ffi::gtk_search_entry_new() };
         check_pointer!(tmp_pointer, SearchEntry)
     }

--- a/src/gtk/widgets/separator.rs
+++ b/src/gtk/widgets/separator.rs
@@ -24,7 +24,7 @@ struct_Widget!(Separator)
 
 
 impl Separator {
-    pub fn new(orientation: Orientation) -> Option<Separator> {
+    pub fn new(orientation: Orientation) -> Separator {
         let tmp_pointer = unsafe { ffi::gtk_separator_new(orientation) };
         check_pointer!(tmp_pointer, Separator)
     }

--- a/src/gtk/widgets/separatortoolitem.rs
+++ b/src/gtk/widgets/separatortoolitem.rs
@@ -23,7 +23,7 @@ use gtk::cast::GTK_SEPARATORTOOLITEM;
 struct_Widget!(SeparatorToolItem)
 
 impl SeparatorToolItem {
-    pub fn new() -> Option<SeparatorToolItem> {
+    pub fn new() -> SeparatorToolItem {
         let tmp_pointer = unsafe { ffi::gtk_separator_tool_item_new() };
         check_pointer!(tmp_pointer, SeparatorToolItem)
     }

--- a/src/gtk/widgets/spinbutton.rs
+++ b/src/gtk/widgets/spinbutton.rs
@@ -39,12 +39,12 @@ struct_Widget!(SpinButton)
 impl SpinButton {
     pub fn new(adjustment: &gtk::Adjustment,
                climb_rate: f64,
-               digits: u32) -> Option<SpinButton> {
+               digits: u32) -> SpinButton {
         let tmp_pointer = unsafe { ffi::gtk_spin_button_new(adjustment.get_pointer(), climb_rate as c_double, digits as c_uint) };
         check_pointer!(tmp_pointer, SpinButton)
     }
 
-    pub fn new_with_range(min: f64, max: f64, step: f64) -> Option<SpinButton> {
+    pub fn new_with_range(min: f64, max: f64, step: f64) -> SpinButton {
         let tmp_pointer = unsafe { ffi::gtk_spin_button_new_with_range(min as c_double, max as c_double, step as c_double) };
         check_pointer!(tmp_pointer, SpinButton)
     }

--- a/src/gtk/widgets/spinner.rs
+++ b/src/gtk/widgets/spinner.rs
@@ -22,7 +22,7 @@ use gtk::ffi;
 struct_Widget!(Spinner)
 
 impl Spinner {
-    pub fn new() -> Option<Spinner> {
+    pub fn new() -> Spinner {
         let tmp_pointer = unsafe { ffi::gtk_spinner_new() };
         check_pointer!(tmp_pointer, Spinner)
     }

--- a/src/gtk/widgets/switch.rs
+++ b/src/gtk/widgets/switch.rs
@@ -26,7 +26,7 @@ use gtk::ffi;
 struct_Widget!(Switch)
 
 impl Switch {
-    pub fn new() -> Option<Switch> {
+    pub fn new() -> Switch {
         let tmp_pointer = unsafe { ffi::gtk_switch_new() };
         check_pointer!(tmp_pointer, Switch)
     }

--- a/src/gtk/widgets/togglebutton.rs
+++ b/src/gtk/widgets/togglebutton.rs
@@ -27,12 +27,12 @@ use gtk::traits;
 struct_Widget!(ToggleButton)
 
 impl ToggleButton {
-    pub fn new() -> Option<ToggleButton> {
+    pub fn new() -> ToggleButton {
         let tmp_pointer = unsafe { ffi::gtk_toggle_button_new() };
         check_pointer!(tmp_pointer, ToggleButton)
     }
 
-    pub fn new_with_label(label: &str) -> Option<ToggleButton> {
+    pub fn new_with_label(label: &str) -> ToggleButton {
         let tmp_pointer = unsafe {
             label.with_c_str(|c_str| {
                 ffi::gtk_toggle_button_new_with_label(c_str)
@@ -41,7 +41,7 @@ impl ToggleButton {
         check_pointer!(tmp_pointer, ToggleButton)
     }
 
-    pub fn new_with_mnemonic(mnemonic: &str) -> Option<ToggleButton> {
+    pub fn new_with_mnemonic(mnemonic: &str) -> ToggleButton {
         let tmp_pointer = unsafe {
             mnemonic.with_c_str(|c_str| {
                 ffi::gtk_toggle_button_new_with_mnemonic(c_str)

--- a/src/gtk/widgets/toggletoolbutton.rs
+++ b/src/gtk/widgets/toggletoolbutton.rs
@@ -22,12 +22,12 @@ use gtk::traits;
 struct_Widget!(ToggleToolButton)
 
 impl ToggleToolButton {
-    pub fn new() -> Option<ToggleToolButton> {
+    pub fn new() -> ToggleToolButton {
         let tmp_pointer = unsafe { ffi::gtk_toggle_tool_button_new() };
         check_pointer!(tmp_pointer, ToggleToolButton)
     }
 
-    pub fn new_from_stock(stock_id: &str) -> Option<ToggleToolButton> {
+    pub fn new_from_stock(stock_id: &str) -> ToggleToolButton {
         let tmp_pointer = stock_id.with_c_str(|c_str| {
             unsafe { ffi::gtk_toggle_tool_button_new_from_stock(c_str) }
         });

--- a/src/gtk/widgets/toolbar.rs
+++ b/src/gtk/widgets/toolbar.rs
@@ -35,7 +35,7 @@ use gtk::{IconSize, ReliefStyle, ToolbarStyle};
 struct_Widget!(Toolbar)
 
 impl Toolbar {
-    pub fn new() -> Option<Toolbar> {
+    pub fn new() -> Toolbar {
         let tmp_pointer = unsafe { ffi::gtk_toolbar_new() };
         check_pointer!(tmp_pointer, Toolbar)
     }

--- a/src/gtk/widgets/toolbutton.rs
+++ b/src/gtk/widgets/toolbutton.rs
@@ -24,7 +24,7 @@ use gtk::traits;
 struct_Widget!(ToolButton)
 
 impl ToolButton {
-    pub fn new<T: traits::Widget>(icon_widget: Option<&T>, label: Option<&str>) -> Option<ToolButton> {
+    pub fn new<T: traits::Widget>(icon_widget: Option<&T>, label: Option<&str>) -> ToolButton {
         let tmp_pointer: *ffi::C_GtkWidget = unsafe {
             match label {
                 Some(l) => {
@@ -46,7 +46,7 @@ impl ToolButton {
         check_pointer!(tmp_pointer, ToolButton)
     }
 
-    pub fn new_from_stock(stock_id: &str) -> Option<ToolButton> {
+    pub fn new_from_stock(stock_id: &str) -> ToolButton {
         let tmp_pointer = stock_id.with_c_str(|c_str| {
             unsafe { ffi::gtk_tool_button_new_from_stock(c_str) }
         });

--- a/src/gtk/widgets/toolitem.rs
+++ b/src/gtk/widgets/toolitem.rs
@@ -22,7 +22,7 @@ use gtk::traits;
 struct_Widget!(ToolItem)
 
 impl ToolItem {
-    pub fn new() -> Option<ToolItem> {
+    pub fn new() -> ToolItem {
         let tmp_pointer = unsafe { ffi::gtk_tool_item_new() };
         check_pointer!(tmp_pointer, ToolItem)
     }

--- a/src/gtk/widgets/volumebutton.rs
+++ b/src/gtk/widgets/volumebutton.rs
@@ -22,7 +22,7 @@ use gtk::traits;
 struct_Widget!(VolumeButton)
 
 impl VolumeButton {
-    pub fn new() -> Option<VolumeButton> {
+    pub fn new() -> VolumeButton {
         let tmp_pointer = unsafe { ffi::gtk_volume_button_new() };
         check_pointer!(tmp_pointer, VolumeButton)
     }

--- a/src/gtk/widgets/window.rs
+++ b/src/gtk/widgets/window.rs
@@ -32,7 +32,7 @@ use gtk::WindowType;
 struct_Widget!(Window)
 
 impl Window {
-    pub fn new(window_type: WindowType) -> Option<Window> {
+    pub fn new(window_type: WindowType) -> Window {
         let tmp_pointer = unsafe { ffi::gtk_window_new(window_type) };
         check_pointer!(tmp_pointer, Window)
     }

--- a/test/main.rs
+++ b/test/main.rs
@@ -10,35 +10,35 @@ use rgtk::gtk::signals;
 fn main() {
     gtk::init();
     println!("Major: {}, Minor: {}", gtk::get_major_version(), gtk::get_minor_version());
-    let mut window = gtk::Window::new(gtk::window_type::TopLevel).unwrap();
-    let mut frame = gtk::Frame::new(Some("Yep a frame")).unwrap();
-    let mut _box = gtk::_Box::new(gtk::orientation::Horizontal, 10).unwrap();
-    let mut v_box = gtk::_Box::new(gtk::orientation::Horizontal, 10).unwrap();
-    let mut button_box = gtk::ButtonBox::new(gtk::orientation::Horizontal).unwrap();
-    let mut label = gtk::Label::new("Yeah a wonderful label too !").unwrap();
-    let mut button = gtk::Button::new_with_label("Whattttt a button !").unwrap();
-    let font_button = gtk::FontButton::new().unwrap();
-    let toggle_button = gtk::ToggleButton::new_with_label("Toggle Me !").unwrap();
-    let check_button = gtk::CheckButton::new_with_label("Labeled check button").unwrap();
-    let color_button = gtk::ColorButton::new().unwrap();
-    let menu_button = gtk::MenuButton::new().unwrap();
-    let link_button = gtk::LinkButton::new("www.rust-lang.org").unwrap();
-    let mut volume_button = gtk::VolumeButton::new().unwrap();
-    let mut entry = gtk::Entry::new().unwrap();
-    let search_entry = gtk::SearchEntry::new().unwrap();
-    let separator = gtk::Separator::new(gtk::orientation::Horizontal).unwrap();
-    let separator2 = gtk::Separator::new(gtk::orientation::Horizontal).unwrap();
-    let switch = gtk::Switch::new().unwrap();
-    let mut switch2 = gtk::Switch::new().unwrap();
-    let scale = gtk::Scale::new_with_range(gtk::orientation::Horizontal, 0., 100., 1.).unwrap();
-    let mut level_bar = gtk::LevelBar::new_for_interval(0., 100.).unwrap();
-    let spin_button = gtk::SpinButton::new_with_range(0., 100., 1.).unwrap();
-    let mut spinner = gtk::Spinner::new().unwrap();
-    let image = gtk::Image::new_from_file("./test/resources/gtk.jpg").unwrap();
-    let mut progress_bar = gtk::ProgressBar::new().unwrap();
-    let arrow = gtk::Arrow::new(gtk::arrow_type::Right, gtk::shadow_type::EtchedOut).unwrap();
-    let calendar = gtk::Calendar::new().unwrap();
-    let mut info_bar = gtk::InfoBar::new().unwrap();
+    let mut window = gtk::Window::new(gtk::window_type::TopLevel);
+    let mut frame = gtk::Frame::new(Some("Yep a frame"));
+    let mut _box = gtk::_Box::new(gtk::orientation::Horizontal, 10);
+    let mut v_box = gtk::_Box::new(gtk::orientation::Horizontal, 10);
+    let mut button_box = gtk::ButtonBox::new(gtk::orientation::Horizontal);
+    let mut label = gtk::Label::new("Yeah a wonderful label too !");
+    let mut button = gtk::Button::new_with_label("Whattttt a button !");
+    let font_button = gtk::FontButton::new();
+    let toggle_button = gtk::ToggleButton::new_with_label("Toggle Me !");
+    let check_button = gtk::CheckButton::new_with_label("Labeled check button");
+    let color_button = gtk::ColorButton::new();
+    let menu_button = gtk::MenuButton::new();
+    let link_button = gtk::LinkButton::new("www.rust-lang.org");
+    let mut volume_button = gtk::VolumeButton::new();
+    let mut entry = gtk::Entry::new();
+    let search_entry = gtk::SearchEntry::new();
+    let separator = gtk::Separator::new(gtk::orientation::Horizontal);
+    let separator2 = gtk::Separator::new(gtk::orientation::Horizontal);
+    let switch = gtk::Switch::new();
+    let mut switch2 = gtk::Switch::new();
+    let scale = gtk::Scale::new_with_range(gtk::orientation::Horizontal, 0., 100., 1.);
+    let mut level_bar = gtk::LevelBar::new_for_interval(0., 100.);
+    let spin_button = gtk::SpinButton::new_with_range(0., 100., 1.);
+    let mut spinner = gtk::Spinner::new();
+    let image = gtk::Image::new_from_file("./test/resources/gtk.jpg");
+    let mut progress_bar = gtk::ProgressBar::new();
+    let arrow = gtk::Arrow::new(gtk::arrow_type::Right, gtk::shadow_type::EtchedOut);
+    let calendar = gtk::Calendar::new();
+    let mut info_bar = gtk::InfoBar::new();
 
     println!("test");
 
@@ -63,7 +63,7 @@ fn main() {
     button.connect(signals::Clicked::new(||{
         //entry.set_text("Clicked!".to_string());
         let dialog = gtk::MessageDialog::new_with_markup(None, gtk::dialog_flags::Modal, gtk::message_type::Info,
-            gtk::buttons_type::OkCancel, "This is a trap !").unwrap();
+            gtk::buttons_type::OkCancel, "This is a trap !");
 
         dialog.run();
     }));


### PR DESCRIPTION
When foreign functions are nearly sure to return proper values dont wrap in an Option monad for invalid data but just `fail!`.

I think it is OK to `fail!` instead of Option when there is really an error state. The resulting api is also a lot cleaner.
