### PR TITLE
Cast as fn pointer to fix build error

### DIFF
--- a/src/gtk/traits/button.rs
+++ b/src/gtk/traits/button.rs
@@ -179,7 +179,7 @@ pub trait ButtonTrait: gtk::WidgetTrait + gtk::ContainerTrait {
                     cstr,
                     Some(mem::transmute(widget_destroy_callback)),
                     data,
-                    Some(drop_widget_destroy_handler),
+                    Some(drop_widget_destroy_handler as extern "C" fn(ffi::gpointer, *const ffi::C_GClosure)),
                     0);
             }
         });


### PR DESCRIPTION
Fixes a build error with the latest nightly. See: https://github.com/rust-lang/rust/issues/20178
