### PR TITLE
Fix GtkRecentChooserDialog segfault

### DIFF
--- a/src/gtk/widgets/recentchooserdialog.rs
+++ b/src/gtk/widgets/recentchooserdialog.rs
@@ -16,6 +16,7 @@
 use gtk::ffi;
 use gtk::ffi::FFIWidget;
 use gtk::traits;
+use gtk::enums::response_type;
 use gtk::cast::{GTK_WINDOW, GTK_RECENT_MANAGER};
 use gtk;
 
@@ -29,7 +30,10 @@ impl RecentChooserDialog {
                     ffi::gtk_recent_chooser_dialog_new(c_str, match parent {
                         Some(ref p) => GTK_WINDOW(p.get_widget()),
                         None => ::std::ptr::mut_null()
-                    }, c_str2, c_str3)
+                    },
+                    c_str2, response_type::Ok,
+                    c_str3, response_type::Cancel,
+                    ::std::ptr::null::<::libc::c_void>())
                 })
             })
         })};
@@ -48,7 +52,10 @@ impl RecentChooserDialog {
                     ffi::gtk_recent_chooser_dialog_new_for_manager(c_str, match parent {
                         Some(ref p) => GTK_WINDOW(p.get_widget()),
                         None => ::std::ptr::mut_null()
-                    }, GTK_RECENT_MANAGER(manager.get_widget()), c_str2, c_str3)
+                    }, GTK_RECENT_MANAGER(manager.get_widget()),
+                    c_str2, response_type::Ok,
+                    c_str3, response_type::Cancel,
+                    ::std::ptr::null::<::libc::c_void>())
                 })
             })
         })};


### PR DESCRIPTION
C-function _gtk_recent_chooser_dialog_new_ is similar to _gtk_dialog_new_with_buttons_.

From [GtkDialog](https://developer.gnome.org/gtk3/3.12/GtkDialog.html#gtk-dialog-new-with-buttons) documentation:

> After flags , button text/response ID pairs should be listed, with a NULL pointer ending the list.

Currently gtk_recent_chooser_dialog_new is called with two _c_strs_ at the end without the NULL guard. This causes a segfault in one of the rgtk examples.
