### PR TITLE
Don't drop TreeIter created by wrap_pointer

### DIFF
--- a/src/gtk/widgets/tree_iter.rs
+++ b/src/gtk/widgets/tree_iter.rs
@@ -16,7 +16,8 @@
 use gtk::ffi;
 
 pub struct TreeIter {
-    pointer: *mut ffi::C_GtkTreeIter
+    pointer: *mut ffi::C_GtkTreeIter,
+    is_owned: bool,
 }
 
 impl TreeIter {
@@ -27,7 +28,8 @@ impl TreeIter {
             None
         } else {
             Some(TreeIter {
-                pointer: tmp_pointer
+                pointer: tmp_pointer,
+                is_owned: true,
             })
         }
     }
@@ -39,7 +41,8 @@ impl TreeIter {
             None
         } else {
             Some(TreeIter {
-                pointer: tmp_pointer
+                pointer: tmp_pointer,
+                is_owned: true,
             })
         }
     }
@@ -52,14 +55,15 @@ impl TreeIter {
     #[doc(hidden)]
     pub fn wrap_pointer(c_treeiter: *mut ffi::C_GtkTreeIter) -> TreeIter {
         TreeIter {
-            pointer: c_treeiter
+            pointer: c_treeiter,
+            is_owned: false,
         }
     }
 }
 
 impl Drop for TreeIter {
     fn drop(&mut self) {
-        if !self.pointer.is_null() {
+        if !self.pointer.is_null() && self.is_owned {
             unsafe { ffi::gtk_tree_iter_free(self.pointer) };
             self.pointer = ::std::ptr::null_mut();
         }


### PR DESCRIPTION
I noticed a problem when I wanted to use the RowExpanded and RowCollapsed signals with my TreeView. It provides a raw C_GtkTreeIter pointer, so I have to wrap it. Since TreeIter implements `Drop`, it will free the pointer at the end of the closure, which we do _not_ want since it is a pointer we didn't create.

```rust
tree.connect(gtk::signals::RowExpanded::new(&mut |&mut: iter_raw, tree_path| {
    let iter = gtk::TreeIter::wrap_pointer(iter_raw);
    // iter_raw will be freed
}));
```

My solution is to keep track of whether the internal pointer is "owned". If it was created via `new` or `copy`, it will be dropped like usual. If it is created via `wrap_pointer`, it will not be dropped. This should allow us to wrap system-provided pointers without accidentally freeing them afterwards.