### PR TITLE
Fixing build for x86_64-w64-mingw32

### DIFF
--- a/gtk_glue/gtk_glue.c
+++ b/gtk_glue/gtk_glue.c
@@ -119,6 +119,10 @@ GtkTextView* cast_GtkTextView(GtkWidget* widget) {
     return GTK_TEXT_VIEW(widget);
 }
 
+GtkTextTagTable* cast_GtkTextTagTable(GtkWidget* widget) {
+    return GTK_TEXT_TAG_TABLE(widget);
+}
+
 GtkTextBuffer* cast_GtkTextBuffer(void* widget) {
     return GTK_TEXT_BUFFER(widget);
 }

--- a/src/gtk/widgets/treepath.rs
+++ b/src/gtk/widgets/treepath.rs
@@ -53,7 +53,7 @@ impl TreePath {
     }
 
     pub fn new_from_indicesv(indices: &mut [i32]) -> Option<TreePath> {
-        let tmp = unsafe { ffi::gtk_tree_path_new_from_indicesv(indices.as_mut_ptr(), indices.len() as u64) };
+        let tmp = unsafe { ffi::gtk_tree_path_new_from_indicesv(indices.as_mut_ptr(), indices.len() as u32) };
 
         if tmp.is_null() {
             None


### PR DESCRIPTION
As discussed, these changes allow the build to succeed on 64 bit windows using mingw64 gcc.

I've also verified that the example programs load.
