### PR TITLE
Fix build errors

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -48,15 +48,14 @@ fn main() {
     }).collect();
 
     // build include path
-    let gcc_conf = Config {
-        include_directories: paths,
-        definitions: vec!(),
-        objects: vec!(),
-	flags: vec!()
-    };
+    let mut gcc_conf = Config::new();
+    for path in paths {
+        gcc_conf.include(path);
+    }
+    gcc_conf.file("./gtk_glue/gtk_glue.c");
 
     // build library
-    gcc::compile_library("librgtk_glue.a", &gcc_conf, &["./gtk_glue/gtk_glue.c"]);
+    gcc_conf.compile("librgtk_glue.a");
 
     // say to cargo where it is
     println!("cargo:rustc-flags=-L {:?} -l rgtk_glue:static", out_dir);

--- a/src/gtk/widgets/info_bar.rs
+++ b/src/gtk/widgets/info_bar.rs
@@ -21,7 +21,7 @@ use std::ffi::CString;
 use gtk::MessageType;
 use gtk::cast::GTK_INFOBAR;
 use gtk::{self, ffi};
-use gtk::ffi::to_gboolean;
+use gtk::ffi::{to_bool, to_gboolean};
 
 /// InfoBar — Report important messages to the user
 struct_Widget!(InfoBar);


### PR DESCRIPTION
1. Change how `gcc::Config` is constructed, following the public interface in http://alexcrichton.com/gcc-rs/gcc/struct.Config.html.
2. `gtk/widget/info_bar.rs` failed to compile due to missing import of `gtk::ffi::to_bool`.

I have only tested on Mac OS X with gtk+ 3.14, but this should work on other platforms.