### PR TITLE
Create GObject trait and move connect method to there

### DIFF
--- a/src/glib/ffi.rs
+++ b/src/glib/ffi.rs
@@ -154,6 +154,11 @@ extern "C" {
     pub fn g_object_ref(object: *mut C_GObject) -> *mut C_GObject;
     pub fn g_object_unref(object: *mut C_GObject);
 
+    pub fn glue_signal_connect(g_object: *mut C_GObject,
+                               signal: *const c_char,
+                               func: Option<extern "C" fn()>,
+                               user_data: *const c_void);
+
     //=========================================================================
     // GType constants
     //=========================================================================

--- a/src/glib/mod.rs
+++ b/src/glib/mod.rs
@@ -25,6 +25,7 @@ pub use self::glib_container::GlibContainer;
 pub use self::error::{Error};
 pub use self::permission::Permission;
 pub use self::ffi::GType;
+pub use self::traits::{FFIGObject, GObject};
 
 mod list;
 mod slist;
@@ -32,6 +33,7 @@ pub mod ffi;
 mod glib_container;
 mod error;
 mod permission;
+pub mod traits;
 
 // An opaque structure used as the base of all interface types.
 pub struct TypeInterface;

--- a/src/glib/traits.rs
+++ b/src/glib/traits.rs
@@ -1,0 +1,43 @@
+// This file is part of rgtk.
+//
+// rgtk is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// rgtk is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
+
+use glib::ffi;
+use gtk::signals::Signal;
+
+pub trait FFIGObject {
+    fn get_gobject(&self) -> *mut ffi::C_GObject;
+}
+
+pub trait GObject: FFIGObject {
+    fn connect<'a>(&self, signal: Box<Signal<'a>>) -> () {
+        use std::mem::transmute;
+
+        unsafe {
+            let signal_name     = signal.get_signal_name().to_string();
+            let trampoline      = signal.get_trampoline();
+
+            let user_data_ptr   = transmute(box signal);
+
+            signal_name.replace("_", "-").with_c_str(|signal_name| {
+                ffi::glue_signal_connect(
+                    self.get_gobject(),
+                    signal_name,
+                    Some(trampoline),
+                    user_data_ptr
+                )
+            });
+        }
+    }
+}

--- a/src/gtk/ffi.rs
+++ b/src/gtk/ffi.rs
@@ -2904,10 +2904,6 @@ extern "C" {
     //=========================================================================
     // Glue fixe code
     //=========================================================================
-    pub fn glue_signal_connect(g_object: *mut C_GtkWidget,
-                               signal: *const c_char,
-                               func: Option<extern "C" fn()>,
-                               user_data: *const c_void);
     pub fn g_signal_connect_data(instance: gpointer,
                                  detailed_signal: *const c_char,
                                  c_hanlder: Option<extern "C" fn()>,
@@ -2956,7 +2952,7 @@ extern "C" {
     //=========================================================================
     // GTK Casts functions
     //=========================================================================
-    pub fn cast_GObject(widget: *mut C_GtkWidget) -> *mut glib::ffi::C_GObject;
+    pub fn cast_GtkObject(widget: *mut C_GtkWidget) -> *mut glib::ffi::C_GObject;
     pub fn cast_GtkWindow(widget: *mut C_GtkWidget) -> *mut C_GtkWindow;
     pub fn cast_GtkBin(widget: *mut C_GtkWidget) -> *mut C_GtkBin;
     pub fn cast_GtkButton(widget: *mut C_GtkWidget) -> *mut C_GtkButton;

--- a/src/gtk/macros.rs
+++ b/src/gtk/macros.rs
@@ -58,6 +58,17 @@ macro_rules! impl_TraitWidget(
         }
 
         impl ::gtk::traits::Widget for $gtk_struct {}
+
+        impl ::glib::traits::FFIGObject for $gtk_struct {
+            fn get_gobject(&self) -> *mut ::glib::ffi::C_GObject {
+                use gtk::ffi::FFIWidget;
+                unsafe {
+                    ::gtk::ffi::cast_GtkObject(self.get_widget())
+                }
+            }
+        }
+
+        impl ::glib::traits::GObject for $gtk_struct {}
     );
 )
 

--- a/src/gtk/traits/widget.rs
+++ b/src/gtk/traits/widget.rs
@@ -15,7 +15,6 @@
 
 use libc::{c_int, c_char};
 use gtk::ffi;
-use gtk::signals::Signal;
 use gtk::enums;
 use gdk;
 use gtk;
@@ -664,26 +663,6 @@ pub trait Widget: ffi::FFIWidget {
     fn get_margin_bottom(&mut self) -> i32 {
         unsafe {
             ffi::gtk_widget_get_margin_bottom(self.get_widget()) as i32
-        }
-    }
-
-    fn connect<'a>(&self, signal: Box<Signal<'a>>) -> () {
-        use std::mem::transmute;
-
-        unsafe {
-            let signal_name     = signal.get_signal_name().to_string();
-            let trampoline      = signal.get_trampoline();
-
-            let user_data_ptr   = transmute(box signal);
-
-            signal_name.replace("_", "-").with_c_str(|signal_name| {
-                ffi::glue_signal_connect(
-                    self.get_widget(),
-                    signal_name,
-                    Some(trampoline),
-                    user_data_ptr
-                )
-            });
         }
     }
 

--- a/src/rgtk.rs
+++ b/src/rgtk.rs
@@ -47,6 +47,7 @@ let button = gtk::Button:new(); // trait gtk::traits::Button reexported as GtkBu
 
 extern crate libc;
 
+pub use glib::traits::GObject         as GObjectTrait;
 pub use gtk::traits::Widget           as GtkWidgetTrait;
 pub use gtk::traits::Container        as GtkContainerTrait;
 pub use gtk::traits::Window           as GtkWindowTrait;


### PR DESCRIPTION
Resolves #118.

All examples are working.

There's also another way of handling this. We can have something like this:

``` rust
pub trait Signals<S:Signal> {
    fn connect(&self, &s: S);
}
```

and implement this for every type. I think this is a bit better because it allows us to have more precise types, for example, we can't connect a callback to a signal that the object won't fire. If you like this idea I think I can implement.
