### PR TITLE
Use generic syntax to fix build errors

### DIFF
--- a/src/gtk/traits/cell_layout.rs
+++ b/src/gtk/traits/cell_layout.rs
@@ -19,7 +19,7 @@ use gtk::cast::{GTK_CELL_LAYOUT, GTK_CELL_RENDERER};
 use glib;
 
 pub trait CellLayoutTrait: gtk::WidgetTrait {
-    fn pack_start(&self, cell: &gtk::CellRendererTrait, expand: bool) {
+    fn pack_start<T: gtk::CellRendererTrait>(&self, cell: &T, expand: bool) {
         unsafe {
             ffi::gtk_cell_layout_pack_start(GTK_CELL_LAYOUT(self.get_widget()), GTK_CELL_RENDERER(cell.get_widget()), match expand {
                 true => 1,
@@ -28,7 +28,7 @@ pub trait CellLayoutTrait: gtk::WidgetTrait {
         }
     }
 
-    fn pack_end(&self, cell: &gtk::CellRendererTrait, expand: bool) {
+    fn pack_end<T: gtk::CellRendererTrait>(&self, cell: &T, expand: bool) {
         unsafe {
             ffi::gtk_cell_layout_pack_end(GTK_CELL_LAYOUT(self.get_widget()), GTK_CELL_RENDERER(cell.get_widget()), match expand {
                 true => 1,
@@ -59,7 +59,7 @@ pub trait CellLayoutTrait: gtk::WidgetTrait {
         }
     }
 
-    fn reorder(&self, cell: &gtk::CellRendererTrait, position: i32) {
+    fn reorder<T: gtk::CellRendererTrait>(&self, cell: &T, position: i32) {
         unsafe { ffi::gtk_cell_layout_reorder(GTK_CELL_LAYOUT(self.get_widget()), GTK_CELL_RENDERER(cell.get_widget()), position) }
     }
 
@@ -67,7 +67,7 @@ pub trait CellLayoutTrait: gtk::WidgetTrait {
         unsafe { ffi::gtk_cell_layout_clear(GTK_CELL_LAYOUT(self.get_widget())) }
     }
 
-    fn add_attribute(&self, cell: &gtk::CellRendererTrait, attribute: &str, column: i32) {
+    fn add_attribute<T: gtk::CellRendererTrait>(&self, cell: &T, attribute: &str, column: i32) {
         let c_str = CString::from_slice(attribute.as_bytes());
 
         unsafe {
@@ -76,7 +76,7 @@ pub trait CellLayoutTrait: gtk::WidgetTrait {
             }
     }
 
-    fn clear_attributes(&self, cell: &gtk::CellRendererTrait) {
+    fn clear_attributes<T: gtk::CellRendererTrait>(&self, cell: &T) {
         unsafe { ffi::gtk_cell_layout_clear_attributes(GTK_CELL_LAYOUT(self.get_widget()), GTK_CELL_RENDERER(cell.get_widget())) }
     }
 }

--- a/src/gtk/traits/cell_renderer.rs
+++ b/src/gtk/traits/cell_renderer.rs
@@ -82,7 +82,7 @@ pub trait CellRendererTrait: gtk::WidgetTrait {
         unsafe { ffi::gtk_cell_renderer_set_padding(GTK_CELL_RENDERER(self.get_widget()), xpad, ypad) }
     }
 
-    fn get_state(&self, widget: &gtk::WidgetTrait, cell_state: gtk::CellRendererState) -> gtk::StateFlags {
+    fn get_state<T: gtk::WidgetTrait>(&self, widget: &T, cell_state: gtk::CellRendererState) -> gtk::StateFlags {
         unsafe { ffi::gtk_cell_renderer_get_state(GTK_CELL_RENDERER(self.get_widget()), widget.get_widget(), cell_state) }
     }
 
@@ -93,22 +93,22 @@ pub trait CellRendererTrait: gtk::WidgetTrait {
         }
     }
 
-    fn get_preferred_height(&self, widget: &gtk::WidgetTrait, minimum_size: &mut i32, natural_size: &mut i32) {
+    fn get_preferred_height<T: gtk::WidgetTrait>(&self, widget: &T, minimum_size: &mut i32, natural_size: &mut i32) {
         unsafe { ffi::gtk_cell_renderer_get_preferred_height(GTK_CELL_RENDERER(self.get_widget()), widget.get_widget(), minimum_size,
             natural_size) }
     }
 
-    fn get_preferred_height_for_width(&self, widget: &gtk::WidgetTrait, width: i32, minimum_size: &mut i32, natural_size: &mut i32) {
+    fn get_preferred_height_for_width<T: gtk::WidgetTrait>(&self, widget: &T, width: i32, minimum_size: &mut i32, natural_size: &mut i32) {
         unsafe { ffi::gtk_cell_renderer_get_preferred_height_for_width(GTK_CELL_RENDERER(self.get_widget()), widget.get_widget(), width,
             minimum_size, natural_size) }
     }
 
-    fn get_preferred_width(&self, widget: &gtk::WidgetTrait, minimum_size: &mut i32, natural_size: &mut i32) {
+    fn get_preferred_width<T: gtk::WidgetTrait>(&self, widget: &T, minimum_size: &mut i32, natural_size: &mut i32) {
         unsafe { ffi::gtk_cell_renderer_get_preferred_width(GTK_CELL_RENDERER(self.get_widget()), widget.get_widget(), minimum_size,
             natural_size) }
     }
 
-    fn get_preferred_width_for_height(&self, widget: &gtk::WidgetTrait, height: i32, minimum_size: &mut i32, natural_size: &mut i32) {
+    fn get_preferred_width_for_height<T: gtk::WidgetTrait>(&self, widget: &T, height: i32, minimum_size: &mut i32, natural_size: &mut i32) {
         unsafe { ffi::gtk_cell_renderer_get_preferred_width_for_height(GTK_CELL_RENDERER(self.get_widget()), widget.get_widget(), height,
             minimum_size, natural_size) }
     }

--- a/src/gtk/traits/dialog.rs
+++ b/src/gtk/traits/dialog.rs
@@ -54,7 +54,7 @@ pub trait DialogTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrait + 
         ret
     }
 
-    fn add_action_widget(&self, child: &gtk::WidgetTrait, response_id: i32) -> () {
+    fn add_action_widget<T: gtk::WidgetTrait>(&self, child: &T, response_id: i32) -> () {
         unsafe { ffi::gtk_dialog_add_action_widget(GTK_DIALOG(self.get_widget()), child.get_widget(), response_id) }
     }
 
@@ -66,7 +66,7 @@ pub trait DialogTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrait + 
         unsafe { ffi::gtk_dialog_set_response_sensitive(GTK_DIALOG(self.get_widget()), response_id, setting) }
     }
 
-    fn get_response_for_widget(&self, widget: &gtk::WidgetTrait) -> Result<i32, gtk::ResponseType> {
+    fn get_response_for_widget<T: gtk::WidgetTrait>(&self, widget: &T) -> Result<i32, gtk::ResponseType> {
         let tmp = unsafe { ffi::gtk_dialog_get_response_for_widget(GTK_DIALOG(self.get_widget()), widget.get_widget()) };
 
         if tmp < 0 {

--- a/src/gtk/traits/file_chooser.rs
+++ b/src/gtk/traits/file_chooser.rs
@@ -246,7 +246,7 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
         }
     }
 
-    fn set_preview_widget(&self, preview_widget: &gtk::WidgetTrait) -> () {
+    fn set_preview_widget<T: gtk::WidgetTrait>(&self, preview_widget: &T) -> () {
         unsafe { ffi::gtk_file_chooser_set_preview_widget(GTK_FILE_CHOOSER(self.get_widget()), preview_widget.get_widget()) }
     }
 
@@ -302,7 +302,7 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
         }
     }
 
-    fn set_extra_widget(&self, extra_widget: &gtk::WidgetTrait) -> () {
+    fn set_extra_widget<T: gtk::WidgetTrait>(&self, extra_widget: &T) -> () {
         unsafe { ffi::gtk_file_chooser_set_extra_widget(GTK_FILE_CHOOSER(self.get_widget()), extra_widget.get_widget()) }
     }
 

--- a/src/gtk/traits/menu_item.rs
+++ b/src/gtk/traits/menu_item.rs
@@ -21,7 +21,7 @@ use gtk::cast::GTK_MENU_ITEM;
 
 /// The widget used for item in menus
 pub trait MenuItemTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrait {
-    fn set_submenu(&mut self, widget: &mut gtk::WidgetTrait) {
+    fn set_submenu<T: gtk::WidgetTrait>(&mut self, widget: &mut T) {
         unsafe {
             ffi::gtk_menu_item_set_submenu(GTK_MENU_ITEM(self.get_widget()),
                                            widget.get_widget())

--- a/src/gtk/traits/menu_shell.rs
+++ b/src/gtk/traits/menu_shell.rs
@@ -20,19 +20,19 @@ use gtk::cast::GTK_MENU_SHELL;
 
 /// A base class for menu objects
 pub trait MenuShellTrait: gtk::WidgetTrait + gtk::ContainerTrait {
-    fn append(&mut self, widget: &gtk::WidgetTrait) {
+    fn append<T: gtk::WidgetTrait>(&mut self, widget: &T) {
         unsafe {
             ffi::gtk_menu_shell_append(GTK_MENU_SHELL(self.get_widget()), widget.get_widget())
         }
     }
 
-    fn prepend(&mut self, widget: &gtk::WidgetTrait) {
+    fn prepend<T: gtk::WidgetTrait>(&mut self, widget: &T) {
         unsafe {
             ffi::gtk_menu_shell_prepend(GTK_MENU_SHELL(self.get_widget()), widget.get_widget())
         }
     }
 
-    fn insert(&mut self, widget: &gtk::WidgetTrait, position: i32) {
+    fn insert<T: gtk::WidgetTrait>(&mut self, widget: &T, position: i32) {
         unsafe {
             ffi::gtk_menu_shell_insert(GTK_MENU_SHELL(self.get_widget()),
                                        widget.get_widget(),
@@ -46,7 +46,7 @@ pub trait MenuShellTrait: gtk::WidgetTrait + gtk::ContainerTrait {
         }
     }
 
-    fn select_item(&mut self, menu_item: &gtk::MenuItemTrait) {
+    fn select_item<T: gtk::MenuItemTrait>(&mut self, menu_item: &T) {
         unsafe {
             ffi::gtk_menu_shell_select_item(GTK_MENU_SHELL(self.get_widget()),
                                             menu_item.get_widget())
@@ -59,7 +59,7 @@ pub trait MenuShellTrait: gtk::WidgetTrait + gtk::ContainerTrait {
         }
     }
 
-    fn activate_item(&mut self, menu_item: &gtk::MenuItemTrait, force_deactivate: bool) {
+    fn activate_item<T: gtk::MenuItemTrait>(&mut self, menu_item: &T, force_deactivate: bool) {
         unsafe {
             ffi::gtk_menu_shell_activate_item(GTK_MENU_SHELL(self.get_widget()),
                                               menu_item.get_widget(),

--- a/src/gtk/traits/widget.rs
+++ b/src/gtk/traits/widget.rs
@@ -73,7 +73,7 @@ pub trait WidgetTrait: ffi::FFIWidget + gtk::GObjectTrait {
         unsafe { to_bool(ffi::gtk_widget_activate(self.get_widget())) }
     }
 
-    fn reparent(&self, new_parent: &WidgetTrait) {
+    fn reparent<T: WidgetTrait>(&self, new_parent: &T) {
         unsafe { ffi::gtk_widget_reparent(self.get_widget(), new_parent.get_widget()) }
     }
 
@@ -111,7 +111,7 @@ pub trait WidgetTrait: ffi::FFIWidget + gtk::GObjectTrait {
         unsafe { ffi::gtk_widget_set_sensitive(self.get_widget(), to_gboolean(sensitive)) }
     }
 
-    fn set_parent(&self, parent: &WidgetTrait) {
+    fn set_parent<T: WidgetTrait>(&self, parent: &T) {
         unsafe { ffi::gtk_widget_set_parent(self.get_widget(), parent.get_widget()) }
     }
 
@@ -139,7 +139,7 @@ pub trait WidgetTrait: ffi::FFIWidget + gtk::GObjectTrait {
         }
     }
 
-    fn is_ancestor(&self, ancestor: &WidgetTrait) -> bool {
+    fn is_ancestor<T: WidgetTrait>(&self, ancestor: &T) -> bool {
         unsafe { to_bool(ffi::gtk_widget_is_ancestor(self.get_widget(), ancestor.get_widget())) }
     }
 
@@ -171,7 +171,7 @@ pub trait WidgetTrait: ffi::FFIWidget + gtk::GObjectTrait {
         unsafe { ffi::gtk_widget_unparent(self.get_widget()) }
     }
 
-    fn translate_coordinates(&self, dest_widget: &WidgetTrait, src_x: i32, src_y: i32) -> Option<(i32, i32)> {
+    fn translate_coordinates<T: WidgetTrait>(&self, dest_widget: &T, src_x: i32, src_y: i32) -> Option<(i32, i32)> {
         let mut dest_x = 0i32;
         let mut dest_y = 0i32;
 
@@ -292,11 +292,11 @@ pub trait WidgetTrait: ffi::FFIWidget + gtk::GObjectTrait {
         }
     }
 
-    fn add_mnemonic_label(&self, label: &WidgetTrait) {
+    fn add_mnemonic_label<T: WidgetTrait>(&self, label: &T) {
         unsafe { ffi::gtk_widget_add_mnemonic_label(self.get_widget(), label.get_widget()) }
     }
 
-    fn remove_mnemonic_label(&self, label: &WidgetTrait) {
+    fn remove_mnemonic_label<T: WidgetTrait>(&self, label: &T) {
         unsafe { ffi::gtk_widget_remove_mnemonic_label(self.get_widget(), label.get_widget()) }
     }
 

--- a/src/gtk/widgets/icon_view.rs
+++ b/src/gtk/widgets/icon_view.rs
@@ -84,7 +84,7 @@ impl IconView {
         }
     }
 
-    pub fn get_item_at_pos(&self, x: i32, y: i32, path: &TreePath, cell: &gtk::CellRendererTrait) -> bool {
+    pub fn get_item_at_pos<T: gtk::CellRendererTrait>(&self, x: i32, y: i32, path: &TreePath, cell: &T) -> bool {
         match unsafe { ffi::gtk_icon_view_get_item_at_pos(GTK_ICON_VIEW(self.pointer), x, y, &mut path.get_pointer(),
             &mut GTK_CELL_RENDERER(cell.get_widget())) } {
             0 => false,
@@ -96,7 +96,7 @@ impl IconView {
         unsafe { ffi::gtk_icon_view_convert_widget_to_bin_window_coords(GTK_ICON_VIEW(self.pointer), wx, wy, bx, by) }
     }
 
-    pub fn set_cursor(&self, path: &TreePath, cell: &gtk::CellRendererTrait, start_edition: bool) {
+    pub fn set_cursor<T: gtk::CellRendererTrait>(&self, path: &TreePath, cell: &T, start_edition: bool) {
         unsafe { ffi::gtk_icon_view_set_cursor(GTK_ICON_VIEW(self.pointer), path.get_pointer(), GTK_CELL_RENDERER(cell.get_widget()),
             match start_edition {
                 true => 1,
@@ -104,7 +104,7 @@ impl IconView {
             }) }
     }
 
-    pub fn get_cursor(&self, path: &TreePath, cell: &gtk::CellRendererTrait) -> bool {
+    pub fn get_cursor<T: gtk::CellRendererTrait>(&self, path: &TreePath, cell: &T) -> bool {
         match unsafe { ffi::gtk_icon_view_get_cursor(GTK_ICON_VIEW(self.pointer), &mut path.get_pointer(),
             &mut GTK_CELL_RENDERER(cell.get_widget())) } {
             0 => false,

--- a/src/gtk/widgets/tree_view_column.rs
+++ b/src/gtk/widgets/tree_view_column.rs
@@ -181,7 +181,7 @@ impl TreeViewColumn {
         }
     }
 
-    pub fn set_widget(&mut self, widget: &gtk::WidgetTrait) {
+    pub fn set_widget<T: gtk::WidgetTrait>(&mut self, widget: &T) {
         unsafe {
             ffi::gtk_tree_view_column_set_widget(self.pointer, widget.get_widget())
         }


### PR DESCRIPTION
This fixes the fresh build errors regarding core::marker::Sized not being implemented. It seems that using generic syntax resolves them.