### PR TITLE
Fix more build errors

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -48,7 +48,7 @@ fn main() {
     // build include path
     let mut gcc_conf = Config::new();
     for path in paths {
-        gcc_conf.include(path);
+        gcc_conf.include(&path);
     }
     gcc_conf.file("./gtk_glue/gtk_glue.c");
 

--- a/src/cairo/paths.rs
+++ b/src/cairo/paths.rs
@@ -75,7 +75,7 @@ pub enum PathSegment {
 }
 
 pub struct PathSegments<'a> {
-    data: CVec<(f64, f64)>,
+    data: CVec<'a, (f64, f64)>,
     i: usize,
     num_data: usize
 }

--- a/src/glib/traits.rs
+++ b/src/glib/traits.rs
@@ -16,6 +16,7 @@
 use glib::ffi;
 use gtk::signals::Signal;
 use std::ffi::CString;
+use std::marker::PhantomFn;
 
 pub trait FFIGObject {
     fn get_gobject(&self) -> *mut ffi::C_GObject;
@@ -44,7 +45,7 @@ pub trait FFIGObject {
 //     }
 // }
 
-pub trait Connect<'a, T: Signal<'a>>: FFIGObject {
+pub trait Connect<'a, T: Signal<'a>>: FFIGObject + PhantomFn<&'a T> {
     fn connect(&self, signal: Box<T>) -> () {
         use std::mem::transmute;
 


### PR DESCRIPTION
This should fix the latest round of breakage from alpha 2. I used PhantomData and PhantonFn to fix the errors related to unused types and lifetimes. If you prefer fixing them another way, feel free to close this. You will need to build with [my fork of c_vec-rs](https://github.com/oakes/c_vec-rs) because that was broken as well. @GuillaumeGomez please let me know if you'd like a PR for that as well.