### PR TITLE
Fixes for cairo::Context::set_dash and get_dash

### DIFF
--- a/examples/cairotest/src/cairotest.rs
+++ b/examples/cairotest/src/cairotest.rs
@@ -17,6 +17,9 @@ fn main() {
     gtk::init();
 
     drawable(500, 500, &mut |cr: Context| {
+        cr.set_dash(&[3., 2., 1.], 42.);
+        assert_eq!(cr.get_dash(), (vec![3., 2., 1.], 42.));
+
         cr.scale(500f64, 500f64);
 
         cr.set_source_rgb(250.0/255.0, 224.0/255.0, 55.0/255.0);

--- a/src/cairo/context.rs
+++ b/src/cairo/context.rs
@@ -171,9 +171,9 @@ impl Context {
         }
     }
 
-    pub fn set_dash(&self, dashes: &[f64], num_dashes: i32, offset: f64){
+    pub fn set_dash(&self, dashes: &[f64], offset: f64){
         unsafe {
-            ffi::cairo_set_dash(self.get_ptr(), dashes.as_ptr(), num_dashes, offset)
+            ffi::cairo_set_dash(self.get_ptr(), dashes.as_ptr(), dashes.len() as i32, offset)
         }
         self.ensure_status(); //Possible invalid dashes value
     }

--- a/src/cairo/context.rs
+++ b/src/cairo/context.rs
@@ -191,6 +191,7 @@ impl Context {
 
         unsafe {
             ffi::cairo_get_dash(self.get_ptr(), dashes.as_mut_ptr(), &mut offset);
+            dashes.set_len(dash_count);
             (dashes, offset)
         }
     }


### PR DESCRIPTION
Please see individual commit messages, and confirm that the test fails on the second commit and is fixed on the third. I was not able to run tests locally.