### PR TITLE
Fix spelling of "mnemonic" in function definitions

### DIFF
--- a/src/gtk/widgets/button.rs
+++ b/src/gtk/widgets/button.rs
@@ -48,7 +48,7 @@ impl Button {
         check_pointer!(tmp_pointer, Button)
     }
 
-    pub fn new_with_menmonic(mnemonic: &str) -> Option<Button> {
+    pub fn new_with_mnemonic(mnemonic: &str) -> Option<Button> {
         let tmp_pointer = unsafe {
             mnemonic.with_c_str(|c_str| {
                 ffi::gtk_button_new_with_mnemonic(c_str)

--- a/src/gtk/widgets/radiobutton.rs
+++ b/src/gtk/widgets/radiobutton.rs
@@ -38,7 +38,7 @@ impl RadioButton {
         check_pointer!(tmp_pointer, RadioButton)
     }
 
-    pub fn new_with_menmonic(mnemonic: &str) -> Option<RadioButton> {
+    pub fn new_with_mnemonic(mnemonic: &str) -> Option<RadioButton> {
         let tmp_pointer = unsafe {
             mnemonic.with_c_str(|c_str| {
                 ffi::gtk_radio_button_new_with_mnemonic(ptr::null_mut(), c_str)


### PR DESCRIPTION
RadioButton and Button had typos.
