### PR TITLE
Move cargo bins to examples/, and fix the cargo building.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,14 +2,9 @@
 name = "rgtk"
 version = "0.0.1"
 authors = ["letang.jeremy@gmail.com", "mathijs.henquet@gmail.com", "guillaume1.gomez@gmail.com"]
-build = "make glue"
+build = "./cargobuild.sh"
 
 [[lib]]
 name = "rgtk"
 crate-type = ["rlib"]
-
-[[bin]]
-name = "gtktest"
-
-[[bin]]
-name ="cairotest"
+path = "src/rgtk.rs"

--- a/Makefile.in
+++ b/Makefile.in
@@ -7,8 +7,13 @@ ECHO 		= echo -e
 
 LIBNAME             = rgtk
 
-GLUE_LIBNAME 		= lib$(LIBNAME)_glue
+DEPS_DIR 			?= ./target/deps
+
+EXAMPLE_DIR			?= ./target/example/
+
+GLUE_LIBNAME		= lib$(LIBNAME)_glue
 GLUE_SRC			= gtk_glue/gtk_glue.c
+GLUE_DST			= $(DEPS_DIR)
 
 TEST_SRC 		  	= test/main.rs
 
@@ -27,44 +32,52 @@ examples: gtktest cairotest
 .PHONY: rgtk-build
 rgtk-build: src/*
 					@$(ECHO) "$(OK_COLOR) Building rgtk.rlib $(NO_COLOR)"
-					$(RUSTC) --cfg $(GTK_VERSION) -L target/ src/$(LIBNAME).rs --out-dir target/
+					$(RUSTC) --cfg $(GTK_VERSION) -L $(GLUE_DST) src/$(LIBNAME).rs --out-dir target/
 
-glue : target/$(GLUE_LIBNAME).a
+.PHONY:
+glue : $(GLUE_DST)/$(GLUE_LIBNAME).a
 
-target/$(GLUE_LIBNAME).dylib: $(GLUE_SRC) | target/
-					$(CC) $(INC) $(LIBS) -dynamiclib -o target/$(GLUE_LIBNAME).dylib $(SRC)
+$(GLUE_DST)/$(GLUE_LIBNAME).dylib: $(GLUE_SRC) | $(GLUE_DST)/
+					$(CC) $(INC) $(LIBS) -dynamiclib -o $(GLUE_DST)/$(GLUE_LIBNAME).dylib $(SRC)
 
-target/$(GLUE_LIBNAME).o: $(GLUE_SRC) | target/
+$(GLUE_DST)/$(GLUE_LIBNAME).o: $(GLUE_SRC) | $(GLUE_DST)/
 					$(CC) -g -c $^ $(INC) -o $@ $(LIBS)
 
-target/$(GLUE_LIBNAME).a: target/$(GLUE_LIBNAME).o | target/
+$(GLUE_DST)/$(GLUE_LIBNAME).a: $(GLUE_DST)/$(GLUE_LIBNAME).o | $(GLUE_DST)/
 					ar -rcs $@ $^
 
-target/$(GLUE_LIBNAME).so:    target/$(GLUE_LIBNAME).o | target/
+$(GLUE_DST)/$(GLUE_LIBNAME).so:    $(GLUE_DST)/$(GLUE_LIBNAME).o | $(GLUE_DST)/
 					$(CC) -shared -Wl,-soname,$(GLUE_LIBNAME).so -o $@ $^ -lc
 
-.PHONY: gtktest
-gtktest:			src/bin/gtktest.rs | target
-					@$(ECHO) "$(OK_COLOR) Building gtk test $(NO_COLOR)"
-					$(RUSTC) -L target/ src/bin/gtktest.rs -o ./target/gtktest
+# Examples
+.PHONY: examples cairotest gtktest
 
-.PHONY: cairotest
-cairotest:			src/bin/cairotest.rs | target
-					@$(ECHO) "$(OK_COLOR) Building cairo test $(NO_COLOR)"
-					$(RUSTC) -L target/ src/bin/cairotest.rs -o ./target/cairotest
+examples: cairotest gtktest
+
+cairotest:	$(EXAMPLE_DIR)cairotest
+					@$(ECHO) "$(OK_COLOR) Building $@ $(NO_COLOR)"
+
+gtktest: 	$(EXAMPLE_DIR)gtktest
+					@$(ECHO) "$(OK_COLOR) Building $@ $(NO_COLOR)"
+
+$(EXAMPLE_DIR)cairotest: rgtk examples/cairotest.rs | $(EXAMPLE_DIR)
+					$(RUSTC) -L target/ examples/cairotest.rs -o $@
+
+
+$(EXAMPLE_DIR)gtktest: rgtk examples/gtktest.rs | $(EXAMPLE_DIR)
+					$(RUSTC) -L target/ examples/gtktest.rs -o $@
 
 .PHONY: doc
 doc:
 					rustdoc --cfg $(GTK_VERSION) -o doc/ src/rgtk.rs
 					chmod -R 755 doc/
 
-target/:
+$(GLUE_DST)/  $(EXAMPLE_DIR) target/:
 					mkdir -p $@
 					@$(ECHO) "$(OK_COLOR) Created $@ folder $(NO_COLOR)"
 
 .PHONY: full
-full:				glue rgtk gtktest cairotest
-
+full:				glue rgtk examples
 .PHONY: clean
 clean:
 					rm -rf target/ doc/

--- a/cargobuild.sh
+++ b/cargobuild.sh
@@ -1,0 +1,6 @@
+set +e
+
+./configure
+export GTK_VERSION=${GTK_VERSION:=GTK_3_12}
+echo $GTK_VERSION
+make glue

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "rgtk-examples"
+version = "0.0.1"
+authors = []
+
+[dependencies.rgtk]
+path = "../"
+
+[[bin]]
+name = "gtktest"
+
+[[bin]]
+name = "cairotest"

--- a/examples/cairotest.rs
+++ b/examples/cairotest.rs
@@ -1,5 +1,5 @@
-
 #![feature(globs)]
+#![crate_type = "bin"]
 
 extern crate rgtk;
 extern crate log;

--- a/examples/gtktest.rs
+++ b/examples/gtktest.rs
@@ -1,5 +1,5 @@
-
 #![feature(globs)]
+#![crate_type = "bin"]
 
 extern crate rgtk;
 


### PR DESCRIPTION
Make sure ./configure is run when building.
DEPS_DIR is provided by cargo so the linker can see object archives. Put the gtk_glue there, so it can be seen when lib is built as a dependency, or when running tests.

Examples go in ./examples  and can be built with `cargo test'. This stops their dependency on 3.12 breaking the build. They can also be built separately by using cargo with ./examples as the working directory.
