### PR TITLE
Fix bug in TreeIter::new()

### DIFF
--- a/src/gtk/widgets/tree_iter.rs
+++ b/src/gtk/widgets/tree_iter.rs
@@ -22,10 +22,15 @@ pub struct TreeIter {
 
 impl TreeIter {
     pub fn new() -> Option<TreeIter> {
-        let iter = TreeIter {
-            pointer: unsafe { ::std::mem::uninitialized() }
-        };
-        iter.copy()
+        let tmp_pointer = unsafe { ffi::gtk_tree_iter_copy(::std::mem::uninitialized()) };
+
+        if tmp_pointer.is_null() {
+            None
+        } else {
+            Some(TreeIter {
+                pointer: tmp_pointer
+            })
+        }
     }
 
     pub fn copy(&self) -> Option<TreeIter> {


### PR DESCRIPTION
Somehow this bug didn't surface when I tested the treeview example. It turns out that TreeIter's `new` method can fail because I implemented `Drop`. This is because it creates a temporary `TreeIter` object that has the same pointer as the one that it eventually returns, and its pointer is freed at the end of the `new` method by the `drop` method. The simple fix is to not make any temporary `TreeIter` object.
