### PR TITLE
Discard outdated build instructions

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -23,8 +23,6 @@ use gcc::Config;
 use std::env;
 
 fn main() {
-    let out_dir = env::var("OUT_DIR").unwrap();
-
     env::set_var("PKG_CONFIG_ALLOW_CROSS", "1");
 
     // try to find gtk+-3.0 library
@@ -56,7 +54,4 @@ fn main() {
 
     // build library
     gcc_conf.compile("librgtk_glue.a");
-
-    // say to cargo where it is
-    println!("cargo:rustc-flags=-L {:?} -l rgtk_glue:static", out_dir);
 }

--- a/src/rgtk.rs
+++ b/src/rgtk.rs
@@ -96,42 +96,6 @@ pub use gtk::ToolShellTrait as GtkToolShellTrait;
 pub use gtk::WidgetTrait as GtkWidgetTrait;
 pub use gtk::WindowTrait as GtkWindowTrait;
 
-#[doc(hidden)]
-#[cfg(target_os="macos")]
-mod platform {
-    #[link(name = "glib-2.0")]
-    #[link(name = "gtk-3.0")]
-    #[link(name = "gio-2.0")]
-    #[link(name = "gobject-2.0")]
-    #[link(name = "gdk-3.0")]
-    #[link(name = "rgtk_glue", kind = "static")]
-    extern{}
-}
-
-#[doc(hidden)]
-#[cfg(target_os="linux")]
-mod platform {
-    #[link(name = "glib-2.0")]
-    #[link(name = "gtk-3")]
-    #[link(name = "gio-2.0")]
-    #[link(name = "gobject-2.0")]
-    #[link(name = "gdk-3")]
-    #[link(name = "rgtk_glue", kind = "static")]
-    extern{}
-}
-
-#[doc(hidden)]
-#[cfg(target_os="windows")]
-mod platform {
-    #[link(name = "glib-2.0")]
-    #[link(name = "gtk-3")]
-    #[link(name = "gio-2.0")]
-    #[link(name = "gobject-2.0")]
-    #[link(name = "gdk-3")]
-    #[link(name = "rgtk_glue", kind = "static")]
-    extern{}
-}
-
 pub mod gtk;
 pub mod cairo;
 pub mod gdk;


### PR DESCRIPTION
`cargo test` won't blow up now.