### PR TITLE
Fix TreeView example

### DIFF
--- a/examples/treeview/src/treeview.rs
+++ b/examples/treeview/src/treeview.rs
@@ -36,7 +36,7 @@ fn main() {
 
     let mut left_tree = gtk::TreeView::new().unwrap();
     let column_types = [glib::ffi::g_type_string];
-    let left_store = gtk::ListStore::new(column_types).unwrap();
+    let left_store = gtk::ListStore::new(&column_types).unwrap();
     let left_model = left_store.get_model().unwrap();
     left_tree.set_model(&left_model);
     left_tree.set_headers_visible(false);
@@ -52,7 +52,7 @@ fn main() {
 
     let mut right_tree = gtk::TreeView::new().unwrap();
     let column_types = [glib::ffi::g_type_string];
-    let right_store = gtk::TreeStore::new(column_types).unwrap();
+    let right_store = gtk::TreeStore::new(&column_types).unwrap();
     let right_model = right_store.get_model().unwrap();
     right_tree.set_model(&right_model);
     right_tree.set_headers_visible(false);


### PR DESCRIPTION
Due to [this change](https://github.com/rust-lang/rust/commit/85914df05a95b1d14e483b69d9c4f0eba44b5d25), slices must be explicitly borrowed.
