### PR TITLE
Rename Gtrue and Gfalse to GTRUE and GFALSE

### DIFF
--- a/src/glib/error.rs
+++ b/src/glib/error.rs
@@ -46,7 +46,7 @@ impl Error {
 
     pub fn matches(&self, domain: GQuark, code: i32) -> bool {
         match unsafe { ffi::g_error_matches(self.pointer, domain, code) } {
-            ffi::Gfalse => false,
+            ffi::GFALSE => false,
             _ => true
         }
     }

--- a/src/glib/ffi.rs
+++ b/src/glib/ffi.rs
@@ -20,10 +20,8 @@ use libc::{c_int, c_void, c_uint, c_char};
 pub type GQuark = u32;
 
 pub type Gboolean = c_int;
-#[allow(non_uppercase_statics)]
-pub static Gfalse:  c_int = 0;
-#[allow(non_uppercase_statics)]
-pub static Gtrue:   c_int = !Gfalse;
+pub static GFALSE:  c_int = 0;
+pub static GTRUE:   c_int = !GFALSE;
 
 #[repr(C)]
 pub struct C_GList {

--- a/src/gtk/ffi.rs
+++ b/src/gtk/ffi.rs
@@ -25,10 +25,8 @@ use glib;
 pub type Gboolean = c_int;
 //pub type C_GtkAllocation = C_GdkRectangle;
 pub type GType = c_int;
-#[allow(non_uppercase_statics)]
-pub static Gfalse:  c_int = 0;
-#[allow(non_uppercase_statics)]
-pub static Gtrue:   c_int = !Gfalse;
+pub static GFALSE:  c_int = 0;
+pub static GTRUE:   c_int = !GFALSE;
 
 pub type gpointer = *const c_void;
 pub type time_t = i64;
@@ -317,13 +315,13 @@ pub struct C_GtkIconView;
 
 pub fn to_gboolean(b: bool) -> Gboolean {
     match b {
-        true => Gtrue,
-        false => Gfalse
+        true => GTRUE,
+        false => GFALSE
     }
 }
 
 pub fn to_bool(b: Gboolean) -> bool {
-    b == Gtrue
+    b == GTRUE
 }
 
 pub trait FFIWidget {

--- a/src/gtk/rt.rs
+++ b/src/gtk/rt.rs
@@ -44,15 +44,15 @@ pub fn main_level() -> u32 {
 
 pub fn main_iteration() -> bool {
     match unsafe { ffi::gtk_main_iteration() } {
-        ffi::Gfalse => false,
+        ffi::GFALSE => false,
         _           => true
     }
 }
 
 pub fn main_iteration_do(blocking: bool) -> bool {
-    let c_blocking = if blocking { ffi::Gtrue } else { ffi::Gfalse };
+    let c_blocking = if blocking { ffi::GTRUE } else { ffi::GFALSE };
     match unsafe { ffi::gtk_main_iteration_do(c_blocking) } {
-        ffi::Gfalse => false,
+        ffi::GFALSE => false,
         _           => true
     }
 }

--- a/src/gtk/traits/_box.rs
+++ b/src/gtk/traits/_box.rs
@@ -22,16 +22,16 @@ use gtk::ffi;
 
 pub trait Box: Widget {
     fn pack_start<'r, T: Widget>(&'r mut self, child: &'r T, expand: bool, fill: bool, padding: u32) -> () {
-        let c_expand = if expand { ffi::Gtrue } else { ffi::Gfalse };
-        let c_fill = if fill { ffi::Gtrue } else { ffi::Gfalse };
+        let c_expand = if expand { ffi::GTRUE } else { ffi::GFALSE };
+        let c_fill = if fill { ffi::GTRUE } else { ffi::GFALSE };
         unsafe {
             ffi::gtk_box_pack_start(GTK_BOX(self.get_widget()), child.get_widget(), c_expand, c_fill, padding as c_uint);
         }
     }
 
     fn pack_end<'r, T: Widget>(&'r mut self, child: &'r T, expand: bool, fill: bool, padding: u32) -> () {
-        let c_expand = if expand { ffi::Gtrue } else { ffi::Gfalse };
-        let c_fill = if fill { ffi::Gtrue } else { ffi::Gfalse };
+        let c_expand = if expand { ffi::GTRUE } else { ffi::GFALSE };
+        let c_fill = if fill { ffi::GTRUE } else { ffi::GFALSE };
         unsafe {
             ffi::gtk_box_pack_end(GTK_BOX(self.get_widget()), child.get_widget(), c_expand, c_fill, padding as c_uint);
         }
@@ -39,15 +39,15 @@ pub trait Box: Widget {
 
     fn get_homogeneous(&self) -> bool {
         match unsafe { ffi::gtk_box_get_homogeneous(GTK_BOX(self.get_widget())) } {
-            ffi::Gfalse => false,
+            ffi::GFALSE => false,
             _           => true
         }
     }
 
     fn set_homogeneouse(&mut self, homogeneous: bool) -> () {
         match homogeneous {
-            true    => unsafe { ffi::gtk_box_set_homogeneous(GTK_BOX(self.get_widget()), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_box_set_homogeneous(GTK_BOX(self.get_widget()), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_box_set_homogeneous(GTK_BOX(self.get_widget()), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_box_set_homogeneous(GTK_BOX(self.get_widget()), ffi::GFALSE) }
         }
     }
 
@@ -82,8 +82,8 @@ pub trait Box: Widget {
                                              &mut c_padding,
                                              &mut pack_type);
         }
-        let expand = if c_expand == ffi::Gfalse { false } else { true };
-        let fill = if c_fill == ffi::Gfalse { false } else { true };
+        let expand = if c_expand == ffi::GFALSE { false } else { true };
+        let fill = if c_fill == ffi::GFALSE { false } else { true };
         (expand, fill, c_padding as u32, pack_type)
     }
 
@@ -93,8 +93,8 @@ pub trait Box: Widget {
                                         fill: bool,
                                         padding: u32,
                                         pack_type: PackType) {
-        let c_expand = if expand { ffi::Gtrue } else { ffi::Gfalse };
-        let c_fill = if fill { ffi::Gtrue } else { ffi::Gfalse };
+        let c_expand = if expand { ffi::GTRUE } else { ffi::GFALSE };
+        let c_fill = if fill { ffi::GTRUE } else { ffi::GFALSE };
         unsafe {
             ffi::gtk_box_set_child_packing(GTK_BOX(self.get_widget()),
                                            child.get_widget(),

--- a/src/gtk/traits/button.rs
+++ b/src/gtk/traits/button.rs
@@ -85,42 +85,42 @@ pub trait Button: Widget + Container {
 
     fn get_use_stock(&self) -> bool {
         match unsafe { ffi::gtk_button_get_use_stock(GTK_BUTTON(self.get_widget())) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
 
     fn set_use_stock(&mut self, use_stock: bool) -> () {
         match use_stock {
-            true    => unsafe { ffi::gtk_button_set_use_stock(GTK_BUTTON(self.get_widget()), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_button_set_use_stock(GTK_BUTTON(self.get_widget()), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_button_set_use_stock(GTK_BUTTON(self.get_widget()), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_button_set_use_stock(GTK_BUTTON(self.get_widget()), ffi::GFALSE) }
         }
     }
 
     fn get_use_underline(&self) -> bool {
         match unsafe { ffi::gtk_button_get_use_underline(GTK_BUTTON(self.get_widget())) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
 
     fn set_use_underline(&mut self, use_underline: bool) -> () {
         match use_underline {
-            true    => unsafe { ffi::gtk_button_set_use_underline(GTK_BUTTON(self.get_widget()), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_button_set_use_underline(GTK_BUTTON(self.get_widget()), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_button_set_use_underline(GTK_BUTTON(self.get_widget()), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_button_set_use_underline(GTK_BUTTON(self.get_widget()), ffi::GFALSE) }
         }
     }
 
     fn set_focus_on_click(&mut self, focus_on_click: bool) -> () {
         match focus_on_click {
-            true    => unsafe { ffi::gtk_button_set_focus_on_click(GTK_BUTTON(self.get_widget()), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_button_set_focus_on_click(GTK_BUTTON(self.get_widget()), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_button_set_focus_on_click(GTK_BUTTON(self.get_widget()), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_button_set_focus_on_click(GTK_BUTTON(self.get_widget()), ffi::GFALSE) }
         }
     }
 
     fn get_focus_on_click(&self) -> bool {
         match unsafe { ffi::gtk_button_get_focus_on_click(GTK_BUTTON(self.get_widget())) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
@@ -161,15 +161,15 @@ pub trait Button: Widget + Container {
     #[cfg(any(GTK_3_6, GTK_3_8, GTK_3_10, GTK_3_12))]
     fn set_always_show_image(&mut self, always_show: bool) -> () {
         match always_show {
-            true    => unsafe { ffi::gtk_button_set_always_show_image(GTK_BUTTON(self.get_widget()), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_button_set_always_show_image(GTK_BUTTON(self.get_widget()), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_button_set_always_show_image(GTK_BUTTON(self.get_widget()), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_button_set_always_show_image(GTK_BUTTON(self.get_widget()), ffi::GFALSE) }
         }
     }
 
     #[cfg(any(GTK_3_6, GTK_3_8, GTK_3_10, GTK_3_12))]
     fn get_always_show_image(&self) -> bool {
         match unsafe { ffi::gtk_button_get_always_show_image(GTK_BUTTON(self.get_widget())) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }

--- a/src/gtk/traits/colorchooser.rs
+++ b/src/gtk/traits/colorchooser.rs
@@ -37,15 +37,15 @@ pub trait ColorChooser: traits::Widget {
 
     fn get_use_alpha(&self) -> bool {
         match unsafe { ffi::gtk_color_chooser_get_use_alpha(GTK_COLOR_CHOOSER(self.get_widget())) } {
-            ffi::Gfalse => false,
+            ffi::GFALSE => false,
             _ => true
         }
     }
 
     fn set_use_alpha(&self, use_alpha: bool) -> () {
         unsafe { ffi::gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(self.get_widget()), match use_alpha {
-            false => ffi::Gfalse,
-            _ => ffi::Gtrue
+            false => ffi::GFALSE,
+            _ => ffi::GTRUE
         }) }
     }
 

--- a/src/gtk/traits/entry.rs
+++ b/src/gtk/traits/entry.rs
@@ -61,8 +61,8 @@ pub trait Entry: Widget {
 
     fn set_visibility(&mut self, visible: bool) -> () {
         match visible {
-            true    => unsafe { ffi::gtk_entry_set_visibility(GTK_ENTRY(self.get_widget()), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_entry_set_visibility(GTK_ENTRY(self.get_widget()), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_entry_set_visibility(GTK_ENTRY(self.get_widget()), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_entry_set_visibility(GTK_ENTRY(self.get_widget()), ffi::GFALSE) }
         }
     }
 
@@ -86,14 +86,14 @@ pub trait Entry: Widget {
 
     fn get_activates_default(&self) -> bool {
         match unsafe { ffi::gtk_entry_get_activates_default(GTK_ENTRY(self.get_widget())) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
 
     fn get_has_frame(&self) -> bool {
         match unsafe { ffi::gtk_entry_get_has_frame(GTK_ENTRY(self.get_widget())) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
@@ -106,15 +106,15 @@ pub trait Entry: Widget {
 
     fn set_activates_default(&mut self, setting: bool) {
         match setting {
-            true    => unsafe { ffi::gtk_entry_set_activates_default(GTK_ENTRY(self.get_widget()), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_entry_set_activates_default(GTK_ENTRY(self.get_widget()), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_entry_set_activates_default(GTK_ENTRY(self.get_widget()), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_entry_set_activates_default(GTK_ENTRY(self.get_widget()), ffi::GFALSE) }
         }
     }
 
     fn set_has_frame(&mut self, setting: bool) {
         match setting {
-            true    => unsafe { ffi::gtk_entry_set_has_frame(GTK_ENTRY(self.get_widget()), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_entry_set_has_frame(GTK_ENTRY(self.get_widget()), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_entry_set_has_frame(GTK_ENTRY(self.get_widget()), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_entry_set_has_frame(GTK_ENTRY(self.get_widget()), ffi::GFALSE) }
         }
     }
 
@@ -159,15 +159,15 @@ pub trait Entry: Widget {
 
     fn get_overwrite_mode(&self) -> bool {
         match unsafe { ffi::gtk_entry_get_overwrite_mode(GTK_ENTRY(self.get_widget())) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
 
     fn set_overwrite_mode(&mut self, overwrite: bool) {
         match overwrite {
-            true    => unsafe { ffi::gtk_entry_set_overwrite_mode(GTK_ENTRY(self.get_widget()), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_entry_set_overwrite_mode(GTK_ENTRY(self.get_widget()), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_entry_set_overwrite_mode(GTK_ENTRY(self.get_widget()), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_entry_set_overwrite_mode(GTK_ENTRY(self.get_widget()), ffi::GFALSE) }
         }
     }
 
@@ -200,7 +200,7 @@ pub trait Entry: Widget {
 
     fn get_visibility(&self) -> bool {
         match unsafe { ffi::gtk_entry_get_visibility(GTK_ENTRY(self.get_widget())) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
@@ -289,29 +289,29 @@ pub trait Entry: Widget {
 
     fn get_icon_activatable(&self, icon_pos: EntryIconPosition) -> bool {
         match unsafe { ffi::gtk_entry_get_icon_activatable(GTK_ENTRY(self.get_widget()), icon_pos) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
 
     fn set_icon_activatable(&mut self, icon_pos: EntryIconPosition, activatable: bool) {
         match activatable {
-            true    => unsafe { ffi::gtk_entry_set_icon_activatable(GTK_ENTRY(self.get_widget()), icon_pos, ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_entry_set_icon_activatable(GTK_ENTRY(self.get_widget()), icon_pos, ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_entry_set_icon_activatable(GTK_ENTRY(self.get_widget()), icon_pos, ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_entry_set_icon_activatable(GTK_ENTRY(self.get_widget()), icon_pos, ffi::GFALSE) }
         }
     }
 
     fn get_icon_sensitive(&self, icon_pos: EntryIconPosition) -> bool {
         match unsafe { ffi::gtk_entry_get_icon_sensitive(GTK_ENTRY(self.get_widget()), icon_pos) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
 
     fn set_icon_sensitive(&mut self, icon_pos: EntryIconPosition, sensitive: bool) {
         match sensitive {
-            true    => unsafe { ffi::gtk_entry_set_icon_sensitive(GTK_ENTRY(self.get_widget()), icon_pos, ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_entry_set_icon_sensitive(GTK_ENTRY(self.get_widget()), icon_pos, ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_entry_set_icon_sensitive(GTK_ENTRY(self.get_widget()), icon_pos, ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_entry_set_icon_sensitive(GTK_ENTRY(self.get_widget()), icon_pos, ffi::GFALSE) }
         }
     }
 

--- a/src/gtk/traits/filechooser.rs
+++ b/src/gtk/traits/filechooser.rs
@@ -34,70 +34,70 @@ pub trait FileChooser: traits::Widget {
 
     fn set_local_only(&self, local_only: bool) -> () {
         unsafe { ffi::gtk_file_chooser_set_local_only(GTK_FILE_CHOOSER(self.get_widget()), match local_only {
-            true => ffi::Gtrue,
-            false => ffi::Gfalse
+            true => ffi::GTRUE,
+            false => ffi::GFALSE
         }) }
     }
 
     fn get_local_only(&self) -> bool {
         match unsafe { ffi::gtk_file_chooser_get_local_only(GTK_FILE_CHOOSER(self.get_widget())) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     fn set_select_multiple(&self, select_multiple: bool) -> () {
         unsafe { ffi::gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(self.get_widget()), match select_multiple {
-            true => ffi::Gtrue,
-            false => ffi::Gfalse
+            true => ffi::GTRUE,
+            false => ffi::GFALSE
         }) }
     }
 
     fn get_select_multiple(&self) -> bool {
         match unsafe { ffi::gtk_file_chooser_get_select_multiple(GTK_FILE_CHOOSER(self.get_widget())) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     fn set_show_hidden(&self, show_hidden: bool) -> () {
         unsafe { ffi::gtk_file_chooser_set_show_hidden(GTK_FILE_CHOOSER(self.get_widget()), match show_hidden {
-            true => ffi::Gtrue,
-            false => ffi::Gfalse
+            true => ffi::GTRUE,
+            false => ffi::GFALSE
         }) }
     }
 
     fn get_show_hidden(&self) -> bool {
         match unsafe { ffi::gtk_file_chooser_get_show_hidden(GTK_FILE_CHOOSER(self.get_widget())) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     fn set_do_overwrite_confirmation(&self, do_overwrite_confirmation: bool) -> () {
         unsafe { ffi::gtk_file_chooser_set_do_overwrite_confirmation(GTK_FILE_CHOOSER(self.get_widget()), match do_overwrite_confirmation {
-            true => ffi::Gtrue,
-            false => ffi::Gfalse
+            true => ffi::GTRUE,
+            false => ffi::GFALSE
         }) }
     }
 
     fn get_do_overwrite_confirmation(&self) -> bool {
         match unsafe { ffi::gtk_file_chooser_get_do_overwrite_confirmation(GTK_FILE_CHOOSER(self.get_widget())) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     fn set_create_folders(&self, create_folders: bool) -> () {
         unsafe { ffi::gtk_file_chooser_set_create_folders(GTK_FILE_CHOOSER(self.get_widget()), match create_folders {
-            true => ffi::Gtrue,
-            false => ffi::Gfalse
+            true => ffi::GTRUE,
+            false => ffi::GFALSE
         }) }
     }
 
     fn get_create_folders(&self) -> bool {
         match unsafe { ffi::gtk_file_chooser_get_create_folders(GTK_FILE_CHOOSER(self.get_widget())) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -126,7 +126,7 @@ pub trait FileChooser: traits::Widget {
                 ffi::gtk_file_chooser_set_filename(GTK_FILE_CHOOSER(self.get_widget()), c_str)
             })
         } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -147,7 +147,7 @@ pub trait FileChooser: traits::Widget {
                 ffi::gtk_file_chooser_select_filename(GTK_FILE_CHOOSER(self.get_widget()), c_str)
             })
         } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -192,7 +192,7 @@ pub trait FileChooser: traits::Widget {
                 ffi::gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(self.get_widget()), c_str)
             })
         } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -213,7 +213,7 @@ pub trait FileChooser: traits::Widget {
                 ffi::gtk_file_chooser_set_uri(GTK_FILE_CHOOSER(self.get_widget()), c_str)
             })
         } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -234,7 +234,7 @@ pub trait FileChooser: traits::Widget {
                 ffi::gtk_file_chooser_select_uri(GTK_FILE_CHOOSER(self.get_widget()), c_str)
             })
         } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -271,7 +271,7 @@ pub trait FileChooser: traits::Widget {
                 ffi::gtk_file_chooser_set_current_folder_uri(GTK_FILE_CHOOSER(self.get_widget()), c_str)
             })
         } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -302,28 +302,28 @@ pub trait FileChooser: traits::Widget {
 
     fn set_preview_widget_active(&self, preview_widget_active: bool) -> () {
         unsafe { ffi::gtk_file_chooser_set_preview_widget_active(GTK_FILE_CHOOSER(self.get_widget()), match preview_widget_active {
-            true => ffi::Gtrue,
-            false => ffi::Gfalse
+            true => ffi::GTRUE,
+            false => ffi::GFALSE
         }) }
     }
 
     fn get_preview_widget_active(&self) -> bool {
         match unsafe { ffi::gtk_file_chooser_get_preview_widget_active(GTK_FILE_CHOOSER(self.get_widget())) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     fn set_use_preview_label(&self, use_label: bool) -> () {
         unsafe { ffi::gtk_file_chooser_set_use_preview_label(GTK_FILE_CHOOSER(self.get_widget()), match use_label {
-            true => ffi::Gtrue,
-            false => ffi::Gfalse
+            true => ffi::GTRUE,
+            false => ffi::GFALSE
         }) }
     }
 
     fn get_use_preview_label(&self) -> bool {
         match unsafe { ffi::gtk_file_chooser_get_use_preview_label(GTK_FILE_CHOOSER(self.get_widget())) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -390,7 +390,7 @@ pub trait FileChooser: traits::Widget {
                 ffi::gtk_file_chooser_add_shortcut_folder(GTK_FILE_CHOOSER(self.get_widget()), c_str, &mut error.unwrap())
             })
         } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -401,7 +401,7 @@ pub trait FileChooser: traits::Widget {
                 ffi::gtk_file_chooser_remove_shortcut_folder(GTK_FILE_CHOOSER(self.get_widget()), c_str, &mut error.unwrap())
             })
         } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -412,7 +412,7 @@ pub trait FileChooser: traits::Widget {
                 ffi::gtk_file_chooser_add_shortcut_folder(GTK_FILE_CHOOSER(self.get_widget()), c_str, &mut error.unwrap())
             })
         } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -423,7 +423,7 @@ pub trait FileChooser: traits::Widget {
                 ffi::gtk_file_chooser_remove_shortcut_folder(GTK_FILE_CHOOSER(self.get_widget()), c_str, &mut error.unwrap())
             })
         } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }

--- a/src/gtk/traits/fontchooser.rs
+++ b/src/gtk/traits/fontchooser.rs
@@ -63,15 +63,15 @@ pub trait FontChooser: traits::Widget {
 
     fn get_show_preview_entry(&self) -> bool {
         match unsafe { ffi::gtk_font_chooser_get_show_preview_entry(GTK_FONT_CHOOSER(self.get_widget())) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     fn set_show_preview_entry(&self, show_preview_entry: bool) {
         unsafe { ffi::gtk_font_chooser_set_show_preview_entry(GTK_FONT_CHOOSER(self.get_widget()), match show_preview_entry {
-            true => ffi::Gtrue,
-            false => ffi::Gfalse
+            true => ffi::GTRUE,
+            false => ffi::GFALSE
         }) }
     }
 }

--- a/src/gtk/traits/label.rs
+++ b/src/gtk/traits/label.rs
@@ -90,14 +90,14 @@ pub trait Label : Widget {
 
     fn set_line_wrap(&mut self, wrap: bool) -> () {
         match wrap {
-            true    => unsafe { ffi::gtk_label_set_line_wrap(GTK_LABEL(self.get_widget()), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_label_set_line_wrap(GTK_LABEL(self.get_widget()), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_label_set_line_wrap(GTK_LABEL(self.get_widget()), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_label_set_line_wrap(GTK_LABEL(self.get_widget()), ffi::GFALSE) }
         }
     }
 
     fn get_line_wrap(&self) -> bool {
         match unsafe { ffi::gtk_label_get_line_wrap(GTK_LABEL(self.get_widget())) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
@@ -133,70 +133,70 @@ pub trait Label : Widget {
 
     fn set_selectable(&mut self, selectable: bool) -> () {
         match selectable {
-            true    => unsafe { ffi::gtk_label_set_selectable(GTK_LABEL(self.get_widget()), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_label_set_selectable(GTK_LABEL(self.get_widget()), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_label_set_selectable(GTK_LABEL(self.get_widget()), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_label_set_selectable(GTK_LABEL(self.get_widget()), ffi::GFALSE) }
         }
     }
 
     fn get_selectable(&self) -> bool {
         match unsafe { ffi::gtk_label_get_selectable(GTK_LABEL(self.get_widget())) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
 
     fn set_use_markup(&mut self, use_markup: bool) -> () {
         match use_markup {
-            true    => unsafe { ffi::gtk_label_set_use_markup(GTK_LABEL(self.get_widget()), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_label_set_use_markup(GTK_LABEL(self.get_widget()), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_label_set_use_markup(GTK_LABEL(self.get_widget()), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_label_set_use_markup(GTK_LABEL(self.get_widget()), ffi::GFALSE) }
         }
     }
 
     fn get_use_markup(&self) -> bool {
         match unsafe { ffi::gtk_label_get_use_markup(GTK_LABEL(self.get_widget())) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
 
     fn set_use_underline(&mut self, use_underline: bool) -> () {
         match use_underline {
-            true    => unsafe { ffi::gtk_label_set_use_underline(GTK_LABEL(self.get_widget()), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_label_set_use_underline(GTK_LABEL(self.get_widget()), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_label_set_use_underline(GTK_LABEL(self.get_widget()), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_label_set_use_underline(GTK_LABEL(self.get_widget()), ffi::GFALSE) }
         }
     }
 
     fn get_use_underline(&self) -> bool {
         match unsafe { ffi::gtk_label_get_use_underline(GTK_LABEL(self.get_widget())) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
 
     fn set_single_line_mode(&mut self, single_line_mode: bool) -> () {
         match single_line_mode {
-            true    => unsafe { ffi::gtk_label_set_single_line_mode(GTK_LABEL(self.get_widget()), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_label_set_single_line_mode(GTK_LABEL(self.get_widget()), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_label_set_single_line_mode(GTK_LABEL(self.get_widget()), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_label_set_single_line_mode(GTK_LABEL(self.get_widget()), ffi::GFALSE) }
         }
     }
 
     fn get_single_line_mode(&self) -> bool {
         match unsafe { ffi::gtk_label_get_single_line_mode(GTK_LABEL(self.get_widget())) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
 
     fn set_track_visited_links(&mut self, track_visited_links: bool) -> () {
         match track_visited_links {
-            true    => unsafe { ffi::gtk_label_set_track_visited_links(GTK_LABEL(self.get_widget()), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_label_set_track_visited_links(GTK_LABEL(self.get_widget()), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_label_set_track_visited_links(GTK_LABEL(self.get_widget()), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_label_set_track_visited_links(GTK_LABEL(self.get_widget()), ffi::GFALSE) }
         }
     }
 
     fn get_track_visited_links(&self) -> bool {
         match unsafe { ffi::gtk_label_get_track_visited_links(GTK_LABEL(self.get_widget())) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }

--- a/src/gtk/traits/recentchooser.rs
+++ b/src/gtk/traits/recentchooser.rs
@@ -24,70 +24,70 @@ use std::string;
 pub trait RecentChooser: traits::Widget {
     fn set_show_private(&self, show_private: bool) {
         unsafe { ffi::gtk_recent_chooser_set_show_private(GTK_RECENT_CHOOSER(self.get_widget()), match show_private {
-            true => ffi::Gtrue,
-            false => ffi::Gtrue
+            true => ffi::GTRUE,
+            false => ffi::GTRUE
         }) }
     }
 
     fn get_show_private(&self) -> bool {
         match unsafe { ffi::gtk_recent_chooser_get_show_private(GTK_RECENT_CHOOSER(self.get_widget())) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     fn set_show_not_found(&self, show_not_found: bool) {
         unsafe { ffi::gtk_recent_chooser_set_show_not_found(GTK_RECENT_CHOOSER(self.get_widget()), match show_not_found {
-            true => ffi::Gtrue,
-            false => ffi::Gtrue
+            true => ffi::GTRUE,
+            false => ffi::GTRUE
         }) }
     }
 
     fn get_show_not_found(&self) -> bool {
         match unsafe { ffi::gtk_recent_chooser_get_show_not_found(GTK_RECENT_CHOOSER(self.get_widget())) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     fn set_show_icons(&self, show_icons: bool) {
         unsafe { ffi::gtk_recent_chooser_set_show_icons(GTK_RECENT_CHOOSER(self.get_widget()), match show_icons {
-            true => ffi::Gtrue,
-            false => ffi::Gtrue
+            true => ffi::GTRUE,
+            false => ffi::GTRUE
         }) }
     }
 
     fn get_show_icons(&self) -> bool {
         match unsafe { ffi::gtk_recent_chooser_get_show_icons(GTK_RECENT_CHOOSER(self.get_widget())) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     fn set_select_multiple(&self, select_multiple: bool) {
         unsafe { ffi::gtk_recent_chooser_set_select_multiple(GTK_RECENT_CHOOSER(self.get_widget()), match select_multiple {
-            true => ffi::Gtrue,
-            false => ffi::Gtrue
+            true => ffi::GTRUE,
+            false => ffi::GTRUE
         }) }
     }
 
     fn get_select_multiple(&self) -> bool {
         match unsafe { ffi::gtk_recent_chooser_get_select_multiple(GTK_RECENT_CHOOSER(self.get_widget())) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     fn set_local_only(&self, local_only: bool) {
         unsafe { ffi::gtk_recent_chooser_set_local_only(GTK_RECENT_CHOOSER(self.get_widget()), match local_only {
-            true => ffi::Gtrue,
-            false => ffi::Gtrue
+            true => ffi::GTRUE,
+            false => ffi::GTRUE
         }) }
     }
 
     fn get_local_only(&self) -> bool {
         match unsafe { ffi::gtk_recent_chooser_get_local_only(GTK_RECENT_CHOOSER(self.get_widget())) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -102,14 +102,14 @@ pub trait RecentChooser: traits::Widget {
 
     fn set_show_tips(&self, show_tips: bool) {
         unsafe { ffi::gtk_recent_chooser_set_show_tips(GTK_RECENT_CHOOSER(self.get_widget()), match show_tips {
-            true => ffi::Gtrue,
-            false => ffi::Gtrue
+            true => ffi::GTRUE,
+            false => ffi::GTRUE
         }) }
     }
 
     fn get_show_tips(&self) -> bool {
         match unsafe { ffi::gtk_recent_chooser_get_show_tips(GTK_RECENT_CHOOSER(self.get_widget())) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -146,7 +146,7 @@ pub trait RecentChooser: traits::Widget {
         match unsafe { uri.with_c_str(|c_str| {
             ffi::gtk_recent_chooser_unselect_uri(GTK_RECENT_CHOOSER(self.get_widget()), c_str)
         })} {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }

--- a/src/gtk/traits/togglebutton.rs
+++ b/src/gtk/traits/togglebutton.rs
@@ -20,14 +20,14 @@ use gtk::ffi;
 pub trait ToggleButton: Widget + Container + Button {
     fn set_mode(&mut self, draw_indicate: bool) {
         match draw_indicate {
-            true    => unsafe { ffi::gtk_toggle_button_set_mode(GTK_TOGGLEBUTTON(self.get_widget()), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_toggle_button_set_mode(GTK_TOGGLEBUTTON(self.get_widget()), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_toggle_button_set_mode(GTK_TOGGLEBUTTON(self.get_widget()), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_toggle_button_set_mode(GTK_TOGGLEBUTTON(self.get_widget()), ffi::GFALSE) }
         }
     }
 
     fn get_mode(&self) -> bool {
         match unsafe { ffi::gtk_toggle_button_get_mode(GTK_TOGGLEBUTTON(self.get_widget())) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
@@ -40,28 +40,28 @@ pub trait ToggleButton: Widget + Container + Button {
 
     fn set_active(&mut self, is_active: bool) {
         match is_active {
-            true    => unsafe { ffi::gtk_toggle_button_set_active(GTK_TOGGLEBUTTON(self.get_widget()), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_toggle_button_set_active(GTK_TOGGLEBUTTON(self.get_widget()), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_toggle_button_set_active(GTK_TOGGLEBUTTON(self.get_widget()), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_toggle_button_set_active(GTK_TOGGLEBUTTON(self.get_widget()), ffi::GFALSE) }
         }
     }
 
     fn get_active(&self) -> bool {
         match unsafe { ffi::gtk_toggle_button_get_active(GTK_TOGGLEBUTTON(self.get_widget())) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
 
     fn set_inconsistent(&mut self, setting: bool) {
         match setting {
-            true    => unsafe { ffi::gtk_toggle_button_set_inconsistent(GTK_TOGGLEBUTTON(self.get_widget()), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_toggle_button_set_inconsistent(GTK_TOGGLEBUTTON(self.get_widget()), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_toggle_button_set_inconsistent(GTK_TOGGLEBUTTON(self.get_widget()), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_toggle_button_set_inconsistent(GTK_TOGGLEBUTTON(self.get_widget()), ffi::GFALSE) }
         }
     }
 
     fn get_inconsistent(&self) -> bool {
         match unsafe { ffi::gtk_toggle_button_get_inconsistent(GTK_TOGGLEBUTTON(self.get_widget())) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }

--- a/src/gtk/traits/toggletoolbutton.rs
+++ b/src/gtk/traits/toggletoolbutton.rs
@@ -21,15 +21,15 @@ pub trait ToggleToolButton: Widget + Container + Bin + ToolItem + ToolButton {
 
     fn get_active(&self) -> bool {
         match unsafe { ffi::gtk_toggle_tool_button_get_active(GTK_TOGGLETOOLBUTTON(self.get_widget())) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
 
     fn set_active(&mut self, set_underline: bool) -> () {
          match set_underline {
-            true    => unsafe { ffi::gtk_toggle_tool_button_set_active(GTK_TOGGLETOOLBUTTON(self.get_widget()), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_toggle_tool_button_set_active(GTK_TOGGLETOOLBUTTON(self.get_widget()), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_toggle_tool_button_set_active(GTK_TOGGLETOOLBUTTON(self.get_widget()), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_toggle_tool_button_set_active(GTK_TOGGLETOOLBUTTON(self.get_widget()), ffi::GFALSE) }
         }
     }
 }

--- a/src/gtk/traits/toolbutton.rs
+++ b/src/gtk/traits/toolbutton.rs
@@ -79,15 +79,15 @@ pub trait ToolButton: Widget + Container + Bin + ToolItem {
 
     fn get_use_underline(&self) -> bool {
         match unsafe { ffi::gtk_tool_button_get_use_underline(GTK_TOOLBUTTON(self.get_widget())) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
 
     fn set_use_underline(&mut self, set_underline: bool) -> () {
          match set_underline {
-            true    => unsafe { ffi::gtk_tool_button_set_use_underline(GTK_TOOLBUTTON(self.get_widget()), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_tool_button_set_use_underline(GTK_TOOLBUTTON(self.get_widget()), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_tool_button_set_use_underline(GTK_TOOLBUTTON(self.get_widget()), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_tool_button_set_use_underline(GTK_TOOLBUTTON(self.get_widget()), ffi::GFALSE) }
         }
     }
 

--- a/src/gtk/traits/toolitem.rs
+++ b/src/gtk/traits/toolitem.rs
@@ -21,84 +21,84 @@ use gtk::{IconSize, Orientation, ReliefStyle, ToolbarStyle};
 pub trait ToolItem: Widget + Container + Bin {
     fn set_homogeneous(&mut self, homogeneous: bool) -> () {
          match homogeneous {
-            true    => unsafe { ffi::gtk_tool_item_set_homogeneous(GTK_TOOLITEM(self.get_widget()), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_tool_item_set_homogeneous(GTK_TOOLITEM(self.get_widget()), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_tool_item_set_homogeneous(GTK_TOOLITEM(self.get_widget()), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_tool_item_set_homogeneous(GTK_TOOLITEM(self.get_widget()), ffi::GFALSE) }
         }
     }
 
     fn get_homogeneous(&self) -> bool {
         match unsafe { ffi::gtk_tool_item_get_homogeneous(GTK_TOOLITEM(self.get_widget())) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
 
     fn set_expand(&mut self, expand: bool) -> () {
          match expand {
-            true    => unsafe { ffi::gtk_tool_item_set_expand(GTK_TOOLITEM(self.get_widget()), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_tool_item_set_expand(GTK_TOOLITEM(self.get_widget()), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_tool_item_set_expand(GTK_TOOLITEM(self.get_widget()), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_tool_item_set_expand(GTK_TOOLITEM(self.get_widget()), ffi::GFALSE) }
         }
     }
 
     fn get_expand(&self) -> bool {
         match unsafe { ffi::gtk_tool_item_get_expand(GTK_TOOLITEM(self.get_widget())) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
 
     fn set_use_drag_window(&mut self, use_drag_window: bool) -> () {
          match use_drag_window {
-            true    => unsafe { ffi::gtk_tool_item_set_use_drag_window(GTK_TOOLITEM(self.get_widget()), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_tool_item_set_use_drag_window(GTK_TOOLITEM(self.get_widget()), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_tool_item_set_use_drag_window(GTK_TOOLITEM(self.get_widget()), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_tool_item_set_use_drag_window(GTK_TOOLITEM(self.get_widget()), ffi::GFALSE) }
         }
     }
 
     fn get_use_drag_window(&self) -> bool {
         match unsafe { ffi::gtk_tool_item_get_use_drag_window(GTK_TOOLITEM(self.get_widget())) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
 
     fn set_visible_horizontal(&mut self, visible_horizontal: bool) -> () {
          match visible_horizontal {
-            true    => unsafe { ffi::gtk_tool_item_set_visible_horizontal(GTK_TOOLITEM(self.get_widget()), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_tool_item_set_visible_horizontal(GTK_TOOLITEM(self.get_widget()), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_tool_item_set_visible_horizontal(GTK_TOOLITEM(self.get_widget()), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_tool_item_set_visible_horizontal(GTK_TOOLITEM(self.get_widget()), ffi::GFALSE) }
         }
     }
 
     fn get_visible_horizontal(&self) -> bool {
         match unsafe { ffi::gtk_tool_item_get_visible_horizontal(GTK_TOOLITEM(self.get_widget())) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
 
     fn set_visible_vertical(&mut self, visible_vertical: bool) -> () {
          match visible_vertical {
-            true    => unsafe { ffi::gtk_tool_item_set_visible_vertical(GTK_TOOLITEM(self.get_widget()), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_tool_item_set_visible_vertical(GTK_TOOLITEM(self.get_widget()), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_tool_item_set_visible_vertical(GTK_TOOLITEM(self.get_widget()), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_tool_item_set_visible_vertical(GTK_TOOLITEM(self.get_widget()), ffi::GFALSE) }
         }
     }
 
     fn get_visible_vertical(&self) -> bool {
         match unsafe { ffi::gtk_tool_item_get_visible_vertical(GTK_TOOLITEM(self.get_widget())) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
 
     fn set_is_important(&mut self, is_important: bool) -> () {
          match is_important {
-            true    => unsafe { ffi::gtk_tool_item_set_is_important(GTK_TOOLITEM(self.get_widget()), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_tool_item_set_is_important(GTK_TOOLITEM(self.get_widget()), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_tool_item_set_is_important(GTK_TOOLITEM(self.get_widget()), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_tool_item_set_is_important(GTK_TOOLITEM(self.get_widget()), ffi::GFALSE) }
         }
     }
 
     fn get_is_important(&self) -> bool {
         match unsafe { ffi::gtk_tool_item_get_is_important(GTK_TOOLITEM(self.get_widget())) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }

--- a/src/gtk/traits/widget.rs
+++ b/src/gtk/traits/widget.rs
@@ -71,7 +71,7 @@ pub trait Widget: ffi::FFIWidget {
 
     fn activate(&self) -> bool {
         match unsafe { ffi::gtk_widget_activate(self.get_widget()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -82,7 +82,7 @@ pub trait Widget: ffi::FFIWidget {
 
     fn is_focus(&self) -> bool {
         match unsafe { ffi::gtk_widget_is_focus(self.get_widget()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -113,8 +113,8 @@ pub trait Widget: ffi::FFIWidget {
 
     fn set_sensitive(&self, sensitive: bool) {
         unsafe { ffi::gtk_widget_set_sensitive(self.get_widget(), match sensitive {
-            true => ffi::Gtrue,
-            false => ffi::Gfalse
+            true => ffi::GTRUE,
+            false => ffi::GFALSE
         }) }
     }
 
@@ -148,14 +148,14 @@ pub trait Widget: ffi::FFIWidget {
 
     fn is_ancestor(&self, ancestor: &Widget) -> bool {
         match unsafe { ffi::gtk_widget_is_ancestor(self.get_widget(), ancestor.get_widget()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     fn hide_on_delete(&self) -> bool {
         match unsafe { ffi::gtk_widget_hide_on_delete(self.get_widget()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -178,7 +178,7 @@ pub trait Widget: ffi::FFIWidget {
 
     fn in_destruction(&self) -> bool {
         match unsafe { ffi::gtk_widget_in_destruction(self.get_widget()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -192,7 +192,7 @@ pub trait Widget: ffi::FFIWidget {
         let mut dest_y = 0i32;
 
         match unsafe { ffi::gtk_widget_translate_coordinates(self.get_widget(), dest_widget.get_widget(), src_x, src_y, &mut dest_x, &mut dest_y) } {
-            ffi::Gtrue => Some((dest_x, dest_y)),
+            ffi::GTRUE => Some((dest_x, dest_y)),
             _ => None
         }
     }
@@ -221,31 +221,31 @@ pub trait Widget: ffi::FFIWidget {
 
     fn set_app_paintable(&self, app_paintable: bool) {
         unsafe { ffi::gtk_widget_set_app_paintable(self.get_widget(), match app_paintable {
-                true => ffi::Gtrue,
-                false => ffi::Gfalse
+                true => ffi::GTRUE,
+                false => ffi::GFALSE
             }) }
     }
 
     fn set_double_buffered(&self, double_buffered: bool) {
         unsafe { ffi::gtk_widget_set_double_buffered(self.get_widget(), match double_buffered {
-                true => ffi::Gtrue,
-                false => ffi::Gfalse
+                true => ffi::GTRUE,
+                false => ffi::GFALSE
             }) }
     }
 
     fn set_redraw_on_allocate(&self, redraw_on_allocate: bool) {
         unsafe { ffi::gtk_widget_set_redraw_on_allocate(self.get_widget(), match redraw_on_allocate {
-                true => ffi::Gtrue,
-                false => ffi::Gfalse
+                true => ffi::GTRUE,
+                false => ffi::GFALSE
             }) }
     }
 
     fn mnemonic_activate(&self, group_cycling: bool) -> bool {
         match unsafe { ffi::gtk_widget_mnemonic_activate(self.get_widget(), match group_cycling {
-                true => ffi::Gtrue,
-                false => ffi::Gfalse
+                true => ffi::GTRUE,
+                false => ffi::GFALSE
             }) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -256,21 +256,21 @@ pub trait Widget: ffi::FFIWidget {
 
     fn send_focus_change(&self, event: &mut gdk::Event) -> bool {
         match unsafe { ffi::gtk_widget_send_expose(self.get_widget(), event) } {
-            Gtrue => true,
+            GTRUE => true,
             _ => false
         }
     }*/
 
     fn child_focus(&self, direction: gtk::DirectionType) -> bool {
         match unsafe { ffi::gtk_widget_child_focus(self.get_widget(), direction) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     fn get_child_visible(&self) -> bool {
         match unsafe { ffi::gtk_widget_get_child_visible(self.get_widget()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -287,7 +287,7 @@ pub trait Widget: ffi::FFIWidget {
 
     fn has_screen(&self) -> bool {
         match unsafe { ffi::gtk_widget_has_screen(self.get_widget()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -302,8 +302,8 @@ pub trait Widget: ffi::FFIWidget {
 
     fn set_child_visible(&self, is_visible: bool) {
         unsafe { ffi::gtk_widget_set_child_visible(self.get_widget(), match is_visible {
-                true => ffi::Gtrue,
-                false => ffi::Gfalse
+                true => ffi::GTRUE,
+                false => ffi::GFALSE
             }) }
     }
 
@@ -313,14 +313,14 @@ pub trait Widget: ffi::FFIWidget {
 
     fn set_no_show_all(&self, no_show_all: bool) {
         unsafe { ffi::gtk_widget_set_no_show_all(self.get_widget(), match no_show_all {
-                true => ffi::Gtrue,
-                false => ffi::Gfalse
+                true => ffi::GTRUE,
+                false => ffi::GFALSE
             }) }
     }
 
     fn get_no_show_all(&self) -> bool {
         match unsafe { ffi::gtk_widget_get_no_show_all(self.get_widget()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -351,7 +351,7 @@ pub trait Widget: ffi::FFIWidget {
 
     fn is_composited(&self) -> bool {
         match unsafe { ffi::gtk_widget_is_composited(self.get_widget()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -362,7 +362,7 @@ pub trait Widget: ffi::FFIWidget {
 
     fn keynav_failed(&self, direction: gtk::DirectionType) -> bool {
         match unsafe { ffi::gtk_widget_keynav_failed(self.get_widget(), direction) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -406,15 +406,15 @@ pub trait Widget: ffi::FFIWidget {
 
     fn get_has_tooltip(&self) -> bool {
         match unsafe { ffi::gtk_widget_get_has_tooltip(self.get_widget()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     fn set_has_tooltip(&self, has_tooltip: bool) {
         unsafe { ffi::gtk_widget_set_has_tooltip(self.get_widget(), match has_tooltip {
-            true => ffi::Gtrue,
-            false => ffi::Gfalse
+            true => ffi::GTRUE,
+            false => ffi::GFALSE
         }) }
     }
 
@@ -428,99 +428,99 @@ pub trait Widget: ffi::FFIWidget {
 
     fn get_app_paintable(&self) -> bool {
         match unsafe { ffi::gtk_widget_get_app_paintable(self.get_widget()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     fn get_can_default(&self) -> bool {
         match unsafe { ffi::gtk_widget_get_can_default(self.get_widget()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     fn set_can_default(&self, can_default: bool) {
         unsafe { ffi::gtk_widget_set_can_default(self.get_widget(), match can_default {
-            true => ffi::Gtrue,
-            false => ffi::Gfalse
+            true => ffi::GTRUE,
+            false => ffi::GFALSE
         }) }
     }
 
     fn get_can_focus(&self) -> bool {
         match unsafe { ffi::gtk_widget_get_can_focus(self.get_widget()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     fn set_can_focus(&self, can_focus: bool) {
         unsafe { ffi::gtk_widget_set_can_focus(self.get_widget(), match can_focus {
-            true => ffi::Gtrue,
-            false => ffi::Gfalse
+            true => ffi::GTRUE,
+            false => ffi::GFALSE
         }) }
     }
 
     fn get_double_buffered(&self) -> bool {
         match unsafe { ffi::gtk_widget_get_double_buffered(self.get_widget()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     fn get_has_window(&self) -> bool {
         match unsafe { ffi::gtk_widget_get_has_window(self.get_widget()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     fn set_has_window(&self, has_window: bool) {
         unsafe { ffi::gtk_widget_set_has_window(self.get_widget(), match has_window {
-            true => ffi::Gtrue,
-            false => ffi::Gfalse
+            true => ffi::GTRUE,
+            false => ffi::GFALSE
         }) }
     }
 
     fn get_sensitive(&self) -> bool {
         match unsafe { ffi::gtk_widget_get_sensitive(self.get_widget()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     fn is_sensitive(&self) -> bool {
         match unsafe { ffi::gtk_widget_is_sensitive(self.get_widget()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     fn get_visible(&self) -> bool {
         match unsafe { ffi::gtk_widget_get_visible(self.get_widget()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     fn is_visible(&self) -> bool {
         match unsafe { ffi::gtk_widget_is_visible(self.get_widget()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     fn set_visible(&self, visible: bool) {
         unsafe { ffi::gtk_widget_set_visible(self.get_widget(), match visible {
-            true => ffi::Gtrue,
-            false => ffi::Gfalse
+            true => ffi::GTRUE,
+            false => ffi::GFALSE
         }) }
     }
 
     fn set_state_flags(&self, flags: gtk::StateFlags, clear: bool) {
         unsafe { ffi::gtk_widget_set_state_flags(self.get_widget(), flags, match clear {
-            true => ffi::Gtrue,
-            false => ffi::Gfalse
+            true => ffi::GTRUE,
+            false => ffi::GFALSE
         }) }
     }
 
@@ -534,98 +534,98 @@ pub trait Widget: ffi::FFIWidget {
 
     fn has_default(&self) -> bool {
         match unsafe { ffi::gtk_widget_has_default(self.get_widget()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     fn has_focus(&self) -> bool {
         match unsafe { ffi::gtk_widget_has_focus(self.get_widget()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     fn has_visible_focus(&self) -> bool {
         match unsafe { ffi::gtk_widget_has_visible_focus(self.get_widget()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     fn has_grab(&self) -> bool {
         match unsafe { ffi::gtk_widget_has_grab(self.get_widget()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     fn is_drawable(&self) -> bool {
         match unsafe { ffi::gtk_widget_is_drawable(self.get_widget()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     fn is_toplevel(&self) -> bool {
         match unsafe { ffi::gtk_widget_is_toplevel(self.get_widget()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     fn set_receives_default(&self, receives_default: bool) {
         unsafe { ffi::gtk_widget_set_receives_default(self.get_widget(), match receives_default {
-            true => ffi::Gtrue,
-            false => ffi::Gfalse
+            true => ffi::GTRUE,
+            false => ffi::GFALSE
         }) }
     }
 
     fn get_receives_default(&self) -> bool {
         match unsafe { ffi::gtk_widget_get_receives_default(self.get_widget()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     fn set_support_multidevice(&self, support_multidevice: bool) {
         unsafe { ffi::gtk_widget_set_support_multidevice(self.get_widget(), match support_multidevice {
-            true => ffi::Gtrue,
-            false => ffi::Gfalse
+            true => ffi::GTRUE,
+            false => ffi::GFALSE
         }) }
     }
 
     fn get_support_multidevice(&self) -> bool {
         match unsafe { ffi::gtk_widget_get_support_multidevice(self.get_widget()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     fn set_realized(&self, realized: bool) {
         unsafe { ffi::gtk_widget_set_realized(self.get_widget(), match realized {
-            true => ffi::Gtrue,
-            false => ffi::Gfalse
+            true => ffi::GTRUE,
+            false => ffi::GFALSE
         }) }
     }
 
     fn get_realized(&self) -> bool {
         match unsafe { ffi::gtk_widget_get_realized(self.get_widget()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     fn set_mapped(&self, mapped: bool) {
         unsafe { ffi::gtk_widget_set_mapped(self.get_widget(), match mapped {
-            true => ffi::Gtrue,
-            false => ffi::Gfalse
+            true => ffi::GTRUE,
+            false => ffi::GFALSE
         }) }
     }
 
     fn get_mapped(&self) -> bool {
         match unsafe { ffi::gtk_widget_get_mapped(self.get_widget()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -788,57 +788,57 @@ pub trait Widget: ffi::FFIWidget {
 
     fn get_hexpand(&self) -> bool {
         match unsafe { ffi::gtk_widget_get_hexpand(self.get_widget()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     fn set_hexpand(&self, expand: bool) {
         unsafe { ffi::gtk_widget_set_hexpand(self.get_widget(), match expand {
-            true => ffi::Gtrue,
-            false => ffi::Gfalse
+            true => ffi::GTRUE,
+            false => ffi::GFALSE
         }) }
     }
 
     fn get_hexpand_set(&self) -> bool {
         match unsafe { ffi::gtk_widget_get_hexpand_set(self.get_widget()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     fn set_hexpand_set(&self, expand: bool) {
         unsafe { ffi::gtk_widget_set_hexpand_set(self.get_widget(), match expand {
-            true => ffi::Gtrue,
-            false => ffi::Gfalse
+            true => ffi::GTRUE,
+            false => ffi::GFALSE
         }) }
     }
 
     fn get_vexpand(&self) -> bool {
         match unsafe { ffi::gtk_widget_get_vexpand(self.get_widget()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     fn set_vexpand(&self, expand: bool) {
         unsafe { ffi::gtk_widget_set_vexpand(self.get_widget(), match expand {
-            true => ffi::Gtrue,
-            false => ffi::Gfalse
+            true => ffi::GTRUE,
+            false => ffi::GFALSE
         }) }
     }
 
     fn get_vexpand_set(&self) -> bool {
         match unsafe { ffi::gtk_widget_get_vexpand_set(self.get_widget()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     fn set_vexpand_set(&self, expand: bool) {
         unsafe { ffi::gtk_widget_set_vexpand_set(self.get_widget(), match expand {
-            true => ffi::Gtrue,
-            false => ffi::Gfalse
+            true => ffi::GTRUE,
+            false => ffi::GFALSE
         }) }
     }
 
@@ -848,7 +848,7 @@ pub trait Widget: ffi::FFIWidget {
 
     fn compute_expand(&self, orientation: gtk::Orientation) -> bool {
         match unsafe { ffi::gtk_widget_compute_expand(self.get_widget(), orientation) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }

--- a/src/gtk/widgets/aboutdialog.rs
+++ b/src/gtk/widgets/aboutdialog.rs
@@ -125,15 +125,15 @@ impl AboutDialog {
 
     pub fn get_wrap_license(&self) -> bool {
         match unsafe { ffi::gtk_about_dialog_get_wrap_license(GTK_ABOUT_DIALOG(self.get_widget())) } {
-            ffi::Gfalse => false,
+            ffi::GFALSE => false,
             _ => true
         }
     }
 
     pub fn set_wrap_license(&self, wrap_license: bool) -> () {
         unsafe { ffi::gtk_about_dialog_set_wrap_license(GTK_ABOUT_DIALOG(self.get_widget()), match wrap_license {
-            true => ffi::Gtrue,
-            _ => ffi::Gfalse
+            true => ffi::GTRUE,
+            _ => ffi::GFALSE
         }) }
     }
 

--- a/src/gtk/widgets/appinfo.rs
+++ b/src/gtk/widgets/appinfo.rs
@@ -46,7 +46,7 @@ impl AppInfo {/*
 
     pub fn equals(&self, other: &AppInfo) -> bool {
         match unsafe { ffi::g_app_info_equal(GTK_APP_INFO(self.get_widget()), GTK_APP_INFO(other.get_widget())) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -116,21 +116,21 @@ impl AppInfo {/*
             files.unwrap(),
             GTK_APP_LAUNCH_CONTEXT(launch_context.get_widget()),
             &mut error.unwrap()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     pub fn supports_files(&self) -> bool {
         match unsafe { ffi::g_app_info_supports_files(GTK_APP_INFO(self.get_widget())) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     pub fn supports_uris(&self) -> bool {
         match unsafe { ffi::g_app_info_supports_uris(GTK_APP_INFO(self.get_widget())) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -140,28 +140,28 @@ impl AppInfo {/*
             uris.unwrap(),
             GTK_APP_LAUNCH_CONTEXT(launch_context.get_widget()),
             &mut error.unwrap()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     pub fn should_show(&self) -> bool {
         match unsafe { ffi::g_app_info_should_show(GTK_APP_INFO(self.get_widget())) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     pub fn can_delete(&self) -> bool {
         match unsafe { ffi::g_app_info_can_delete(GTK_APP_INFO(self.get_widget())) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     pub fn delete(&self) -> bool {
         match unsafe { ffi::g_app_info_delete(GTK_APP_INFO(self.get_widget())) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -180,7 +180,7 @@ impl AppInfo {/*
                 ffi::g_app_info_set_as_default_for_type(GTK_APP_INFO(self.get_widget()), c_str, &mut error.unwrap())
             })
         } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -191,7 +191,7 @@ impl AppInfo {/*
                 ffi::g_app_info_set_as_default_for_extension(GTK_APP_INFO(self.get_widget()), c_str, &mut error.unwrap())
             })
         } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -202,7 +202,7 @@ impl AppInfo {/*
                 ffi::g_app_info_set_as_last_used_for_type(GTK_APP_INFO(self.get_widget()), c_str, &mut error.unwrap())
             })
         } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -213,14 +213,14 @@ impl AppInfo {/*
                 ffi::g_app_info_add_supports_type(GTK_APP_INFO(self.get_widget()), c_str, &mut error.unwrap())
             })
         } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     pub fn can_remove_supports_type(&self) -> bool {
         match unsafe { ffi::g_app_info_can_remove_supports_type(GTK_APP_INFO(self.get_widget())) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -231,7 +231,7 @@ impl AppInfo {/*
                 ffi::g_app_info_remove_supports_type(GTK_APP_INFO(self.get_widget()), c_str, &mut error.unwrap())
             })
         } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -282,8 +282,8 @@ impl AppInfo {/*
         let tmp_pointer = unsafe {
             content_type.with_c_str(|c_str| {
                 ffi::g_app_info_get_default_for_type(c_str, match must_support_uris {
-                    true => ffi::Gtrue,
-                    false => ffi::Gfalse
+                    true => ffi::GTRUE,
+                    false => ffi::GFALSE
                 }) })
         };
 
@@ -342,7 +342,7 @@ impl AppInfo {/*
                 ffi::g_app_info_launch_default_for_uri(c_str, GTK_APP_LAUNCH_CONTEXT(launch_context.get_widget()), &mut error.unwrap())
             })
         } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }*/

--- a/src/gtk/widgets/aspectframe.rs
+++ b/src/gtk/widgets/aspectframe.rs
@@ -32,7 +32,7 @@ impl AspectFrame {
                ratio: f32,
                obey_child: bool)
                -> Option<AspectFrame> {
-        let c_obey_child = if obey_child { ffi::Gtrue } else { ffi::Gfalse };
+        let c_obey_child = if obey_child { ffi::GTRUE } else { ffi::GFALSE };
         let tmp_pointer = match label {
             Some(l) => unsafe { l.with_c_str(|c_str| { ffi::gtk_aspect_frame_new(c_str, x_align as c_float, y_align as c_float, ratio as c_float, c_obey_child) }) },
             None    => unsafe { ffi::gtk_aspect_frame_new(ptr::null(), x_align as c_float, y_align as c_float, ratio as c_float, c_obey_child) }
@@ -45,7 +45,7 @@ impl AspectFrame {
                y_align: f32,
                ratio: f32,
                obey_child: bool) -> () {
-        let c_obey_child = if obey_child { ffi::Gtrue } else { ffi::Gfalse };
+        let c_obey_child = if obey_child { ffi::GTRUE } else { ffi::GFALSE };
         unsafe {
             ffi::gtk_aspect_frame_set(GTK_ASPECTFRAME(self.pointer), x_align as c_float, y_align as c_float, ratio as c_float, c_obey_child);
         }

--- a/src/gtk/widgets/buttonbox.rs
+++ b/src/gtk/widgets/buttonbox.rs
@@ -37,14 +37,14 @@ impl ButtonBox {
 
     pub fn get_child_secondary<T: traits::Widget + traits::Button>(&self, child: &T) -> bool {
         match unsafe { ffi::gtk_button_box_get_child_secondary(GTK_BUTTONBOX(self.pointer), child.get_widget()) } {
-            ffi::Gfalse => false,
+            ffi::GFALSE => false,
             _           => true
         }
     }
 
     pub fn get_child_non_homogeneous<T: traits::Widget + traits::Button>(&self, child: &T) -> bool {
         match unsafe { ffi::gtk_button_box_get_child_non_homogeneous(GTK_BUTTONBOX(self.pointer), child.get_widget()) } {
-            ffi::Gfalse => false,
+            ffi::GFALSE => false,
             _           => true
         }
     }
@@ -57,15 +57,15 @@ impl ButtonBox {
 
     pub fn set_child_secondary<T: traits::Widget + traits::Button>(&mut self, child: &T, is_secondary: bool) -> () {
         match is_secondary {
-            false   => unsafe { ffi::gtk_button_box_set_child_secondary(GTK_BUTTONBOX(self.pointer), child.get_widget(), ffi::Gfalse) },
-            true    => unsafe { ffi::gtk_button_box_set_child_secondary(GTK_BUTTONBOX(self.pointer), child.get_widget(), ffi::Gtrue) }
+            false   => unsafe { ffi::gtk_button_box_set_child_secondary(GTK_BUTTONBOX(self.pointer), child.get_widget(), ffi::GFALSE) },
+            true    => unsafe { ffi::gtk_button_box_set_child_secondary(GTK_BUTTONBOX(self.pointer), child.get_widget(), ffi::GTRUE) }
         }
     }
 
     pub fn set_child_non_homogeneous<T: traits::Widget + traits::Button>(&mut self, child: &T, non_homogeneous: bool) -> () {
         match non_homogeneous {
-            false   => unsafe { ffi::gtk_button_box_set_child_non_homogeneous(GTK_BUTTONBOX(self.pointer), child.get_widget(), ffi::Gfalse) },
-            true    => unsafe { ffi::gtk_button_box_set_child_non_homogeneous(GTK_BUTTONBOX(self.pointer), child.get_widget(), ffi::Gtrue) }
+            false   => unsafe { ffi::gtk_button_box_set_child_non_homogeneous(GTK_BUTTONBOX(self.pointer), child.get_widget(), ffi::GFALSE) },
+            true    => unsafe { ffi::gtk_button_box_set_child_non_homogeneous(GTK_BUTTONBOX(self.pointer), child.get_widget(), ffi::GTRUE) }
         }
     }
 }

--- a/src/gtk/widgets/calendar.rs
+++ b/src/gtk/widgets/calendar.rs
@@ -67,7 +67,7 @@ impl Calendar {
 
     pub fn get_day_is_marked(&self, day: u32) -> bool {
         match unsafe { ffi::gtk_calendar_get_day_is_marked(GTK_CALENDAR(self.pointer), day as c_uint) } {
-            ffi::Gfalse => false,
+            ffi::GFALSE => false,
             _           => true
         }
     }

--- a/src/gtk/widgets/colorbutton.rs
+++ b/src/gtk/widgets/colorbutton.rs
@@ -88,14 +88,14 @@ impl ColorButton {
 
     pub fn set_use_alpha(&mut self, use_alpha: bool) -> () {
         match use_alpha {
-            true    => unsafe { ffi::gtk_color_button_set_use_alpha(GTK_COLORBUTTON(self.pointer), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_color_button_set_use_alpha(GTK_COLORBUTTON(self.pointer), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_color_button_set_use_alpha(GTK_COLORBUTTON(self.pointer), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_color_button_set_use_alpha(GTK_COLORBUTTON(self.pointer), ffi::GFALSE) }
         }
     }
 
     pub fn get_use_alpha(&self) -> bool {
         match unsafe { ffi::gtk_color_button_get_use_alpha(GTK_COLORBUTTON(self.pointer)) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }

--- a/src/gtk/widgets/expander.rs
+++ b/src/gtk/widgets/expander.rs
@@ -50,70 +50,70 @@ impl Expander {
 
     pub fn set_expanded(&mut self, expanded: bool) -> () {
         match expanded {
-            true    => unsafe { ffi::gtk_expander_set_expanded(GTK_EXPANDER(self.pointer), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_expander_set_expanded(GTK_EXPANDER(self.pointer), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_expander_set_expanded(GTK_EXPANDER(self.pointer), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_expander_set_expanded(GTK_EXPANDER(self.pointer), ffi::GFALSE) }
         }
     }
 
     pub fn get_expanded(&self) -> bool {
         match unsafe { ffi::gtk_expander_get_expanded(GTK_EXPANDER(self.pointer)) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
 
     pub fn set_use_underline(&mut self, use_underline: bool) -> () {
         match use_underline {
-            true    => unsafe { ffi::gtk_expander_set_use_underline(GTK_EXPANDER(self.pointer), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_expander_set_use_underline(GTK_EXPANDER(self.pointer), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_expander_set_use_underline(GTK_EXPANDER(self.pointer), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_expander_set_use_underline(GTK_EXPANDER(self.pointer), ffi::GFALSE) }
         }
     }
 
     pub fn get_use_underline(&self) -> bool {
         match unsafe { ffi::gtk_expander_get_use_underline(GTK_EXPANDER(self.pointer)) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
 
     pub fn set_use_markup(&mut self, use_markup: bool) -> () {
         match use_markup {
-            true    => unsafe { ffi::gtk_expander_set_use_markup(GTK_EXPANDER(self.pointer), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_expander_set_use_markup(GTK_EXPANDER(self.pointer), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_expander_set_use_markup(GTK_EXPANDER(self.pointer), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_expander_set_use_markup(GTK_EXPANDER(self.pointer), ffi::GFALSE) }
         }
     }
 
     pub fn get_use_markup(&self) -> bool {
         match unsafe { ffi::gtk_expander_get_use_markup(GTK_EXPANDER(self.pointer)) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
 
     pub fn set_label_fill(&mut self, label_fill: bool) -> () {
         match label_fill {
-            true    => unsafe { ffi::gtk_expander_set_label_fill(GTK_EXPANDER(self.pointer), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_expander_set_label_fill(GTK_EXPANDER(self.pointer), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_expander_set_label_fill(GTK_EXPANDER(self.pointer), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_expander_set_label_fill(GTK_EXPANDER(self.pointer), ffi::GFALSE) }
         }
     }
 
     pub fn get_label_fill(&self) -> bool {
         match unsafe { ffi::gtk_expander_get_label_fill(GTK_EXPANDER(self.pointer)) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
 
     pub fn set_resize_toplevel(&mut self, resize_toplevel: bool) -> () {
         match resize_toplevel {
-            true    => unsafe { ffi::gtk_expander_set_resize_toplevel(GTK_EXPANDER(self.pointer), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_expander_set_resize_toplevel(GTK_EXPANDER(self.pointer), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_expander_set_resize_toplevel(GTK_EXPANDER(self.pointer), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_expander_set_resize_toplevel(GTK_EXPANDER(self.pointer), ffi::GFALSE) }
         }
     }
 
     pub fn get_resize_toplevel(&self) -> bool {
         match unsafe { ffi::gtk_expander_get_resize_toplevel(GTK_EXPANDER(self.pointer)) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }

--- a/src/gtk/widgets/fontbutton.rs
+++ b/src/gtk/widgets/fontbutton.rs
@@ -46,7 +46,7 @@ impl FontButton {
 
     pub fn set_font_name(&mut self, font_name: &str) -> bool {
         match unsafe { font_name.with_c_str(|c_str| { ffi::gtk_font_button_set_font_name(GTK_FONTBUTTON(self.pointer), c_str) }) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
@@ -58,56 +58,56 @@ impl FontButton {
 
     pub fn set_show_style(&mut self, show_style: bool) -> () {
         match show_style {
-            true    => unsafe { ffi::gtk_font_button_set_show_style(GTK_FONTBUTTON(self.pointer), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_font_button_set_show_style(GTK_FONTBUTTON(self.pointer), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_font_button_set_show_style(GTK_FONTBUTTON(self.pointer), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_font_button_set_show_style(GTK_FONTBUTTON(self.pointer), ffi::GFALSE) }
         }
     }
 
     pub fn get_show_style(&self) -> bool {
         match unsafe { ffi::gtk_font_button_get_show_style(GTK_FONTBUTTON(self.pointer)) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
 
     pub fn set_show_size(&mut self, show_size: bool) -> () {
         match show_size {
-            true    => unsafe { ffi::gtk_font_button_set_show_size(GTK_FONTBUTTON(self.pointer), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_font_button_set_show_size(GTK_FONTBUTTON(self.pointer), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_font_button_set_show_size(GTK_FONTBUTTON(self.pointer), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_font_button_set_show_size(GTK_FONTBUTTON(self.pointer), ffi::GFALSE) }
         }
     }
 
     pub fn get_show_size(&self) -> bool {
         match unsafe { ffi::gtk_font_button_get_show_size(GTK_FONTBUTTON(self.pointer)) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
 
     pub fn set_use_font(&mut self, use_font: bool) -> () {
         match use_font {
-            true    => unsafe { ffi::gtk_font_button_set_use_font(GTK_FONTBUTTON(self.pointer), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_font_button_set_use_font(GTK_FONTBUTTON(self.pointer), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_font_button_set_use_font(GTK_FONTBUTTON(self.pointer), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_font_button_set_use_font(GTK_FONTBUTTON(self.pointer), ffi::GFALSE) }
         }
     }
 
     pub fn get_use_font(&self) -> bool {
         match unsafe { ffi::gtk_font_button_get_use_font(GTK_FONTBUTTON(self.pointer)) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
 
     pub fn set_use_size(&mut self, use_size: bool) -> () {
         match use_size {
-            true    => unsafe { ffi::gtk_font_button_set_use_size(GTK_FONTBUTTON(self.pointer), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_font_button_set_use_font(GTK_FONTBUTTON(self.pointer), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_font_button_set_use_size(GTK_FONTBUTTON(self.pointer), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_font_button_set_use_font(GTK_FONTBUTTON(self.pointer), ffi::GFALSE) }
         }
     }
 
     pub fn get_use_size(&self) -> bool {
         match unsafe { ffi::gtk_font_button_get_use_size(GTK_FONTBUTTON(self.pointer)) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }

--- a/src/gtk/widgets/grid.rs
+++ b/src/gtk/widgets/grid.rs
@@ -99,14 +99,14 @@ impl Grid {
 
     pub fn set_row_homogeneous(&mut self, homogeneous: bool) -> () {
         match homogeneous {
-            true    => unsafe { ffi::gtk_grid_set_row_homogeneous(GTK_GRID(self.pointer), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_grid_set_row_homogeneous(GTK_GRID(self.pointer), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_grid_set_row_homogeneous(GTK_GRID(self.pointer), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_grid_set_row_homogeneous(GTK_GRID(self.pointer), ffi::GFALSE) }
         }
     }
 
     pub fn get_row_homogeneous(&self) -> bool {
         match unsafe { ffi::gtk_grid_get_row_homogeneous(GTK_GRID(self.pointer)) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
@@ -125,14 +125,14 @@ impl Grid {
 
     pub fn set_column_homogeneous(&mut self, homogeneous: bool) -> () {
         match homogeneous {
-            true    => unsafe { ffi::gtk_grid_set_column_homogeneous(GTK_GRID(self.pointer), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_grid_set_column_homogeneous(GTK_GRID(self.pointer), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_grid_set_column_homogeneous(GTK_GRID(self.pointer), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_grid_set_column_homogeneous(GTK_GRID(self.pointer), ffi::GFALSE) }
         }
     }
 
     pub fn get_column_homogeneous(&self) -> bool {
         match unsafe { ffi::gtk_grid_get_column_homogeneous(GTK_GRID(self.pointer)) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }

--- a/src/gtk/widgets/infobar.rs
+++ b/src/gtk/widgets/infobar.rs
@@ -49,8 +49,8 @@ impl InfoBar {
 
     pub fn set_response_sensitive(&mut self, response_id: i32, setting: bool) -> () {
         match setting {
-            true    => unsafe { ffi::gtk_info_bar_set_response_sensitive(GTK_INFOBAR(self.pointer), response_id as c_int, ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_info_bar_set_response_sensitive(GTK_INFOBAR(self.pointer), response_id as c_int, ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_info_bar_set_response_sensitive(GTK_INFOBAR(self.pointer), response_id as c_int, ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_info_bar_set_response_sensitive(GTK_INFOBAR(self.pointer), response_id as c_int, ffi::GFALSE) }
         }
     }
 
@@ -81,15 +81,15 @@ impl InfoBar {
     #[cfg(any(GTK_3_10, GTK_3_12))]
     pub fn show_close_button(&mut self, show: bool) -> () {
          match show {
-            true    => unsafe { ffi::gtk_info_bar_set_show_close_button(GTK_INFOBAR(self.pointer), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_info_bar_set_show_close_button(GTK_INFOBAR(self.pointer), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_info_bar_set_show_close_button(GTK_INFOBAR(self.pointer), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_info_bar_set_show_close_button(GTK_INFOBAR(self.pointer), ffi::GFALSE) }
         }
     }
 
     #[cfg(any(GTK_3_10, GTK_3_12))]
     pub fn get_show_close_button(&self) -> bool {
         match unsafe { ffi::gtk_info_bar_get_show_close_button(GTK_INFOBAR(self.pointer)) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }

--- a/src/gtk/widgets/levelbar.rs
+++ b/src/gtk/widgets/levelbar.rs
@@ -92,15 +92,15 @@ impl LevelBar {
     #[cfg(any(GTK_3_8, GTK_3_10, GTK_3_12))]
     pub fn set_inverted(&mut self, inverted: bool) -> () {
         match inverted {
-            true    => unsafe { ffi::gtk_level_bar_set_inverted(GTK_LEVELBAR(self.pointer), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_level_bar_set_inverted(GTK_LEVELBAR(self.pointer), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_level_bar_set_inverted(GTK_LEVELBAR(self.pointer), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_level_bar_set_inverted(GTK_LEVELBAR(self.pointer), ffi::GFALSE) }
         }
     }
 
     #[cfg(any(GTK_3_8, GTK_3_10, GTK_3_12))]
     pub fn get_inverted(&self) -> bool {
         match unsafe { ffi::gtk_level_bar_get_inverted(GTK_LEVELBAR(self.pointer)) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
@@ -124,7 +124,7 @@ impl LevelBar {
     pub fn get_offset_value(&self, name: &str) -> Option<f64> {
         let value = 0.;
         match unsafe { name.with_c_str(|c_str| { ffi::gtk_level_bar_get_offset_value(GTK_LEVELBAR(self.pointer), c_str, &value) }) } {
-            ffi::Gfalse     => None,
+            ffi::GFALSE     => None,
             _               => Some(value)
         }
     }

--- a/src/gtk/widgets/linkbutton.rs
+++ b/src/gtk/widgets/linkbutton.rs
@@ -65,14 +65,14 @@ impl LinkButton {
 
     pub fn set_visited(&mut self, visited: bool) -> () {
         match visited {
-            true    => unsafe { ffi::gtk_link_button_set_visited(GTK_LINKBUTTON(self.pointer), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_link_button_set_visited(GTK_LINKBUTTON(self.pointer), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_link_button_set_visited(GTK_LINKBUTTON(self.pointer), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_link_button_set_visited(GTK_LINKBUTTON(self.pointer), ffi::GFALSE) }
         }
     }
 
     pub fn get_visited(&self) -> bool {
         match unsafe { ffi::gtk_link_button_get_visited(GTK_LINKBUTTON(self.pointer)) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }

--- a/src/gtk/widgets/paned.rs
+++ b/src/gtk/widgets/paned.rs
@@ -55,16 +55,16 @@ impl Paned {
     }
 
     pub fn pack1<T: traits::Widget>(&mut self, child: &T, resize: bool, schrink: bool) -> () {
-        let r = if resize { ffi::Gtrue } else { ffi::Gfalse };
-        let s = if schrink { ffi::Gtrue } else { ffi::Gfalse };
+        let r = if resize { ffi::GTRUE } else { ffi::GFALSE };
+        let s = if schrink { ffi::GTRUE } else { ffi::GFALSE };
         unsafe {
             ffi::gtk_paned_pack1(GTK_PANED(self.pointer), child.get_widget(), r, s);
         }
     }
 
     pub fn pack2<T: traits::Widget>(&mut self, child: &T, resize: bool, schrink: bool) -> () {
-        let r = if resize { ffi::Gtrue } else { ffi::Gfalse };
-        let s = if schrink { ffi::Gtrue } else { ffi::Gfalse };
+        let r = if resize { ffi::GTRUE } else { ffi::GFALSE };
+        let s = if schrink { ffi::GTRUE } else { ffi::GFALSE };
         unsafe {
             ffi::gtk_paned_pack2(GTK_PANED(self.pointer), child.get_widget(), r, s);
         }

--- a/src/gtk/widgets/papersize.rs
+++ b/src/gtk/widgets/papersize.rs
@@ -81,15 +81,15 @@ impl PaperSize {
 
     pub fn is_equal(&self, other: &PaperSize) -> bool {
         match unsafe { ffi::gtk_paper_size_is_equal(GTK_PAPER_SIZE(self.get_widget()), GTK_PAPER_SIZE(other.get_widget())) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     pub fn get_paper_sizes(include_custom: bool) -> glib::List<Box<PaperSize>> {
         let tmp = unsafe { ffi::gtk_paper_size_get_paper_sizes(match include_custom {
-            true => ffi::Gtrue,
-            false => ffi::Gfalse
+            true => ffi::GTRUE,
+            false => ffi::GFALSE
         }) };
 
         if tmp.is_null() {
@@ -145,7 +145,7 @@ impl PaperSize {
 
     pub fn is_custom(&self) -> bool {
         match unsafe { ffi::gtk_paper_size_is_custom(GTK_PAPER_SIZE(self.get_widget())) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }

--- a/src/gtk/widgets/printsettings.rs
+++ b/src/gtk/widgets/printsettings.rs
@@ -46,7 +46,7 @@ impl PrintSettings {
         match unsafe { key.with_c_str(|c_str| {
             ffi::gtk_print_settings_has_key(GTK_PRINT_SETTINGS(self.get_widget()), c_str)
         }) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -81,7 +81,7 @@ impl PrintSettings {
         match unsafe { key.with_c_str(|c_str| {
             ffi::gtk_print_settings_get_bool(GTK_PRINT_SETTINGS(self.get_widget()), c_str)
         })} {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -89,8 +89,8 @@ impl PrintSettings {
     pub fn set_bool(&self, key: &str, value: bool) {
         unsafe { key.with_c_str(|c_str| {
             ffi::gtk_print_settings_set_bool(GTK_PRINT_SETTINGS(self.get_widget()), c_str, match value {
-                true => ffi::Gtrue,
-                false => ffi::Gfalse
+                true => ffi::GTRUE,
+                false => ffi::GFALSE
             })
         })}
     }
@@ -199,43 +199,43 @@ impl PrintSettings {
 
     pub fn get_use_color(&self) -> bool {
         match unsafe { ffi::gtk_print_settings_get_use_color(GTK_PRINT_SETTINGS(self.get_widget())) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     pub fn set_use_color(&self, use_color: bool) {
         unsafe { ffi::gtk_print_settings_set_use_color(GTK_PRINT_SETTINGS(self.get_widget()), match use_color {
-            true => ffi::Gtrue,
-            false => ffi::Gfalse
+            true => ffi::GTRUE,
+            false => ffi::GFALSE
         }) }
     }
 
     pub fn get_collate(&self) -> bool {
         match unsafe { ffi::gtk_print_settings_get_collate(GTK_PRINT_SETTINGS(self.get_widget())) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     pub fn set_collate(&self, collate: bool) {
         unsafe { ffi::gtk_print_settings_set_collate(GTK_PRINT_SETTINGS(self.get_widget()), match collate {
-            true => ffi::Gtrue,
-            false => ffi::Gfalse
+            true => ffi::GTRUE,
+            false => ffi::GFALSE
         }) }
     }
 
     pub fn get_reverse(&self) -> bool {
         match unsafe { ffi::gtk_print_settings_get_reverse(GTK_PRINT_SETTINGS(self.get_widget())) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     pub fn set_reverse(&self, reverse: bool) {
         unsafe { ffi::gtk_print_settings_set_reverse(GTK_PRINT_SETTINGS(self.get_widget()), match reverse {
-            true => ffi::Gtrue,
-            false => ffi::Gfalse
+            true => ffi::GTRUE,
+            false => ffi::GFALSE
         }) }
     }
 

--- a/src/gtk/widgets/progressbar.rs
+++ b/src/gtk/widgets/progressbar.rs
@@ -66,28 +66,28 @@ impl ProgressBar {
 
     pub fn set_inverted(&mut self, inverted: bool) -> () {
         match inverted {
-            true    => unsafe { ffi::gtk_progress_bar_set_inverted(GTK_PROGRESSBAR(self.pointer), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_progress_bar_set_inverted(GTK_PROGRESSBAR(self.pointer), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_progress_bar_set_inverted(GTK_PROGRESSBAR(self.pointer), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_progress_bar_set_inverted(GTK_PROGRESSBAR(self.pointer), ffi::GFALSE) }
         }
     }
 
     pub fn get_inverted(&self) -> bool {
         match unsafe { ffi::gtk_progress_bar_get_inverted(GTK_PROGRESSBAR(self.pointer)) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
 
     pub fn set_show_text(&mut self, show_text: bool) -> () {
         match show_text {
-            true    => unsafe { ffi::gtk_progress_bar_set_show_text(GTK_PROGRESSBAR(self.pointer), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_progress_bar_set_show_text(GTK_PROGRESSBAR(self.pointer), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_progress_bar_set_show_text(GTK_PROGRESSBAR(self.pointer), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_progress_bar_set_show_text(GTK_PROGRESSBAR(self.pointer), ffi::GFALSE) }
         }
     }
 
     pub fn get_show_text(&self) -> bool {
         match unsafe { ffi::gtk_progress_bar_get_show_text(GTK_PROGRESSBAR(self.pointer)) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }

--- a/src/gtk/widgets/recentdata.rs
+++ b/src/gtk/widgets/recentdata.rs
@@ -55,7 +55,7 @@ impl RecentData {
                     app_exec: string::raw::from_buf((*ptr).app_exec as *const u8),
                     groups: tmp_groups,
                     is_private: match (*ptr).is_private {
-                    	ffi::Gtrue => true,
+                    	ffi::GTRUE => true,
                     	_ => false
                     }
                 }
@@ -83,8 +83,8 @@ impl RecentData {
 		                        app_exec: c_app_exec as *mut c_char,
 		                        groups: t_groups.as_mut_ptr(),
 		                        is_private: match self.is_private {
-		                        	true => ffi::Gtrue,
-		                        	false => ffi::Gfalse
+		                        	true => ffi::GTRUE,
+		                        	false => ffi::GFALSE
 		                        }
 		                    }
                 		})

--- a/src/gtk/widgets/recentfilter.rs
+++ b/src/gtk/widgets/recentfilter.rs
@@ -57,7 +57,7 @@ impl RecentFilter {
 
     pub fn filter(&self, filter_info: &gtk::RecentFilterInfo) -> bool {
         match unsafe { ffi::gtk_recent_filter_filter(GTK_RECENT_FILTER(self.get_widget()), &filter_info.get_ffi()) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }

--- a/src/gtk/widgets/recentinfo.rs
+++ b/src/gtk/widgets/recentinfo.rs
@@ -89,7 +89,7 @@ impl RecentInfo {
 
     pub fn get_private_hint(&self) -> bool {
         match unsafe { ffi::gtk_recent_info_get_private_hint(GTK_RECENT_INFO(self.get_widget())) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -104,7 +104,7 @@ impl RecentInfo {
                 ffi::gtk_recent_info_get_application_info(GTK_RECENT_INFO(self.get_widget()), c_str, &app_exec, &mut count, &mut time_)
             })
         } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         };
         if app_exec.is_null() {
@@ -144,7 +144,7 @@ impl RecentInfo {
         match unsafe { app_name.with_c_str(|c_str| {
             ffi::gtk_recent_info_has_application(GTK_RECENT_INFO(self.get_widget()), c_str)
         })} {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -169,7 +169,7 @@ impl RecentInfo {
         match unsafe { group_name.with_c_str(|c_str| {
             ffi::gtk_recent_info_has_group(GTK_RECENT_INFO(self.get_widget()), c_str)
         })} {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -200,21 +200,21 @@ impl RecentInfo {
 
     pub fn is_local(&self) -> bool {
         match unsafe { ffi::gtk_recent_info_is_local(GTK_RECENT_INFO(self.get_widget())) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     pub fn exists(&self) -> bool {
         match unsafe { ffi::gtk_recent_info_exists(GTK_RECENT_INFO(self.get_widget())) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
 
     pub fn _match(&self, other: &RecentInfo) -> bool {
         match unsafe { ffi::gtk_recent_info_match(GTK_RECENT_INFO(self.get_widget()), GTK_RECENT_INFO(other.get_widget())) } {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }

--- a/src/gtk/widgets/recentmanager.rs
+++ b/src/gtk/widgets/recentmanager.rs
@@ -46,7 +46,7 @@ impl RecentManager {
         match unsafe { uri.with_c_str(|c_str| {
             ffi::gtk_recent_manager_add_item(GTK_RECENT_MANAGER(self.get_widget()), c_str)
         })} {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -55,7 +55,7 @@ impl RecentManager {
         match unsafe { uri.with_c_str(|c_str| {
             ffi::gtk_recent_manager_add_full(GTK_RECENT_MANAGER(self.get_widget()), c_str, &recent_data.get_ffi())
         })} {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }
@@ -64,7 +64,7 @@ impl RecentManager {
         match unsafe { uri.with_c_str(|c_str| {
             ffi::gtk_recent_manager_has_item(GTK_RECENT_MANAGER(self.get_widget()), c_str)
         })} {
-            ffi::Gtrue => true,
+            ffi::GTRUE => true,
             _ => false
         }
     }

--- a/src/gtk/widgets/scale.rs
+++ b/src/gtk/widgets/scale.rs
@@ -54,28 +54,28 @@ impl Scale {
 
     pub fn set_draw_value(&mut self, draw_value: bool) -> () {
         match draw_value {
-            true    => unsafe { ffi::gtk_scale_set_draw_value(GTK_SCALE(self.pointer), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_scale_set_draw_value(GTK_SCALE(self.pointer), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_scale_set_draw_value(GTK_SCALE(self.pointer), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_scale_set_draw_value(GTK_SCALE(self.pointer), ffi::GFALSE) }
         }
     }
 
     pub fn get_draw_value(&self) -> bool {
         match unsafe { ffi::gtk_scale_get_draw_value(GTK_SCALE(self.pointer)) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
 
     pub fn set_has_origin(&mut self, has_origin: bool) -> () {
         match has_origin {
-            true    => unsafe { ffi::gtk_scale_set_has_origin(GTK_SCALE(self.pointer), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_scale_set_has_origin(GTK_SCALE(self.pointer), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_scale_set_has_origin(GTK_SCALE(self.pointer), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_scale_set_has_origin(GTK_SCALE(self.pointer), ffi::GFALSE) }
         }
     }
 
     pub fn get_has_origin(&self) -> bool {
         match unsafe { ffi::gtk_scale_get_has_origin(GTK_SCALE(self.pointer)) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }

--- a/src/gtk/widgets/searchbar.rs
+++ b/src/gtk/widgets/searchbar.rs
@@ -41,28 +41,28 @@ impl SearchBar {
 
     pub fn set_search_mode(&mut self, search_mode: bool) -> () {
         match search_mode {
-            true    => unsafe { ffi::gtk_search_bar_set_search_mode(GTK_SEARCHBAR(self.pointer), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_search_bar_set_search_mode(GTK_SEARCHBAR(self.pointer), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_search_bar_set_search_mode(GTK_SEARCHBAR(self.pointer), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_search_bar_set_search_mode(GTK_SEARCHBAR(self.pointer), ffi::GFALSE) }
         }
     }
 
     pub fn get_search_mode(&self) -> bool {
         match unsafe { ffi::gtk_search_bar_get_search_mode(GTK_SEARCHBAR(self.pointer)) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
 
     pub fn set_show_close_button(&mut self, visible: bool) -> () {
         match visible {
-            true    => unsafe { ffi::gtk_search_bar_set_show_close_button(GTK_SEARCHBAR(self.pointer), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_search_bar_set_show_close_button(GTK_SEARCHBAR(self.pointer), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_search_bar_set_show_close_button(GTK_SEARCHBAR(self.pointer), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_search_bar_set_show_close_button(GTK_SEARCHBAR(self.pointer), ffi::GFALSE) }
         }
     }
 
     pub fn get_show_close_button(&self) -> bool {
         match unsafe { ffi::gtk_search_bar_get_show_close_button(GTK_SEARCHBAR(self.pointer)) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }

--- a/src/gtk/widgets/separatortoolitem.rs
+++ b/src/gtk/widgets/separatortoolitem.rs
@@ -30,14 +30,14 @@ impl SeparatorToolItem {
 
     pub fn set_draw(&mut self, draw: bool) -> () {
         match draw {
-            true    => unsafe { ffi::gtk_separator_tool_item_set_draw(GTK_SEPARATORTOOLITEM(self.pointer), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_separator_tool_item_set_draw(GTK_SEPARATORTOOLITEM(self.pointer), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_separator_tool_item_set_draw(GTK_SEPARATORTOOLITEM(self.pointer), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_separator_tool_item_set_draw(GTK_SEPARATORTOOLITEM(self.pointer), ffi::GFALSE) }
         }
     }
 
     pub fn get_draw(&self) -> bool {
         match unsafe { ffi::gtk_separator_tool_item_get_draw(GTK_SEPARATORTOOLITEM(self.pointer)) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }

--- a/src/gtk/widgets/spinbutton.rs
+++ b/src/gtk/widgets/spinbutton.rs
@@ -105,42 +105,42 @@ impl SpinButton {
 
     pub fn set_numeric(&mut self, numeric: bool) -> () {
         match numeric {
-            true    => unsafe { ffi::gtk_spin_button_set_numeric(GTK_SPINBUTTON(self.pointer), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_spin_button_set_numeric(GTK_SPINBUTTON(self.pointer), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_spin_button_set_numeric(GTK_SPINBUTTON(self.pointer), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_spin_button_set_numeric(GTK_SPINBUTTON(self.pointer), ffi::GFALSE) }
         }
     }
 
     pub fn get_numeric(&self) -> bool {
         match unsafe { ffi::gtk_spin_button_get_numeric(GTK_SPINBUTTON(self.pointer)) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
 
     pub fn set_wrap(&mut self, wrap: bool) -> () {
         match wrap {
-            true    => unsafe { ffi::gtk_spin_button_set_wrap(GTK_SPINBUTTON(self.pointer), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_spin_button_set_wrap(GTK_SPINBUTTON(self.pointer), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_spin_button_set_wrap(GTK_SPINBUTTON(self.pointer), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_spin_button_set_wrap(GTK_SPINBUTTON(self.pointer), ffi::GFALSE) }
         }
     }
 
     pub fn get_wrap(&self) -> bool {
         match unsafe { ffi::gtk_spin_button_get_wrap(GTK_SPINBUTTON(self.pointer)) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }
 
     pub fn set_snap_to_ticks(&mut self, snap_to_ticks: bool) -> () {
         match snap_to_ticks {
-            true    => unsafe { ffi::gtk_spin_button_set_snap_to_ticks(GTK_SPINBUTTON(self.pointer), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_spin_button_set_snap_to_ticks(GTK_SPINBUTTON(self.pointer), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_spin_button_set_snap_to_ticks(GTK_SPINBUTTON(self.pointer), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_spin_button_set_snap_to_ticks(GTK_SPINBUTTON(self.pointer), ffi::GFALSE) }
         }
     }
 
     pub fn get_snap_to_ticks(&self) -> bool {
         match unsafe { ffi::gtk_spin_button_get_snap_to_ticks(GTK_SPINBUTTON(self.pointer)) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }

--- a/src/gtk/widgets/switch.rs
+++ b/src/gtk/widgets/switch.rs
@@ -33,14 +33,14 @@ impl Switch {
 
     pub fn set_active(&mut self, is_active: bool) -> () {
         match is_active {
-            true    => unsafe { ffi::gtk_switch_set_active(GTK_SWITCH(self.pointer), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_switch_set_active(GTK_SWITCH(self.pointer), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_switch_set_active(GTK_SWITCH(self.pointer), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_switch_set_active(GTK_SWITCH(self.pointer), ffi::GFALSE) }
         }
     }
 
     pub fn get_active(&self) -> bool {
         match unsafe { ffi::gtk_switch_get_active(GTK_SWITCH(self.pointer)) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }

--- a/src/gtk/widgets/toolbar.rs
+++ b/src/gtk/widgets/toolbar.rs
@@ -85,8 +85,8 @@ impl Toolbar {
 
     pub fn set_show_arrow(&mut self, show_arrow: bool) -> () {
         match show_arrow {
-            true    => unsafe { ffi::gtk_toolbar_set_show_arrow(GTK_TOOLBAR(self.pointer), ffi::Gtrue) },
-            false   => unsafe { ffi::gtk_toolbar_set_show_arrow(GTK_TOOLBAR(self.pointer), ffi::Gfalse) }
+            true    => unsafe { ffi::gtk_toolbar_set_show_arrow(GTK_TOOLBAR(self.pointer), ffi::GTRUE) },
+            false   => unsafe { ffi::gtk_toolbar_set_show_arrow(GTK_TOOLBAR(self.pointer), ffi::GFALSE) }
         }
     }
 
@@ -98,7 +98,7 @@ impl Toolbar {
 
     pub fn get_show_arrow(&self) -> bool {
         match unsafe { ffi::gtk_toolbar_get_show_arrow(GTK_TOOLBAR(self.pointer)) } {
-            ffi::Gfalse     => false,
+            ffi::GFALSE     => false,
             _               => true
         }
     }


### PR DESCRIPTION
To comply with #[warn(non_uppercase_statics)]

This will/would break everything outside of rgtk using those constants but I think it would be easily enough to fix in any project and seems like the correct thing to do for the future (to comply with rust coding convertions)
