### PR TITLE
Make a wrapper for cairo_rectangle_list_t

### DIFF
--- a/src/cairo/ffi.rs
+++ b/src/cairo/ffi.rs
@@ -79,7 +79,6 @@ pub struct cairo_rectangle_list_t {
     pub rectangles: *mut Rectangle,
     pub num_rectangles: c_int
 }
-unsafe impl Send for *mut cairo_rectangle_list_t {}
 #[repr(C)]
 #[derive(Copy)]
 pub struct cairo_rectangle_int_t;

--- a/src/cairo/mod.rs
+++ b/src/cairo/mod.rs
@@ -21,7 +21,8 @@ extern crate c_vec;
 
 pub use self::context::{
     Context,
-    Rectangle
+    Rectangle,
+    RectangleVec,
 };
 
 pub use self::paths::{


### PR DESCRIPTION
Add `RectangleVec` and return it from `cairo::Context::copy_clip_rectangle_list`.
This avoids using `CVec::new_with_dtor` and dealing with `Send`.

I understand the deal with `c_vec` better now and have an idea for a more flexible version but this should do for now.