### PR TITLE
Added gdk_keyval_name function

### DIFF
--- a/gdk3-sys/src/lib.rs
+++ b/gdk3-sys/src/lib.rs
@@ -625,4 +625,9 @@ extern "C" {
     pub fn gdk_app_launch_context_set_timestamp    (context: *mut C_GdkAppLaunchContext, timestamp: u32);
     //pub fn gdk_app_launch_context_set_icon         (context: *mut C_GdkAppLaunchContext, icon: *mut C_GIcon);
     pub fn gdk_app_launch_context_set_icon_name    (context: *mut C_GdkAppLaunchContext, icon_name: *const c_char);
+
+    //=========================================================================
+    // Gdk Key Handling                                                  NOT OK
+    //=========================================================================
+    pub fn gdk_keyval_name                         (keyval:c_uint) -> *mut c_char;
 }

--- a/src/gdk/keys.rs
+++ b/src/gdk/keys.rs
@@ -1,0 +1,35 @@
+// This file is part of rgtk.
+//
+// rgtk is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// rgtk is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Keyboard Handling Functions
+
+use std::ptr;
+use gdk::ffi;
+use std::ffi::CString;
+use libc::{c_uint, c_void, c_char};
+
+pub fn keyval_name(keyval: u32) -> Option<String> {
+    let tmp = unsafe { ffi::gdk_keyval_name(keyval as c_uint) as *const c_char };
+
+    if tmp.is_null() {
+        None
+    } else {
+        unsafe {
+            let ret = Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp)).to_string());
+
+            ret
+        }
+    }
+}

--- a/src/gdk/keys.rs
+++ b/src/gdk/keys.rs
@@ -17,7 +17,7 @@
 
 use std::ptr;
 use gdk::ffi;
-use std::ffi::CString;
+use std::ffi::CStr;
 use libc::{c_uint, c_void, c_char};
 
 pub fn keyval_name(keyval: u32) -> Option<String> {
@@ -27,9 +27,7 @@ pub fn keyval_name(keyval: u32) -> Option<String> {
         None
     } else {
         unsafe {
-            let ret = Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp)).to_string());
-
-            ret
+            return Some(String::from_utf8_lossy(CStr::from_ptr(tmp).to_bytes()).into_owned());
         }
     }
 }

--- a/src/gdk/mod.rs
+++ b/src/gdk/mod.rs
@@ -126,7 +126,12 @@ pub use self::widgets::{
     AppLaunchContext
 };
 
+pub use self::keys::{
+    keyval_name
+};
+
 mod events;
 mod rt;
+mod keys;
 pub mod widgets;
 


### PR DESCRIPTION
I implemented the keyval_name function, solving issue #203. I tested it and it works. But could someone have a look and see if the fix looks okay.

For instance I am unsure about line 32 in keys.rs. I had to comment that out since my program would crash otherwise. Similar gdk functions that return the same type (like [gdk_screen_get_monitor_plug_name](https://github.com/jeremyletang/rgtk/blob/master/src/gdk/widgets/screen.rs#L151)) however suggest that it should be there.

The other thing I'm uncertain about is whether the return type of this
```
pub fn gdk_keyval_name (keyval:c_uint) -> *mut c_char;
```

should be immutable as [this](https://developer.gnome.org/gdk3/stable/gdk3-Keyboard-Handling.html#gdk-keyval-name) says "The [returned] String should not be modified".