### PR TITLE
Improve naming consistency

### DIFF
--- a/glib/src/traits.rs
+++ b/glib/src/traits.rs
@@ -19,7 +19,7 @@ use ffi;
 use std::any::Any;
 
 pub trait FFIGObject {
-    fn get_gobject(&self) -> *mut ffi::C_GObject;
+    fn unwrap_gobject(&self) -> *mut ffi::C_GObject;
     fn wrap_object(object: *mut ffi::C_GObject) -> Self;
 }
 
@@ -35,7 +35,7 @@ pub trait FFIGObject {
 
 //             signal_name.replace("_", "-").with_c_str(|signal_name| {
 //                 ffi::glue_signal_connect(
-//                     self.get_gobject(),
+//                     self.unwrap_gobject(),
 //                     signal_name,
 //                     Some(trampoline),
 //                     user_data_ptr
@@ -70,7 +70,7 @@ pub trait Connect<'a, T: Signal<'a>>: FFIGObject + PhantomFn<&'a T> {
             let c_str = CString::from_slice(signal_name.replace("_", "-").as_bytes());
             
             ffi::glue_signal_connect(
-                self.get_gobject(),
+                self.unwrap_gobject(),
                 c_str.as_ptr(),
                 Some(trampoline),
                 user_data_ptr

--- a/src/gdk/widgets/app_launch_context.rs
+++ b/src/gdk/widgets/app_launch_context.rs
@@ -28,7 +28,7 @@ pub struct AppLaunchContext {
 
 impl AppLaunchContext {
     pub fn set_screen(&self, screen: &gdk::Screen) {
-        unsafe { ffi::gdk_app_launch_context_set_screen(self.pointer, screen.get_pointer()) }
+        unsafe { ffi::gdk_app_launch_context_set_screen(self.pointer, screen.unwrap_pointer()) }
     }
 
     pub fn set_desktop(&self, desktop: i32) {
@@ -40,7 +40,7 @@ impl AppLaunchContext {
     }
 
     /*pub fn set_icon(&self, icon: GIO::Icon) {
-        unsafe { ffi::gdk_app_launch_context_set_timestamp(self.pointer, icon.get_pointer()) }
+        unsafe { ffi::gdk_app_launch_context_set_timestamp(self.pointer, icon.unwrap_pointer()) }
     }*/
 
     pub fn set_icon_name(&self, icon_name: &str) {

--- a/src/gdk/widgets/atom.rs
+++ b/src/gdk/widgets/atom.rs
@@ -84,7 +84,7 @@ impl Atom {
         }
     }
 
-    pub fn get_pointer(&self) -> ffi::C_GdkAtom {
+    pub fn unwrap_pointer(&self) -> ffi::C_GdkAtom {
         self.pointer
     }
 }

--- a/src/gdk/widgets/cursor.rs
+++ b/src/gdk/widgets/cursor.rs
@@ -39,7 +39,7 @@ impl Cursor {
     }
 
     /*pub fn new_from_pixbuf(display: &gdk::Display, pixbuf: &gdk::Pixbuf, x: i32, y: i32) -> Option<Cursor> {
-        let tmp = unsafe { ffi::gdk_cursor_new_from_pixbuf(display.get_pointer(), pixbuf.get_pointer(), x as c_int, y as c_int) };
+        let tmp = unsafe { ffi::gdk_cursor_new_from_pixbuf(display.unwrap_pointer(), pixbuf.unwrap_pointer(), x as c_int, y as c_int) };
 
         if tmp.is_null() {
             None
@@ -54,7 +54,7 @@ impl Cursor {
         let tmp = unsafe {
             let c_str = CString::from_slice(name.as_bytes());
 
-            ffi::gdk_cursor_new_from_name(display.get_pointer(), c_str.as_ptr())
+            ffi::gdk_cursor_new_from_name(display.unwrap_pointer(), c_str.as_ptr())
         };
 
         if tmp.is_null() {
@@ -67,7 +67,7 @@ impl Cursor {
     }
 
     pub fn new_for_display(display: &gdk::Display, cursor_type: gdk::CursorType) -> Option<Cursor> {
-        let tmp = unsafe { ffi::gdk_cursor_new_for_display(display.get_pointer(), cursor_type) };
+        let tmp = unsafe { ffi::gdk_cursor_new_for_display(display.unwrap_pointer(), cursor_type) };
 
         if tmp.is_null() {
             None

--- a/src/gdk/widgets/device.rs
+++ b/src/gdk/widgets/device.rs
@@ -103,14 +103,14 @@ impl Device {
     }
 
     /*pub fn warp(&self, screen: &gdk::Screen, x: i32, y: i32) {
-        unsafe { ffi::gdk_device_warp(self.pointer, screen.get_pointer(), x as c_int, y as c_int) }
+        unsafe { ffi::gdk_device_warp(self.pointer, screen.unwrap_pointer(), x as c_int, y as c_int) }
     }
 
     pub fn grab(&self, window: &gdk::Window, grab_ownership: gdk::GrabOwnership, owner_events: bool, event_mask: gdk::EventMask,
         cursor: &mut gdk::Cursor, time_: u32) -> gdk::GrabStatus {
         unsafe {
-            ffi::gdk_device_grab(self.pointer, window.get_pointer(), grab_ownership, to_gboolean(owner_events),
-                event_mask, cursor.get_pointer(), time_)
+            ffi::gdk_device_grab(self.pointer, window.unwrap_pointer(), grab_ownership, to_gboolean(owner_events),
+                event_mask, cursor.unwrap_pointer(), time_)
         }
     }*/
 
@@ -119,7 +119,7 @@ impl Device {
     }
 
     /*pub fn get_state(&self, window: &gdk::Window, axes: &mut [f64], mask: &mut gdk;:ModifierType) {
-        unsafe { ffi::gdk_device_get_state(self.pointer, window.get_pointer(), axes.as_mut_ptr(), mask) }
+        unsafe { ffi::gdk_device_get_state(self.pointer, window.unwrap_pointer(), axes.as_mut_ptr(), mask) }
     }
 
     pub fn get_position(&self, x: &mut i32, y: &mut i32) -> Option<gdk::Screen> {
@@ -170,7 +170,7 @@ impl Device {
         let mut ptr = ::std::ptr::null_mut();
         let mut n_events : c_int = 0;
 
-        unsafe { ffi::gdk_device_get_history(self.pointer, window.get_pointer(), start, stop, &mut ptr, &mut n_events) };
+        unsafe { ffi::gdk_device_get_history(self.pointer, window.unwrap_pointer(), start, stop, &mut ptr, &mut n_events) };
         
         let mut ret = Vec::with_capacity(n_events as uint);
         
@@ -184,7 +184,7 @@ impl Device {
         let mut tmp = Vec::with_capacity(events.len());
 
         for i in range(0, events.len()) {
-            tmp.push(events[i].get_pointer());
+            tmp.push(events[i].unwrap_pointer());
         }
         unsafe { ffi::gdk_device_free_history(events.as_mut_ptr(), events.len()) }
     }*/
@@ -194,7 +194,7 @@ impl Device {
     }
 
     /*pub fn get_axis_value(&self, axes: &mut [f64], label: &mut gdk::Atom, value: &mut f64) -> bool {
-        unsafe { to_bool(ffi::gdk_device_get_axis_value(self.pointer, axes.as_mut_ptr(), label.get_pointer(), value)) }
+        unsafe { to_bool(ffi::gdk_device_get_axis_value(self.pointer, axes.as_mut_ptr(), label.unwrap_pointer(), value)) }
     }*/
 
     /*pub fn get_last_event_window(&self) -> Option<gdk::Window> {

--- a/src/gdk/widgets/display.rs
+++ b/src/gdk/widgets/display.rs
@@ -96,7 +96,7 @@ impl Display {
     }*/
 
     pub fn device_is_grabbed(&self, device: &gdk::Device) -> bool {
-        unsafe { to_bool(ffi::gdk_display_device_is_grabbed(self.pointer, device.get_pointer())) }
+        unsafe { to_bool(ffi::gdk_display_device_is_grabbed(self.pointer, device.unwrap_pointer())) }
     }
 
     pub fn beep(&self) {
@@ -140,7 +140,7 @@ impl Display {
     }
 
     pub fn put_event(&self, event: &gdk::Event) {
-        unsafe { ffi::gdk_display_put_event(self.pointer, event.get_pointer() as *const ffi::C_GdkEvent) }
+        unsafe { ffi::gdk_display_put_event(self.pointer, event.unwrap_pointer() as *const ffi::C_GdkEvent) }
     }*/
 
     pub fn has_pending(&self) -> bool {
@@ -186,7 +186,7 @@ impl Display {
     }
 
     /*pub fn request_selection_notification(&self, selection: &gdk::Atom) -> bool {
-        unsafe { to_bool(ffi::gdk_display_request_selection_notification(self.pointer, selection.get_pointer())) }
+        unsafe { to_bool(ffi::gdk_display_request_selection_notification(self.pointer, selection.unwrap_pointer())) }
     }*/
 
     pub fn supports_clipboard_persistence(&self) -> bool {
@@ -194,7 +194,7 @@ impl Display {
     }
 
     /*pub fn store_clipboard(&self, clipboard_window: &gdk::Window, time_: u32, targets: Vec<gdk::Atom>) {
-        unsafe { ffi::gdk_display_store_clipboard(self.pointer, clipboard_window.get_pointer(), time_, targets.as_mut_pointer(),
+        unsafe { ffi::gdk_display_store_clipboard(self.pointer, clipboard_window.unwrap_pointer(), time_, targets.as_mut_pointer(),
             targets.len() as c_int) }
     }*/
 

--- a/src/gdk/widgets/display_manager.rs
+++ b/src/gdk/widgets/display_manager.rs
@@ -48,7 +48,7 @@ impl DisplayManager {
     }
 
     pub fn set_default_display(&self, display: &gdk::Display) {
-        unsafe { ffi::gdk_display_manager_set_default_display(self.pointer, display.get_pointer()) }
+        unsafe { ffi::gdk_display_manager_set_default_display(self.pointer, display.unwrap_pointer()) }
     }
 
     pub fn open_display(&self, name: &str) -> Option<gdk::Display> {

--- a/src/gdk/widgets/drag_context.rs
+++ b/src/gdk/widgets/drag_context.rs
@@ -50,13 +50,13 @@ impl DragContext {
 
     pub fn drag_find_window_for_screen(&self, drag_window: &gdk::Window, screen: &gdk::Screen, x_root: i32, y_root: i32,
         dest_window: &mut gdk::Window, protocol: &mut gdk::DragProtocol) {
-        unsafe { ffi::gdk_drag_find_window_for_screen(self.pointer, drag_window.get_pointer(), screen.get_pointer(), x_root as c_int,
-            y_root as c_int, &mut dest_window.get_pointer(), protocol) }
+        unsafe { ffi::gdk_drag_find_window_for_screen(self.pointer, drag_window.unwrap_pointer(), screen.unwrap_pointer(), x_root as c_int,
+            y_root as c_int, &mut dest_window.unwrap_pointer(), protocol) }
     }
 
     pub fn drag_motion(&self, dest_window: &gdk::Window, protocol: gdk::DragProtocol, x_root: i32, y_root: i32,
         suggested_action: gdk::DragAction, possible_actions: gdk::DragAction, time_: u32) -> bool {
-        unsafe { to_bool(ffi::gdk_drag_motion(self.pointer, dest_window.get_pointer(), protocol, x_root as c_int,
+        unsafe { to_bool(ffi::gdk_drag_motion(self.pointer, dest_window.unwrap_pointer(), protocol, x_root as c_int,
             y_root as c_int, suggested_action, possible_actions, time_)) }
     }
 
@@ -95,7 +95,7 @@ impl DragContext {
     }
 
     pub fn set_device(&self, device: &gdk::Device) {
-        unsafe { ffi::gdk_drag_context_set_device(self.pointer, device.get_pointer()) }
+        unsafe { ffi::gdk_drag_context_set_device(self.pointer, device.unwrap_pointer()) }
     }
 
     pub fn get_source_window(&self) -> Option<gdk::Window> {

--- a/src/gdk/widgets/screen.rs
+++ b/src/gdk/widgets/screen.rs
@@ -137,7 +137,7 @@ impl Screen {
     }
 
     pub fn get_monitor_at_window(&self, window: &mut gdk::Window) -> i32 {
-        unsafe { ffi::gdk_screen_get_monitor_at_window(self.pointer, window.get_pointer()) }
+        unsafe { ffi::gdk_screen_get_monitor_at_window(self.pointer, window.unwrap_pointer()) }
     }
 
     pub fn get_monitor_width_mm(&self, monitor_num: i32) -> i32 {

--- a/src/gdk/widgets/window.rs
+++ b/src/gdk/widgets/window.rs
@@ -67,9 +67,9 @@ impl WindowAttr {
             width: self.width,
             height: self.height,
             wclass: self.wclass,
-            visual: self.visual.get_pointer(),
+            visual: self.visual.unwrap_pointer(),
             window_type: self.window_type,
-            cursor: self.cursor.get_pointer(),
+            cursor: self.cursor.unwrap_pointer(),
             wmclass_name: c_wmclass_name.as_ptr() as *mut c_char,
             wmclass_class: c_wmclass_class.as_ptr() as *mut c_char,
             override_redirect: to_gboolean(self.override_redirect),
@@ -86,7 +86,7 @@ pub struct Window {
 impl Window {
     pub fn new(parent: Option<&Window>, attributes: &gdk::WindowAttr, attributes_mask: i32) -> Option<Window> {
         let t_parent = match parent {
-            Some(s) => s.get_pointer(),
+            Some(s) => s.unwrap_pointer(),
             None => ::std::ptr::null_mut()
         };
         let mut c_attributes = attributes.to_c_type();
@@ -289,7 +289,7 @@ impl Window {
 
     pub fn begin_resize_drag_for_device(&self, edge: gdk::WindowEdge, device: &gdk::Device, button: i32, root_x: i32, root_y: i32,
         timestamp: u32) {
-        unsafe { ffi::gdk_window_begin_resize_drag_for_device(self.pointer, edge, device.get_pointer(), button as c_int,
+        unsafe { ffi::gdk_window_begin_resize_drag_for_device(self.pointer, edge, device.unwrap_pointer(), button as c_int,
             root_x as c_int, root_y as c_int, timestamp) }
     }
 
@@ -298,7 +298,7 @@ impl Window {
     }
 
     pub fn begin_move_drag_for_device(&self, device: &gdk::Device, button: i32, root_x: i32, root_y: i32, timestamp: u32) {
-        unsafe { ffi::gdk_window_begin_move_drag_for_device(self.pointer, device.get_pointer(), button as c_int, root_x as c_int,
+        unsafe { ffi::gdk_window_begin_move_drag_for_device(self.pointer, device.unwrap_pointer(), button as c_int, root_x as c_int,
             root_y as c_int, timestamp) }
     }
 
@@ -307,7 +307,7 @@ impl Window {
 
     // Since 3.14
     pub fn show_window_menu(&self, event: &gdk::Event) {
-        unsafe { ffi::gdk_window_show_window_menu(self.pointer, event.get_pointer()) }
+        unsafe { ffi::gdk_window_show_window_menu(self.pointer, event.unwrap_pointer()) }
     }*/
 
     pub fn constrain_size(&self, flags: gdk::WindowHints, width: i32, height: i32, new_width: &mut i32, new_height: &mut i32) {
@@ -423,7 +423,7 @@ impl Window {
     }
 
     pub fn set_cursor(&self, cursor: &gdk::Cursor) {
-        unsafe { ffi::gdk_window_set_cursor(self.pointer, cursor.get_pointer()) }
+        unsafe { ffi::gdk_window_set_cursor(self.pointer, cursor.unwrap_pointer()) }
     }
 
     pub fn get_cursor(&self) -> Option<gdk::Cursor> {
@@ -517,7 +517,7 @@ impl Window {
 
     pub fn get_device_position(&self, device: &gdk::Device, x: &mut i32, y: &mut i32,
         mask: &mut gdk::ModifierType) -> Option<Window> {
-        let tmp = unsafe { ffi::gdk_window_get_device_position(self.pointer, device.get_pointer(), x as *mut c_int, y as *mut c_int,
+        let tmp = unsafe { ffi::gdk_window_get_device_position(self.pointer, device.unwrap_pointer(), x as *mut c_int, y as *mut c_int,
             mask) };
 
         if tmp.is_null() {
@@ -531,7 +531,7 @@ impl Window {
 
     pub fn get_device_position_double(&self, device: &gdk::Device, x: &mut f64, y: &mut f64,
         mask: &mut gdk::ModifierType) -> Option<Window> {
-        let tmp = unsafe { ffi::gdk_window_get_device_position_double(self.pointer, device.get_pointer(), x, y, mask) };
+        let tmp = unsafe { ffi::gdk_window_get_device_position_double(self.pointer, device.unwrap_pointer(), x, y, mask) };
 
         if tmp.is_null() {
             None
@@ -651,7 +651,7 @@ impl Window {
     }
 
     pub fn get_device_cursor(&self, device: &gdk::Device) -> Option<gdk::Cursor> {
-        let tmp = unsafe { ffi::gdk_window_get_device_cursor(self.pointer, device.get_pointer()) };
+        let tmp = unsafe { ffi::gdk_window_get_device_cursor(self.pointer, device.unwrap_pointer()) };
 
         if tmp.is_null() {
             None
@@ -661,15 +661,15 @@ impl Window {
     }
 
     pub fn set_device_cursor(&self, device: &gdk::Device, cursor: &gdk::Cursor) {
-        unsafe { ffi::gdk_window_set_device_cursor(self.pointer, device.get_pointer(), cursor.get_pointer()) }
+        unsafe { ffi::gdk_window_set_device_cursor(self.pointer, device.unwrap_pointer(), cursor.unwrap_pointer()) }
     }
 
     pub fn get_device_events(&self, device: &gdk::Device) -> gdk::EventMask {
-        unsafe { ffi::gdk_window_get_device_events(self.pointer, device.get_pointer()) }
+        unsafe { ffi::gdk_window_get_device_events(self.pointer, device.unwrap_pointer()) }
     }
 
     pub fn set_device_events(&self, device: &gdk::Device, event_mask: gdk::EventMask) {
-        unsafe { ffi::gdk_window_set_device_events(self.pointer, device.get_pointer(), event_mask) }
+        unsafe { ffi::gdk_window_set_device_events(self.pointer, device.unwrap_pointer(), event_mask) }
     }
 
     pub fn get_source_events(&self, source: gdk::InputSource) -> gdk::EventMask {

--- a/src/gtk/macros.rs
+++ b/src/gtk/macros.rs
@@ -43,7 +43,7 @@ macro_rules! struct_Widget(
 macro_rules! impl_TraitObject(
     ($gtk_struct:ident, $ffi_type:ident) => (
         impl ::glib::traits::FFIGObject for $gtk_struct {
-            fn get_gobject(&self) -> *mut ::glib::ffi::C_GObject {
+            fn unwrap_gobject(&self) -> *mut ::glib::ffi::C_GObject {
                 self.pointer as *mut ::glib::ffi::C_GObject
             }
 
@@ -65,11 +65,11 @@ macro_rules! impl_TraitObject(
 macro_rules! impl_TraitWidget(
     ($gtk_struct:ident) => (
         impl ::gtk::FFIWidget for $gtk_struct {
-            fn get_widget(&self) -> *mut ffi::C_GtkWidget {
+            fn unwrap_widget(&self) -> *mut ffi::C_GtkWidget {
                 self.pointer
             }
 
-            fn wrap(widget: *mut ffi::C_GtkWidget) -> $gtk_struct {
+            fn wrap_widget(widget: *mut ffi::C_GtkWidget) -> $gtk_struct {
                 unsafe{
                     ::glib::ffi::g_object_ref(::gtk::ffi::cast_GtkObject(widget));
                 }
@@ -83,9 +83,9 @@ macro_rules! impl_TraitWidget(
         impl ::gtk::WidgetTrait for $gtk_struct {}
 
         impl ::glib::traits::FFIGObject for $gtk_struct {
-            fn get_gobject(&self) -> *mut ::glib::ffi::C_GObject {
+            fn unwrap_gobject(&self) -> *mut ::glib::ffi::C_GObject {
                 use gtk::FFIWidget;
-                ::gtk::cast::G_OBJECT(self.get_widget())
+                ::gtk::cast::G_OBJECT(self.unwrap_widget())
             }
 
             fn wrap_object(object: *mut ::glib::ffi::C_GObject) -> $gtk_struct {
@@ -122,7 +122,7 @@ macro_rules! impl_connect(
 macro_rules! impl_GObjectFunctions(
     ($gtk_struct:ident, $ffi_type:ident) => (
         impl $gtk_struct {
-            pub fn get_pointer(&self) -> *mut ffi::$ffi_type {
+            pub fn unwrap_pointer(&self) -> *mut ffi::$ffi_type {
                 self.pointer
             }
 
@@ -162,10 +162,10 @@ macro_rules! impl_drop(
 
 // Useful for function wich take a valid widget or NULL for a default widget
 // takes an option<&trait::Widget> and return the c widget pointer or ptr::null()
-macro_rules! get_widget(
+macro_rules! unwrap_widget(
     ($w:ident) => (
         match $w {
-            Some(ref _w) => _w.get_widget(),
+            Some(ref _w) => _w.unwrap_widget(),
             None => ::std::ptr::null_mut()
         };
     );

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -49,8 +49,8 @@ pub use gtk_ffi as ffi;
 pub use gtk_ffi::enums;
 
 pub trait FFIWidget: Sized {
-    fn get_widget(&self) -> *mut ffi::C_GtkWidget;
-    fn wrap(widget: *mut ffi::C_GtkWidget) -> Self;
+    fn unwrap_widget(&self) -> *mut ffi::C_GtkWidget;
+    fn wrap_widget(widget: *mut ffi::C_GtkWidget) -> Self;
 }
 
 // These are/should be inlined

--- a/src/gtk/traits/_box.rs
+++ b/src/gtk/traits/_box.rs
@@ -23,7 +23,7 @@ use glib::{to_bool, to_gboolean};
 pub trait BoxTrait: gtk::WidgetTrait {
     fn pack_start<'r, T: gtk::WidgetTrait>(&'r mut self, child: &'r T, expand: bool, fill: bool, padding: u32) -> () {
         unsafe {
-            ffi::gtk_box_pack_start(GTK_BOX(self.get_widget()), child.get_widget(),
+            ffi::gtk_box_pack_start(GTK_BOX(self.unwrap_widget()), child.unwrap_widget(),
                                     to_gboolean(expand), to_gboolean(fill),
                                     padding as c_uint);
         }
@@ -31,35 +31,35 @@ pub trait BoxTrait: gtk::WidgetTrait {
 
     fn pack_end<'r, T: gtk::WidgetTrait>(&'r mut self, child: &'r T, expand: bool, fill: bool, padding: u32) -> () {
         unsafe {
-            ffi::gtk_box_pack_end(GTK_BOX(self.get_widget()), child.get_widget(),
+            ffi::gtk_box_pack_end(GTK_BOX(self.unwrap_widget()), child.unwrap_widget(),
                                   to_gboolean(expand), to_gboolean(fill),
                                   padding as c_uint);
         }
     }
 
     fn get_homogeneous(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_box_get_homogeneous(GTK_BOX(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_box_get_homogeneous(GTK_BOX(self.unwrap_widget()))) }
     }
 
     fn set_homogeneouse(&mut self, homogeneous: bool) -> () {
-        unsafe { ffi::gtk_box_set_homogeneous(GTK_BOX(self.get_widget()), to_gboolean(homogeneous)); }
+        unsafe { ffi::gtk_box_set_homogeneous(GTK_BOX(self.unwrap_widget()), to_gboolean(homogeneous)); }
     }
 
     fn get_spacing(&self) -> i32 {
         unsafe {
-            ffi::gtk_box_get_spacing(GTK_BOX(self.get_widget())) as i32
+            ffi::gtk_box_get_spacing(GTK_BOX(self.unwrap_widget())) as i32
         }
     }
 
     fn set_spacing(&mut self, spacing: i32) -> () {
         unsafe {
-            ffi::gtk_box_set_spacing(GTK_BOX(self.get_widget()), spacing as c_int);
+            ffi::gtk_box_set_spacing(GTK_BOX(self.unwrap_widget()), spacing as c_int);
         }
     }
 
     fn reorder_child<'r, T: gtk::WidgetTrait>(&'r mut self, child: &'r T, position: i32) -> () {
         unsafe {
-            ffi::gtk_box_reorder_child(GTK_BOX(self.get_widget()), child.get_widget(), position as c_int);
+            ffi::gtk_box_reorder_child(GTK_BOX(self.unwrap_widget()), child.unwrap_widget(), position as c_int);
         }
     }
 
@@ -69,8 +69,8 @@ pub trait BoxTrait: gtk::WidgetTrait {
         let mut c_fill = 0;
         let mut pack_type: PackType = PackType::Start;
         unsafe {
-            ffi::gtk_box_query_child_packing(GTK_BOX(self.get_widget()),
-                                             child.get_widget(),
+            ffi::gtk_box_query_child_packing(GTK_BOX(self.unwrap_widget()),
+                                             child.unwrap_widget(),
                                              &mut c_expand,
                                              &mut c_fill,
                                              &mut c_padding,
@@ -86,8 +86,8 @@ pub trait BoxTrait: gtk::WidgetTrait {
                                                   padding: u32,
                                                   pack_type: PackType) {
         unsafe {
-            ffi::gtk_box_set_child_packing(GTK_BOX(self.get_widget()),
-                                           child.get_widget(),
+            ffi::gtk_box_set_child_packing(GTK_BOX(self.unwrap_widget()),
+                                           child.unwrap_widget(),
                                            to_gboolean(expand),
                                            to_gboolean(fill),
                                            padding as c_uint,

--- a/src/gtk/traits/actionable.rs
+++ b/src/gtk/traits/actionable.rs
@@ -22,7 +22,7 @@ use gtk::{self, ffi};
 pub trait ActionableTrait: gtk::WidgetTrait {
     fn get_action_name(&self) -> Option<String> {
         unsafe {
-            let tmp_pointer = ffi::gtk_actionable_get_action_name(GTK_ACTIONABLE(self.get_widget()));
+            let tmp_pointer = ffi::gtk_actionable_get_action_name(GTK_ACTIONABLE(self.unwrap_widget()));
 
             if tmp_pointer.is_null() {
                 None
@@ -36,7 +36,7 @@ pub trait ActionableTrait: gtk::WidgetTrait {
         unsafe {
             let c_str = CString::from_slice(action_name.as_bytes());
 
-            ffi::gtk_actionable_set_action_name(GTK_ACTIONABLE(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_actionable_set_action_name(GTK_ACTIONABLE(self.unwrap_widget()), c_str.as_ptr())
         }
     }
 
@@ -44,7 +44,7 @@ pub trait ActionableTrait: gtk::WidgetTrait {
         unsafe {
             let c_str = CString::from_slice(detailed_action_name.as_bytes());
 
-            ffi::gtk_actionable_set_detailed_action_name(GTK_ACTIONABLE(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_actionable_set_detailed_action_name(GTK_ACTIONABLE(self.unwrap_widget()), c_str.as_ptr())
         }
     }
 }

--- a/src/gtk/traits/app_chooser.rs
+++ b/src/gtk/traits/app_chooser.rs
@@ -18,17 +18,17 @@ use gtk::cast::GTK_APP_CHOOSER;
 
 pub trait AppChooserTrait: gtk::WidgetTrait {
     fn get_app_info(&self) -> Option<gtk::AppInfo> {
-        let tmp_pointer = unsafe { ffi::gtk_app_chooser_get_app_info(GTK_APP_CHOOSER(self.get_widget())) };
+        let tmp_pointer = unsafe { ffi::gtk_app_chooser_get_app_info(GTK_APP_CHOOSER(self.unwrap_widget())) };
 
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer as *mut ffi::C_GtkWidget))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer as *mut ffi::C_GtkWidget))
         }
     }
 
     fn get_content_info(&self) -> Option<String> {
-        let tmp_pointer = unsafe { ffi::gtk_app_chooser_get_content_type(GTK_APP_CHOOSER(self.get_widget())) };
+        let tmp_pointer = unsafe { ffi::gtk_app_chooser_get_content_type(GTK_APP_CHOOSER(self.unwrap_widget())) };
 
         if tmp_pointer.is_null() {
             None
@@ -38,6 +38,6 @@ pub trait AppChooserTrait: gtk::WidgetTrait {
     }
 
     fn refresh(&self) -> () {
-        unsafe { ffi::gtk_app_chooser_refresh(GTK_APP_CHOOSER(self.get_widget())) }
+        unsafe { ffi::gtk_app_chooser_refresh(GTK_APP_CHOOSER(self.unwrap_widget())) }
     }
 }

--- a/src/gtk/traits/bin.rs
+++ b/src/gtk/traits/bin.rs
@@ -19,12 +19,12 @@ use gtk::{self, ffi};
 pub trait BinTrait: gtk::WidgetTrait + gtk::ContainerTrait {
     fn get_child<T: gtk::WidgetTrait>(&self) ->  Option<T> {
         let tmp_pointer = unsafe {
-            ffi::gtk_bin_get_child(GTK_BIN(self.get_widget()))
+            ffi::gtk_bin_get_child(GTK_BIN(self.unwrap_widget()))
         };
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 }

--- a/src/gtk/traits/button.rs
+++ b/src/gtk/traits/button.rs
@@ -25,49 +25,49 @@ use glib::{to_bool, to_gboolean};
 pub trait ButtonTrait: gtk::WidgetTrait + gtk::ContainerTrait {
     fn pressed(&self) -> () {
         unsafe {
-            ffi::gtk_button_pressed(GTK_BUTTON(self.get_widget()));
+            ffi::gtk_button_pressed(GTK_BUTTON(self.unwrap_widget()));
         }
     }
 
     fn released(&self) -> () {
         unsafe {
-            ffi::gtk_button_released(GTK_BUTTON(self.get_widget()));
+            ffi::gtk_button_released(GTK_BUTTON(self.unwrap_widget()));
         }
     }
 
     fn clicked(&self) -> () {
         unsafe {
-            ffi::gtk_button_clicked(GTK_BUTTON(self.get_widget()));
+            ffi::gtk_button_clicked(GTK_BUTTON(self.unwrap_widget()));
         }
     }
 
     fn enter(&self) -> () {
         unsafe {
-            ffi::gtk_button_enter(GTK_BUTTON(self.get_widget()));
+            ffi::gtk_button_enter(GTK_BUTTON(self.unwrap_widget()));
         }
     }
 
     fn leave(&self) -> () {
         unsafe {
-            ffi::gtk_button_leave(GTK_BUTTON(self.get_widget()));
+            ffi::gtk_button_leave(GTK_BUTTON(self.unwrap_widget()));
         }
     }
 
     fn set_relief(&mut self, new_style: ReliefStyle) -> () {
         unsafe {
-            ffi::gtk_button_set_relief(GTK_BUTTON(self.get_widget()), new_style);
+            ffi::gtk_button_set_relief(GTK_BUTTON(self.unwrap_widget()), new_style);
         }
     }
 
     fn get_relief(&self) -> ReliefStyle {
         unsafe {
-            ffi::gtk_button_get_relief(GTK_BUTTON(self.get_widget()))
+            ffi::gtk_button_get_relief(GTK_BUTTON(self.unwrap_widget()))
         }
     }
 
     fn get_label(&self) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_button_get_label(GTK_BUTTON(self.get_widget()));
+            let c_str = ffi::gtk_button_get_label(GTK_BUTTON(self.unwrap_widget()));
 
             if c_str.is_null() {
                 None
@@ -81,37 +81,37 @@ pub trait ButtonTrait: gtk::WidgetTrait + gtk::ContainerTrait {
         unsafe {
             let c_str = CString::from_slice(label.as_bytes());
 
-            ffi::gtk_button_set_label(GTK_BUTTON(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_button_set_label(GTK_BUTTON(self.unwrap_widget()), c_str.as_ptr())
         }
     }
 
     fn get_use_stock(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_button_get_use_stock(GTK_BUTTON(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_button_get_use_stock(GTK_BUTTON(self.unwrap_widget()))) }
     }
 
     fn set_use_stock(&mut self, use_stock: bool) -> () {
-        unsafe { ffi::gtk_button_set_use_stock(GTK_BUTTON(self.get_widget()), to_gboolean(use_stock)); }
+        unsafe { ffi::gtk_button_set_use_stock(GTK_BUTTON(self.unwrap_widget()), to_gboolean(use_stock)); }
     }
 
     fn get_use_underline(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_button_get_use_underline(GTK_BUTTON(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_button_get_use_underline(GTK_BUTTON(self.unwrap_widget()))) }
     }
 
     fn set_use_underline(&mut self, use_underline: bool) -> () {
-        unsafe { ffi::gtk_button_set_use_underline(GTK_BUTTON(self.get_widget()), to_gboolean(use_underline)); }
+        unsafe { ffi::gtk_button_set_use_underline(GTK_BUTTON(self.unwrap_widget()), to_gboolean(use_underline)); }
     }
 
     fn set_focus_on_click(&mut self, focus_on_click: bool) -> () {
-        unsafe { ffi::gtk_button_set_focus_on_click(GTK_BUTTON(self.get_widget()), to_gboolean(focus_on_click)); }
+        unsafe { ffi::gtk_button_set_focus_on_click(GTK_BUTTON(self.unwrap_widget()), to_gboolean(focus_on_click)); }
     }
 
     fn get_focus_on_click(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_button_get_focus_on_click(GTK_BUTTON(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_button_get_focus_on_click(GTK_BUTTON(self.unwrap_widget()))) }
     }
 
     fn set_alignment(&mut self, x_align: f32, y_align: f32) -> () {
         unsafe {
-            ffi::gtk_button_set_alignment(GTK_BUTTON(self.get_widget()), x_align as c_float, y_align as c_float)
+            ffi::gtk_button_set_alignment(GTK_BUTTON(self.unwrap_widget()), x_align as c_float, y_align as c_float)
         }
     }
 
@@ -119,37 +119,37 @@ pub trait ButtonTrait: gtk::WidgetTrait + gtk::ContainerTrait {
         let mut x_align = 0.1;
         let mut y_align = 0.1;
         unsafe {
-            ffi::gtk_button_get_alignment(GTK_BUTTON(self.get_widget()), &mut x_align, &mut y_align);
+            ffi::gtk_button_get_alignment(GTK_BUTTON(self.unwrap_widget()), &mut x_align, &mut y_align);
         }
         (x_align as f32, y_align as f32)
     }
 
     fn set_image<T: gtk::WidgetTrait>(&mut self, image: &T) -> () {
         unsafe {
-            ffi::gtk_button_set_image(GTK_BUTTON(self.get_widget()), image.get_widget());
+            ffi::gtk_button_set_image(GTK_BUTTON(self.unwrap_widget()), image.unwrap_widget());
         }
     }
 
     fn set_image_position(&mut self, position: PositionType) -> () {
         unsafe {
-            ffi::gtk_button_set_image_position(GTK_BUTTON(self.get_widget()), position);
+            ffi::gtk_button_set_image_position(GTK_BUTTON(self.unwrap_widget()), position);
         }
     }
 
     fn get_image_position(&self) -> PositionType {
         unsafe {
-            ffi::gtk_button_get_image_position(GTK_BUTTON(self.get_widget()))
+            ffi::gtk_button_get_image_position(GTK_BUTTON(self.unwrap_widget()))
         }
     }
 
     #[cfg(any(feature = "GTK_3_6", feature = "GTK_3_8", feature = "GTK_3_10", feature = "GTK_3_12", feature = "GTK_3_14"))]
     fn set_always_show_image(&mut self, always_show: bool) -> () {
-        unsafe { ffi::gtk_button_set_always_show_image(GTK_BUTTON(self.get_widget()), to_gboolean(always_show)); }
+        unsafe { ffi::gtk_button_set_always_show_image(GTK_BUTTON(self.unwrap_widget()), to_gboolean(always_show)); }
     }
 
     #[cfg(any(feature = "GTK_3_6", feature = "GTK_3_8", feature = "GTK_3_10", feature = "GTK_3_12", feature = "GTK_3_14"))]
     fn get_always_show_image(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_button_get_always_show_image(GTK_BUTTON(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_button_get_always_show_image(GTK_BUTTON(self.unwrap_widget()))) }
     }
 
     fn connect_clicked_signal(&self, handler: Box<ButtonClickedHandler>) {
@@ -157,7 +157,7 @@ pub trait ButtonTrait: gtk::WidgetTrait + gtk::ContainerTrait {
         let c_str = CString::from_slice("clicked".as_bytes());
 
         unsafe {
-            ffi::g_signal_connect_data(self.get_widget() as ffi::gpointer,
+            ffi::g_signal_connect_data(self.unwrap_widget() as ffi::gpointer,
                                        c_str.as_ptr(),
                                        Some(mem::transmute(widget_destroy_callback)),
                                        data,
@@ -177,7 +177,7 @@ extern "C" fn widget_destroy_callback(object: *mut ffi::C_GtkWidget, user_data: 
 
     // let mut window = check_pointer!(object, Window).unwrap();
     // window.can_drop = false;
-    let mut button: gtk::Button = gtk::FFIWidget::wrap(object);
+    let mut button: gtk::Button = gtk::FFIWidget::wrap_widget(object);
     handler.callback(&mut button);
 
     unsafe {

--- a/src/gtk/traits/cell_editable.rs
+++ b/src/gtk/traits/cell_editable.rs
@@ -20,10 +20,10 @@ use gtk::cast::GTK_CELL_EDITABLE;
 
 pub trait CellEditableTrait : gtk::WidgetTrait {
     fn editing_done(&self) {
-        unsafe { ffi::gtk_cell_editable_editing_done(GTK_CELL_EDITABLE(self.get_widget())) }
+        unsafe { ffi::gtk_cell_editable_editing_done(GTK_CELL_EDITABLE(self.unwrap_widget())) }
     }
 
     fn remove_widget(&self) {
-        unsafe { ffi::gtk_cell_editable_remove_widget(GTK_CELL_EDITABLE(self.get_widget())) }
+        unsafe { ffi::gtk_cell_editable_remove_widget(GTK_CELL_EDITABLE(self.unwrap_widget())) }
     }
 }

--- a/src/gtk/traits/cell_layout.rs
+++ b/src/gtk/traits/cell_layout.rs
@@ -21,7 +21,7 @@ use glib;
 pub trait CellLayoutTrait: gtk::WidgetTrait {
     fn pack_start<T: gtk::CellRendererTrait>(&self, cell: &T, expand: bool) {
         unsafe {
-            ffi::gtk_cell_layout_pack_start(GTK_CELL_LAYOUT(self.get_widget()), GTK_CELL_RENDERER(cell.get_widget()), match expand {
+            ffi::gtk_cell_layout_pack_start(GTK_CELL_LAYOUT(self.unwrap_widget()), GTK_CELL_RENDERER(cell.unwrap_widget()), match expand {
                 true => 1,
                 false => 0
             })
@@ -30,7 +30,7 @@ pub trait CellLayoutTrait: gtk::WidgetTrait {
 
     fn pack_end<T: gtk::CellRendererTrait>(&self, cell: &T, expand: bool) {
         unsafe {
-            ffi::gtk_cell_layout_pack_end(GTK_CELL_LAYOUT(self.get_widget()), GTK_CELL_RENDERER(cell.get_widget()), match expand {
+            ffi::gtk_cell_layout_pack_end(GTK_CELL_LAYOUT(self.unwrap_widget()), GTK_CELL_RENDERER(cell.unwrap_widget()), match expand {
                 true => 1,
                 false => 0
             })
@@ -38,45 +38,45 @@ pub trait CellLayoutTrait: gtk::WidgetTrait {
     }
 
     /*fn get_area(&self) -> Option<gtk::CellArea> {
-        let tmp = unsafe { ffi::gtk_cell_layout_get_area(GTK_CELL_LAYOUT(self.get_widget())) };
+        let tmp = unsafe { ffi::gtk_cell_layout_get_area(GTK_CELL_LAYOUT(self.unwrap_widget())) };
 
         if tmp.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }*/
 
     fn get_cells<T: gtk::CellRendererTrait>(&self) -> glib::List<T> {
-        let tmp = unsafe { ffi::gtk_cell_layout_get_cells(GTK_CELL_LAYOUT(self.get_widget())) };
+        let tmp = unsafe { ffi::gtk_cell_layout_get_cells(GTK_CELL_LAYOUT(self.unwrap_widget())) };
 
         if tmp.is_null() {
             glib::List::new()
         } else {
             let list: glib::List<*mut ffi::C_GtkWidget> = glib::GlibContainer::wrap(tmp);
 
-            list.iter().map(|it| gtk::FFIWidget::wrap(*it)).collect()
+            list.iter().map(|it| gtk::FFIWidget::wrap_widget(*it)).collect()
         }
     }
 
     fn reorder<T: gtk::CellRendererTrait>(&self, cell: &T, position: i32) {
-        unsafe { ffi::gtk_cell_layout_reorder(GTK_CELL_LAYOUT(self.get_widget()), GTK_CELL_RENDERER(cell.get_widget()), position) }
+        unsafe { ffi::gtk_cell_layout_reorder(GTK_CELL_LAYOUT(self.unwrap_widget()), GTK_CELL_RENDERER(cell.unwrap_widget()), position) }
     }
 
     fn clear(&self) {
-        unsafe { ffi::gtk_cell_layout_clear(GTK_CELL_LAYOUT(self.get_widget())) }
+        unsafe { ffi::gtk_cell_layout_clear(GTK_CELL_LAYOUT(self.unwrap_widget())) }
     }
 
     fn add_attribute<T: gtk::CellRendererTrait>(&self, cell: &T, attribute: &str, column: i32) {
         let c_str = CString::from_slice(attribute.as_bytes());
 
         unsafe {
-                ffi::gtk_cell_layout_add_attribute(GTK_CELL_LAYOUT(self.get_widget()), GTK_CELL_RENDERER(cell.get_widget()),
+                ffi::gtk_cell_layout_add_attribute(GTK_CELL_LAYOUT(self.unwrap_widget()), GTK_CELL_RENDERER(cell.unwrap_widget()),
                     c_str.as_ptr(), column)
             }
     }
 
     fn clear_attributes<T: gtk::CellRendererTrait>(&self, cell: &T) {
-        unsafe { ffi::gtk_cell_layout_clear_attributes(GTK_CELL_LAYOUT(self.get_widget()), GTK_CELL_RENDERER(cell.get_widget())) }
+        unsafe { ffi::gtk_cell_layout_clear_attributes(GTK_CELL_LAYOUT(self.unwrap_widget()), GTK_CELL_RENDERER(cell.unwrap_widget())) }
     }
 }

--- a/src/gtk/traits/cell_renderer.rs
+++ b/src/gtk/traits/cell_renderer.rs
@@ -19,7 +19,7 @@ use gtk::cast::GTK_CELL_RENDERER;
 pub trait CellRendererTrait: gtk::WidgetTrait {
     fn stop_editing(&self, canceled: bool) {
         unsafe {
-            ffi::gtk_cell_renderer_stop_editing(GTK_CELL_RENDERER(self.get_widget()), match canceled {
+            ffi::gtk_cell_renderer_stop_editing(GTK_CELL_RENDERER(self.unwrap_widget()), match canceled {
                 true => 1,
                 false => 0
             })
@@ -27,15 +27,15 @@ pub trait CellRendererTrait: gtk::WidgetTrait {
     }
 
     fn get_fixed_size(&self, width: &mut i32, height: &mut i32) {
-        unsafe { ffi::gtk_cell_renderer_get_fixed_size(GTK_CELL_RENDERER(self.get_widget()), width, height) }
+        unsafe { ffi::gtk_cell_renderer_get_fixed_size(GTK_CELL_RENDERER(self.unwrap_widget()), width, height) }
     }
 
     fn set_fixed_size(&self, width: i32, height: i32) {
-        unsafe { ffi::gtk_cell_renderer_set_fixed_size(GTK_CELL_RENDERER(self.get_widget()), width, height) }
+        unsafe { ffi::gtk_cell_renderer_set_fixed_size(GTK_CELL_RENDERER(self.unwrap_widget()), width, height) }
     }
 
     fn get_visible(&self) -> bool {
-        match unsafe { ffi::gtk_cell_renderer_get_visible(GTK_CELL_RENDERER(self.get_widget())) } {
+        match unsafe { ffi::gtk_cell_renderer_get_visible(GTK_CELL_RENDERER(self.unwrap_widget())) } {
             0 => false,
             _ => true
         }
@@ -43,7 +43,7 @@ pub trait CellRendererTrait: gtk::WidgetTrait {
 
     fn set_visible(&self, visible: bool) {
         unsafe {
-            ffi::gtk_cell_renderer_set_visible(GTK_CELL_RENDERER(self.get_widget()), match visible {
+            ffi::gtk_cell_renderer_set_visible(GTK_CELL_RENDERER(self.unwrap_widget()), match visible {
                 true => 1,
                 false => 0
             })
@@ -51,7 +51,7 @@ pub trait CellRendererTrait: gtk::WidgetTrait {
     }
 
     fn get_sensitive(&self) -> bool {
-        match unsafe { ffi::gtk_cell_renderer_get_sensitive(GTK_CELL_RENDERER(self.get_widget())) } {
+        match unsafe { ffi::gtk_cell_renderer_get_sensitive(GTK_CELL_RENDERER(self.unwrap_widget())) } {
             0 => false,
             _ => true
         }
@@ -59,7 +59,7 @@ pub trait CellRendererTrait: gtk::WidgetTrait {
 
     fn set_sensitive(&self, sensitive: bool) {
         unsafe {
-            ffi::gtk_cell_renderer_set_sensitive(GTK_CELL_RENDERER(self.get_widget()), match sensitive {
+            ffi::gtk_cell_renderer_set_sensitive(GTK_CELL_RENDERER(self.unwrap_widget()), match sensitive {
                 true => 1,
                 false => 0
             })
@@ -67,53 +67,53 @@ pub trait CellRendererTrait: gtk::WidgetTrait {
     }
 
     fn get_alignment(&self, xalign: &mut f32, yalign: &mut f32) {
-        unsafe { ffi::gtk_cell_renderer_get_alignment(GTK_CELL_RENDERER(self.get_widget()), xalign, yalign) }
+        unsafe { ffi::gtk_cell_renderer_get_alignment(GTK_CELL_RENDERER(self.unwrap_widget()), xalign, yalign) }
     }
 
     fn set_alignment(&self, xalign: f32, yalign: f32) {
-        unsafe { ffi::gtk_cell_renderer_set_alignment(GTK_CELL_RENDERER(self.get_widget()), xalign, yalign) }
+        unsafe { ffi::gtk_cell_renderer_set_alignment(GTK_CELL_RENDERER(self.unwrap_widget()), xalign, yalign) }
     }
 
     fn get_padding(&self, xpad: &mut i32, ypad: &mut i32) {
-        unsafe { ffi::gtk_cell_renderer_get_padding(GTK_CELL_RENDERER(self.get_widget()), xpad, ypad) }
+        unsafe { ffi::gtk_cell_renderer_get_padding(GTK_CELL_RENDERER(self.unwrap_widget()), xpad, ypad) }
     }
 
     fn set_padding(&self, xpad: i32, ypad: i32) {
-        unsafe { ffi::gtk_cell_renderer_set_padding(GTK_CELL_RENDERER(self.get_widget()), xpad, ypad) }
+        unsafe { ffi::gtk_cell_renderer_set_padding(GTK_CELL_RENDERER(self.unwrap_widget()), xpad, ypad) }
     }
 
     fn get_state<T: gtk::WidgetTrait>(&self, widget: &T, cell_state: gtk::CellRendererState) -> gtk::StateFlags {
-        unsafe { ffi::gtk_cell_renderer_get_state(GTK_CELL_RENDERER(self.get_widget()), widget.get_widget(), cell_state) }
+        unsafe { ffi::gtk_cell_renderer_get_state(GTK_CELL_RENDERER(self.unwrap_widget()), widget.unwrap_widget(), cell_state) }
     }
 
     fn is_activable(&self) -> bool {
-        match unsafe { ffi::gtk_cell_renderer_is_activatable(GTK_CELL_RENDERER(self.get_widget())) } {
+        match unsafe { ffi::gtk_cell_renderer_is_activatable(GTK_CELL_RENDERER(self.unwrap_widget())) } {
             0 => false,
             _ => true
         }
     }
 
     fn get_preferred_height<T: gtk::WidgetTrait>(&self, widget: &T, minimum_size: &mut i32, natural_size: &mut i32) {
-        unsafe { ffi::gtk_cell_renderer_get_preferred_height(GTK_CELL_RENDERER(self.get_widget()), widget.get_widget(), minimum_size,
+        unsafe { ffi::gtk_cell_renderer_get_preferred_height(GTK_CELL_RENDERER(self.unwrap_widget()), widget.unwrap_widget(), minimum_size,
             natural_size) }
     }
 
     fn get_preferred_height_for_width<T: gtk::WidgetTrait>(&self, widget: &T, width: i32, minimum_size: &mut i32, natural_size: &mut i32) {
-        unsafe { ffi::gtk_cell_renderer_get_preferred_height_for_width(GTK_CELL_RENDERER(self.get_widget()), widget.get_widget(), width,
+        unsafe { ffi::gtk_cell_renderer_get_preferred_height_for_width(GTK_CELL_RENDERER(self.unwrap_widget()), widget.unwrap_widget(), width,
             minimum_size, natural_size) }
     }
 
     fn get_preferred_width<T: gtk::WidgetTrait>(&self, widget: &T, minimum_size: &mut i32, natural_size: &mut i32) {
-        unsafe { ffi::gtk_cell_renderer_get_preferred_width(GTK_CELL_RENDERER(self.get_widget()), widget.get_widget(), minimum_size,
+        unsafe { ffi::gtk_cell_renderer_get_preferred_width(GTK_CELL_RENDERER(self.unwrap_widget()), widget.unwrap_widget(), minimum_size,
             natural_size) }
     }
 
     fn get_preferred_width_for_height<T: gtk::WidgetTrait>(&self, widget: &T, height: i32, minimum_size: &mut i32, natural_size: &mut i32) {
-        unsafe { ffi::gtk_cell_renderer_get_preferred_width_for_height(GTK_CELL_RENDERER(self.get_widget()), widget.get_widget(), height,
+        unsafe { ffi::gtk_cell_renderer_get_preferred_width_for_height(GTK_CELL_RENDERER(self.unwrap_widget()), widget.unwrap_widget(), height,
             minimum_size, natural_size) }
     }
 
     fn get_request_mode(&self) -> gtk::SizeRequestMode {
-        unsafe { ffi::gtk_cell_renderer_get_request_mode(GTK_CELL_RENDERER(self.get_widget())) }
+        unsafe { ffi::gtk_cell_renderer_get_request_mode(GTK_CELL_RENDERER(self.unwrap_widget())) }
     }
 }

--- a/src/gtk/traits/check_menu_item.rs
+++ b/src/gtk/traits/check_menu_item.rs
@@ -27,46 +27,46 @@ pub trait CheckMenuItemTrait: gtk::WidgetTrait +
 
     fn set_active(&mut self, is_active: bool) {
         unsafe {
-            ffi::gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(self.get_widget()),
+            ffi::gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(self.unwrap_widget()),
                                                 to_gboolean(is_active))
         }
     }
 
     fn active(&self) -> bool {
         unsafe {
-            to_bool(ffi::gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(self.get_widget())))
+            to_bool(ffi::gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(self.unwrap_widget())))
         }
     }
 
     fn toggled(&mut self) {
         unsafe {
-            ffi::gtk_check_menu_item_toggled(GTK_CHECK_MENU_ITEM(self.get_widget()))
+            ffi::gtk_check_menu_item_toggled(GTK_CHECK_MENU_ITEM(self.unwrap_widget()))
         }
     }
 
     fn set_inconsistent(&mut self, setting: bool) {
         unsafe {
-            ffi::gtk_check_menu_item_set_inconsistent(GTK_CHECK_MENU_ITEM(self.get_widget()),
+            ffi::gtk_check_menu_item_set_inconsistent(GTK_CHECK_MENU_ITEM(self.unwrap_widget()),
                                                       to_gboolean(setting))
         }
     }
 
     fn inconsistent(&self) -> bool {
         unsafe {
-            to_bool(ffi::gtk_check_menu_item_get_inconsistent(GTK_CHECK_MENU_ITEM(self.get_widget())))
+            to_bool(ffi::gtk_check_menu_item_get_inconsistent(GTK_CHECK_MENU_ITEM(self.unwrap_widget())))
         }
     }
 
     fn set_draw_as_radio(&mut self, setting: bool) {
         unsafe {
-            ffi::gtk_check_menu_item_set_draw_as_radio(GTK_CHECK_MENU_ITEM(self.get_widget()),
+            ffi::gtk_check_menu_item_set_draw_as_radio(GTK_CHECK_MENU_ITEM(self.unwrap_widget()),
                                                        to_gboolean(setting))
         }
     }
 
     fn draw_as_radio(&self) -> bool {
         unsafe {
-            to_bool(ffi::gtk_check_menu_item_get_draw_as_radio(GTK_CHECK_MENU_ITEM(self.get_widget())))
+            to_bool(ffi::gtk_check_menu_item_get_draw_as_radio(GTK_CHECK_MENU_ITEM(self.unwrap_widget())))
         }
     }
 }

--- a/src/gtk/traits/color_chooser.rs
+++ b/src/gtk/traits/color_chooser.rs
@@ -26,23 +26,23 @@ pub trait ColorChooserTrait: gtk::WidgetTrait {
             blue: 0f64,
             alpha: 0f64
         };
-        unsafe { ffi::gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(self.get_widget()), &color) };
+        unsafe { ffi::gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(self.unwrap_widget()), &color) };
         color
     }
 
     fn set_rgba(&self, color: gdk_ffi::C_GdkRGBA) -> () {
-        unsafe { ffi::gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(self.get_widget()), &color) };
+        unsafe { ffi::gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(self.unwrap_widget()), &color) };
     }
 
     fn get_use_alpha(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_color_chooser_get_use_alpha(GTK_COLOR_CHOOSER(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_color_chooser_get_use_alpha(GTK_COLOR_CHOOSER(self.unwrap_widget()))) }
     }
 
     fn set_use_alpha(&self, use_alpha: bool) -> () {
-        unsafe { ffi::gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(self.get_widget()), to_gboolean(use_alpha)) }
+        unsafe { ffi::gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(self.unwrap_widget()), to_gboolean(use_alpha)) }
     }
 
     fn add_palette(&self, orientation: gtk::Orientation, colors_per_line: i32, colors: Vec<gdk_ffi::C_GdkRGBA>) -> () {
-        unsafe { ffi::gtk_color_chooser_add_palette(GTK_COLOR_CHOOSER(self.get_widget()), orientation, colors_per_line, colors.len() as i32, colors.as_slice().as_ptr()) }
+        unsafe { ffi::gtk_color_chooser_add_palette(GTK_COLOR_CHOOSER(self.unwrap_widget()), orientation, colors_per_line, colors.len() as i32, colors.as_slice().as_ptr()) }
     }
 }

--- a/src/gtk/traits/combo_box.rs
+++ b/src/gtk/traits/combo_box.rs
@@ -20,39 +20,39 @@ use gtk::cast::GTK_COMBO_BOX;
 
 pub trait ComboBoxTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrait {
     fn get_wrap_width(&self) -> i32 {
-        unsafe { ffi::gtk_combo_box_get_wrap_width(GTK_COMBO_BOX(self.get_widget())) }
+        unsafe { ffi::gtk_combo_box_get_wrap_width(GTK_COMBO_BOX(self.unwrap_widget())) }
     }
 
     fn set_wrap_width(&self, width: i32) {
-        unsafe { ffi::gtk_combo_box_set_wrap_width(GTK_COMBO_BOX(self.get_widget()), width) }
+        unsafe { ffi::gtk_combo_box_set_wrap_width(GTK_COMBO_BOX(self.unwrap_widget()), width) }
     }
 
     fn get_row_span_column(&self) -> i32 {
-        unsafe { ffi::gtk_combo_box_get_row_span_column(GTK_COMBO_BOX(self.get_widget())) }
+        unsafe { ffi::gtk_combo_box_get_row_span_column(GTK_COMBO_BOX(self.unwrap_widget())) }
     }
 
     fn set_row_span_column(&self, row_span: i32) {
-        unsafe { ffi::gtk_combo_box_set_row_span_column(GTK_COMBO_BOX(self.get_widget()), row_span) }
+        unsafe { ffi::gtk_combo_box_set_row_span_column(GTK_COMBO_BOX(self.unwrap_widget()), row_span) }
     }
 
     fn get_column_span_column(&self) -> i32 {
-        unsafe { ffi::gtk_combo_box_get_column_span_column(GTK_COMBO_BOX(self.get_widget())) }
+        unsafe { ffi::gtk_combo_box_get_column_span_column(GTK_COMBO_BOX(self.unwrap_widget())) }
     }
 
     fn set_column_span_column(&self, column_span: i32) {
-        unsafe { ffi::gtk_combo_box_set_column_span_column(GTK_COMBO_BOX(self.get_widget()), column_span) }
+        unsafe { ffi::gtk_combo_box_set_column_span_column(GTK_COMBO_BOX(self.unwrap_widget()), column_span) }
     }
 
     fn get_active(&self) -> i32 {
-        unsafe { ffi::gtk_combo_box_get_active(GTK_COMBO_BOX(self.get_widget())) }
+        unsafe { ffi::gtk_combo_box_get_active(GTK_COMBO_BOX(self.unwrap_widget())) }
     }
 
     fn set_active(&self, active: i32) {
-        unsafe { ffi::gtk_combo_box_set_active(GTK_COMBO_BOX(self.get_widget()), active) }
+        unsafe { ffi::gtk_combo_box_set_active(GTK_COMBO_BOX(self.unwrap_widget()), active) }
     }
 
     fn get_active_iter(&self) -> Option<gtk::TreeIter> {
-        let tmp_pointer = unsafe { ffi::gtk_combo_box_get_active_iter(GTK_COMBO_BOX(self.get_widget())) };
+        let tmp_pointer = unsafe { ffi::gtk_combo_box_get_active_iter(GTK_COMBO_BOX(self.unwrap_widget())) };
 
         if tmp_pointer.is_null() {
             None
@@ -62,19 +62,19 @@ pub trait ComboBoxTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrait 
     }
 
     fn set_active_iter(&self, iter: &gtk::TreeIter) {
-        unsafe { ffi::gtk_combo_box_set_active_iter(GTK_COMBO_BOX(self.get_widget()), iter.get_pointer()) }
+        unsafe { ffi::gtk_combo_box_set_active_iter(GTK_COMBO_BOX(self.unwrap_widget()), iter.unwrap_pointer()) }
     }
 
     fn get_id_column(&self) -> i32 {
-        unsafe { ffi::gtk_combo_box_get_id_column(GTK_COMBO_BOX(self.get_widget())) }
+        unsafe { ffi::gtk_combo_box_get_id_column(GTK_COMBO_BOX(self.unwrap_widget())) }
     }
 
     fn set_id_column(&self, id_column: i32) {
-        unsafe { ffi::gtk_combo_box_set_id_column(GTK_COMBO_BOX(self.get_widget()), id_column) }
+        unsafe { ffi::gtk_combo_box_set_id_column(GTK_COMBO_BOX(self.unwrap_widget()), id_column) }
     }
 
     fn get_active_id(&self) -> Option<String> {
-        let tmp = unsafe { ffi::gtk_combo_box_get_active_id(GTK_COMBO_BOX(self.get_widget())) };
+        let tmp = unsafe { ffi::gtk_combo_box_get_active_id(GTK_COMBO_BOX(self.unwrap_widget())) };
 
         if tmp.is_null() {
             None
@@ -87,12 +87,12 @@ pub trait ComboBoxTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrait 
         unsafe {
             let c_str = CString::from_slice(active_id.as_bytes());
 
-            to_bool(ffi::gtk_combo_box_set_active_id(GTK_COMBO_BOX(self.get_widget()), c_str.as_ptr()))
+            to_bool(ffi::gtk_combo_box_set_active_id(GTK_COMBO_BOX(self.unwrap_widget()), c_str.as_ptr()))
         }
     }
 
     fn get_model(&self) -> Option<gtk::TreeModel> {
-        let tmp = unsafe { ffi::gtk_combo_box_get_model(GTK_COMBO_BOX(self.get_widget())) };
+        let tmp = unsafe { ffi::gtk_combo_box_get_model(GTK_COMBO_BOX(self.unwrap_widget())) };
 
         if tmp.is_null() {
             None
@@ -102,50 +102,50 @@ pub trait ComboBoxTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrait 
     }
 
     fn set_model(&self, model: gtk::TreeModel) {
-        unsafe { ffi::gtk_combo_box_set_model(GTK_COMBO_BOX(self.get_widget()), model.get_pointer()) }
+        unsafe { ffi::gtk_combo_box_set_model(GTK_COMBO_BOX(self.unwrap_widget()), model.unwrap_pointer()) }
     }
 
     fn popup(&self) {
-        unsafe { ffi::gtk_combo_box_popup(GTK_COMBO_BOX(self.get_widget())) }
+        unsafe { ffi::gtk_combo_box_popup(GTK_COMBO_BOX(self.unwrap_widget())) }
     }
 
     fn popdown(&self) {
-        unsafe { ffi::gtk_combo_box_popdown(GTK_COMBO_BOX(self.get_widget())) }
+        unsafe { ffi::gtk_combo_box_popdown(GTK_COMBO_BOX(self.unwrap_widget())) }
     }
 
     fn get_focus_on_click(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_combo_box_get_focus_on_click(GTK_COMBO_BOX(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_combo_box_get_focus_on_click(GTK_COMBO_BOX(self.unwrap_widget()))) }
     }
 
     fn set_focus_on_click(&self, focus_on_click: bool) {
-        unsafe { ffi::gtk_combo_box_set_focus_on_click(GTK_COMBO_BOX(self.get_widget()), to_gboolean(focus_on_click)) }
+        unsafe { ffi::gtk_combo_box_set_focus_on_click(GTK_COMBO_BOX(self.unwrap_widget()), to_gboolean(focus_on_click)) }
     }
 
     fn get_button_sensitivity(&self) -> gtk::SensitivityType {
-        unsafe { ffi::gtk_combo_box_get_button_sensitivity(GTK_COMBO_BOX(self.get_widget())) }
+        unsafe { ffi::gtk_combo_box_get_button_sensitivity(GTK_COMBO_BOX(self.unwrap_widget())) }
     }
 
     fn set_button_sensitivity(&self, sensitivity: gtk::SensitivityType) {
-        unsafe { ffi::gtk_combo_box_set_button_sensitivity(GTK_COMBO_BOX(self.get_widget()), sensitivity) }
+        unsafe { ffi::gtk_combo_box_set_button_sensitivity(GTK_COMBO_BOX(self.unwrap_widget()), sensitivity) }
     }
 
     fn get_has_entry(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_combo_box_get_has_entry(GTK_COMBO_BOX(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_combo_box_get_has_entry(GTK_COMBO_BOX(self.unwrap_widget()))) }
     }
 
     fn set_entry_text_column(&self, text_column: i32) {
-        unsafe { ffi::gtk_combo_box_set_entry_text_column(GTK_COMBO_BOX(self.get_widget()), text_column) }
+        unsafe { ffi::gtk_combo_box_set_entry_text_column(GTK_COMBO_BOX(self.unwrap_widget()), text_column) }
     }
 
     fn get_entry_text_column(&self) -> i32 {
-        unsafe { ffi::gtk_combo_box_get_entry_text_column(GTK_COMBO_BOX(self.get_widget())) }
+        unsafe { ffi::gtk_combo_box_get_entry_text_column(GTK_COMBO_BOX(self.unwrap_widget())) }
     }
 
     fn set_popup_fixed_width(&self, fixed: bool) {
-        unsafe { ffi::gtk_combo_box_set_popup_fixed_width(GTK_COMBO_BOX(self.get_widget()), to_gboolean(fixed)) }
+        unsafe { ffi::gtk_combo_box_set_popup_fixed_width(GTK_COMBO_BOX(self.unwrap_widget()), to_gboolean(fixed)) }
     }
 
     fn get_popup_fixed_width(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_combo_box_get_popup_fixed_width(GTK_COMBO_BOX(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_combo_box_get_popup_fixed_width(GTK_COMBO_BOX(self.unwrap_widget()))) }
     }
 }

--- a/src/gtk/traits/container.rs
+++ b/src/gtk/traits/container.rs
@@ -22,37 +22,37 @@ use gtk::{self, ffi};
 pub trait ContainerTrait: gtk::WidgetTrait {
     fn add<'r, T: gtk::WidgetTrait>(&'r mut self, widget: &'r T) {
         unsafe {
-            ffi::gtk_container_add(GTK_CONTAINER(self.get_widget()), widget.get_widget());
+            ffi::gtk_container_add(GTK_CONTAINER(self.unwrap_widget()), widget.unwrap_widget());
         }
     }
 
     fn remove<'r, T: gtk::WidgetTrait>(&'r mut self, widget: &'r T) {
         unsafe {
-            ffi::gtk_container_remove(GTK_CONTAINER(self.get_widget()), widget.get_widget());
+            ffi::gtk_container_remove(GTK_CONTAINER(self.unwrap_widget()), widget.unwrap_widget());
         }
     }
 
     fn get_resize_mode(&self) -> ResizeMode {
         unsafe {
-            ffi::gtk_container_get_resize_mode(GTK_CONTAINER(self.get_widget()))
+            ffi::gtk_container_get_resize_mode(GTK_CONTAINER(self.unwrap_widget()))
         }
     }
 
     fn set_resize_mode(&mut self, resize_mode: ResizeMode) -> () {
         unsafe {
-            ffi::gtk_container_set_resize_mode(GTK_CONTAINER(self.get_widget()), resize_mode);
+            ffi::gtk_container_set_resize_mode(GTK_CONTAINER(self.unwrap_widget()), resize_mode);
         }
     }
 
     fn get_border_width(&self) -> u32 {
         unsafe {
-            ffi::gtk_container_get_border_width(GTK_CONTAINER(self.get_widget())) as u32
+            ffi::gtk_container_get_border_width(GTK_CONTAINER(self.unwrap_widget())) as u32
         }
     }
 
     fn set_border_width(&self, border_width: u32) -> () {
         unsafe {
-            ffi::gtk_container_set_border_width(GTK_CONTAINER(self.get_widget()), border_width as c_uint);
+            ffi::gtk_container_set_border_width(GTK_CONTAINER(self.unwrap_widget()), border_width as c_uint);
         }
     }
 }

--- a/src/gtk/traits/dialog.rs
+++ b/src/gtk/traits/dialog.rs
@@ -20,29 +20,29 @@ use gtk;
 
 pub trait DialogTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrait + gtk::WindowTrait {
     fn run(&self) -> i32 {
-        unsafe { ffi::gtk_dialog_run(GTK_DIALOG(self.get_widget())) }
+        unsafe { ffi::gtk_dialog_run(GTK_DIALOG(self.unwrap_widget())) }
     }
 
     fn response(&self, response_id: i32) -> () {
-        unsafe { ffi::gtk_dialog_response(GTK_DIALOG(self.get_widget()), response_id) }
+        unsafe { ffi::gtk_dialog_response(GTK_DIALOG(self.unwrap_widget()), response_id) }
     }
 
     fn add_button(&self, button_text: &str, response_id: i32) -> Option<gtk::Button> {
         let tmp_pointer = unsafe {
             let c_str = CString::from_slice(button_text.as_bytes());
 
-            ffi::gtk_dialog_add_button(GTK_DIALOG(self.get_widget()), c_str.as_ptr(), response_id)
+            ffi::gtk_dialog_add_button(GTK_DIALOG(self.unwrap_widget()), c_str.as_ptr(), response_id)
         };
 
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 
     fn add_buttons(&self, buttons: Vec<(&str, i32)>) -> Vec<gtk::Button> {
-        //unsafe { ffi::gtk_dialog_add_buttons(GTK_DIALOG(self.get_widget()), ...) }
+        //unsafe { ffi::gtk_dialog_add_buttons(GTK_DIALOG(self.unwrap_widget()), ...) }
         let mut ret = Vec::new();
 
         for &(button_text, response_id) in buttons.iter() {
@@ -55,19 +55,19 @@ pub trait DialogTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrait + 
     }
 
     fn add_action_widget<T: gtk::WidgetTrait>(&self, child: &T, response_id: i32) -> () {
-        unsafe { ffi::gtk_dialog_add_action_widget(GTK_DIALOG(self.get_widget()), child.get_widget(), response_id) }
+        unsafe { ffi::gtk_dialog_add_action_widget(GTK_DIALOG(self.unwrap_widget()), child.unwrap_widget(), response_id) }
     }
 
     fn set_default_response(&self, response_id: i32) -> () {
-        unsafe { ffi::gtk_dialog_set_default_response(GTK_DIALOG(self.get_widget()), response_id) }
+        unsafe { ffi::gtk_dialog_set_default_response(GTK_DIALOG(self.unwrap_widget()), response_id) }
     }
 
     fn set_response_sensitive(&self, response_id: i32, setting: ffi::Gboolean) -> () {
-        unsafe { ffi::gtk_dialog_set_response_sensitive(GTK_DIALOG(self.get_widget()), response_id, setting) }
+        unsafe { ffi::gtk_dialog_set_response_sensitive(GTK_DIALOG(self.unwrap_widget()), response_id, setting) }
     }
 
     fn get_response_for_widget<T: gtk::WidgetTrait>(&self, widget: &T) -> Result<i32, gtk::ResponseType> {
-        let tmp = unsafe { ffi::gtk_dialog_get_response_for_widget(GTK_DIALOG(self.get_widget()), widget.get_widget()) };
+        let tmp = unsafe { ffi::gtk_dialog_get_response_for_widget(GTK_DIALOG(self.unwrap_widget()), widget.unwrap_widget()) };
 
         if tmp < 0 {
             Err(unsafe { ::std::mem::transmute(tmp) })
@@ -77,43 +77,43 @@ pub trait DialogTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrait + 
     }
 
     fn get_widget_for_reponse<T: gtk::WidgetTrait>(&self, response_id: i32) -> Option<T> {
-        let tmp_pointer = unsafe { ffi::gtk_dialog_get_widget_for_response(GTK_DIALOG(self.get_widget()), response_id) };
+        let tmp_pointer = unsafe { ffi::gtk_dialog_get_widget_for_response(GTK_DIALOG(self.unwrap_widget()), response_id) };
 
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 
     fn get_action_area<T: gtk::WidgetTrait>(&self) -> Option<T> {
-        let tmp_pointer = unsafe { ffi::gtk_dialog_get_action_area(GTK_DIALOG(self.get_widget())) };
+        let tmp_pointer = unsafe { ffi::gtk_dialog_get_action_area(GTK_DIALOG(self.unwrap_widget())) };
 
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 
     fn get_content_area<T: gtk::WidgetTrait>(&self) -> Option<T> {
-        let tmp_pointer = unsafe { ffi::gtk_dialog_get_content_area(GTK_DIALOG(self.get_widget())) };
+        let tmp_pointer = unsafe { ffi::gtk_dialog_get_content_area(GTK_DIALOG(self.unwrap_widget())) };
 
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 
     #[cfg(any(feature = "GTK_3_12", feature = "GTK_3_14"))]
     fn get_header_bar<T: gtk::WidgetTrait>(&self) -> Option<T> {
-        let tmp_pointer = unsafe { ffi::gtk_dialog_get_header_bar(GTK_DIALOG(self.get_widget())) };
+        let tmp_pointer = unsafe { ffi::gtk_dialog_get_header_bar(GTK_DIALOG(self.unwrap_widget())) };
 
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 }

--- a/src/gtk/traits/editable.rs
+++ b/src/gtk/traits/editable.rs
@@ -21,14 +21,14 @@ use glib::{to_bool, to_gboolean};
 pub trait EditableTrait: gtk::WidgetTrait {
     fn select_region(&mut self, start_pos: i32, end_pos: i32) {
         unsafe {
-            ffi::gtk_editable_select_region(GTK_EDITABLE(self.get_widget()), start_pos, end_pos)
+            ffi::gtk_editable_select_region(GTK_EDITABLE(self.unwrap_widget()), start_pos, end_pos)
         }
     }
     fn get_selection_bounds (&self) -> Option<(i32, i32)> {
         let mut i: i32 = 0;
         let mut j: i32 = 0;
         let res = unsafe {
-            to_bool(ffi::gtk_editable_get_selection_bounds(GTK_EDITABLE(self.get_widget()),
+            to_bool(ffi::gtk_editable_get_selection_bounds(GTK_EDITABLE(self.unwrap_widget()),
                                                                 &mut i,
                                                                 &mut j))
         };
@@ -43,7 +43,7 @@ pub trait EditableTrait: gtk::WidgetTrait {
         unsafe {
             let c_str = CString::from_slice(new_text.as_bytes());
 
-            ffi::gtk_editable_insert_text(GTK_EDITABLE(self.get_widget()),
+            ffi::gtk_editable_insert_text(GTK_EDITABLE(self.unwrap_widget()),
                                               c_str.as_ptr(),
                                               new_text_length,
                                               position)
@@ -52,13 +52,13 @@ pub trait EditableTrait: gtk::WidgetTrait {
 
     fn delete_text(&mut self, start_pos: i32, end_pos: i32) {
         unsafe {
-            ffi::gtk_editable_delete_text(GTK_EDITABLE(self.get_widget()), start_pos, end_pos)
+            ffi::gtk_editable_delete_text(GTK_EDITABLE(self.unwrap_widget()), start_pos, end_pos)
         }
     }
 
     fn get_chars(&self, start_pos: i32, end_pos: i32) -> Option<String> {
         let chars = unsafe {
-            ffi::gtk_editable_get_chars(GTK_EDITABLE(self.get_widget()), start_pos, end_pos)
+            ffi::gtk_editable_get_chars(GTK_EDITABLE(self.unwrap_widget()), start_pos, end_pos)
         };
 
         if chars.is_null() {
@@ -70,49 +70,49 @@ pub trait EditableTrait: gtk::WidgetTrait {
 
     fn cut_clipboard(&mut self) {
         unsafe {
-            ffi::gtk_editable_cut_clipboard(GTK_EDITABLE(self.get_widget()))
+            ffi::gtk_editable_cut_clipboard(GTK_EDITABLE(self.unwrap_widget()))
         }
     }
 
     fn copy_clipboard(&mut self) {
         unsafe {
-            ffi::gtk_editable_copy_clipboard(GTK_EDITABLE(self.get_widget()))
+            ffi::gtk_editable_copy_clipboard(GTK_EDITABLE(self.unwrap_widget()))
         }
     }
 
     fn paste_clipboard(&mut self) {
         unsafe {
-            ffi::gtk_editable_paste_clipboard(GTK_EDITABLE(self.get_widget()))
+            ffi::gtk_editable_paste_clipboard(GTK_EDITABLE(self.unwrap_widget()))
         }
     }
 
     fn delete_selection(&mut self) {
         unsafe {
-            ffi::gtk_editable_delete_selection(GTK_EDITABLE(self.get_widget()))
+            ffi::gtk_editable_delete_selection(GTK_EDITABLE(self.unwrap_widget()))
         }
     }
 
     fn set_position(&mut self, position: i32) {
         unsafe {
-            ffi::gtk_editable_set_editable(GTK_EDITABLE(self.get_widget()), position)
+            ffi::gtk_editable_set_editable(GTK_EDITABLE(self.unwrap_widget()), position)
         }
     }
 
     fn get_position(&self) -> i32 {
         unsafe {
-            ffi::gtk_editable_get_position(GTK_EDITABLE(self.get_widget()))
+            ffi::gtk_editable_get_position(GTK_EDITABLE(self.unwrap_widget()))
         }
     }
 
     fn set_editable(&mut self, editable: bool) {
         unsafe {
-            ffi::gtk_editable_set_editable(GTK_EDITABLE(self.get_widget()), to_gboolean(editable))
+            ffi::gtk_editable_set_editable(GTK_EDITABLE(self.unwrap_widget()), to_gboolean(editable))
         }
     }
 
     fn is_editable(&self) -> bool {
         unsafe {
-            to_bool(ffi::gtk_editable_get_editable(GTK_EDITABLE(self.get_widget())))
+            to_bool(ffi::gtk_editable_get_editable(GTK_EDITABLE(self.unwrap_widget())))
         }
     }
 }

--- a/src/gtk/traits/entry.rs
+++ b/src/gtk/traits/entry.rs
@@ -24,14 +24,14 @@ use glib::{to_bool, to_gboolean};
 
 pub trait EntryTrait: gtk::WidgetTrait {
     fn get_buffer(&self) -> gtk::EntryBuffer {
-        let tmp_pointer = unsafe { ffi::gtk_entry_get_buffer(GTK_ENTRY(self.get_widget())) };
+        let tmp_pointer = unsafe { ffi::gtk_entry_get_buffer(GTK_ENTRY(self.unwrap_widget())) };
 
         gtk::EntryBuffer::wrap_pointer(tmp_pointer)
     }
 
     fn set_buffer(&mut self, buffer: &gtk::EntryBuffer) -> () {
         unsafe {
-            ffi::gtk_entry_set_buffer(GTK_ENTRY(self.get_widget()), buffer.get_pointer())
+            ffi::gtk_entry_set_buffer(GTK_ENTRY(self.unwrap_widget()), buffer.unwrap_pointer())
         }
     }
 
@@ -39,13 +39,13 @@ pub trait EntryTrait: gtk::WidgetTrait {
         unsafe {
             let c_str = CString::from_slice(text.as_bytes());
 
-            ffi::gtk_entry_set_text(GTK_ENTRY(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_entry_set_text(GTK_ENTRY(self.unwrap_widget()), c_str.as_ptr())
         }
     }
 
     fn get_text(&self) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_entry_get_text(GTK_ENTRY(self.get_widget()));
+            let c_str = ffi::gtk_entry_get_text(GTK_ENTRY(self.unwrap_widget()));
 
             if c_str.is_null() {
                 None
@@ -57,75 +57,75 @@ pub trait EntryTrait: gtk::WidgetTrait {
 
     fn get_text_length(&self) -> i16 {
         unsafe {
-            ffi::gtk_entry_get_text_length(GTK_ENTRY(self.get_widget())) as i16
+            ffi::gtk_entry_get_text_length(GTK_ENTRY(self.unwrap_widget())) as i16
         }
     }
 
     fn set_visibility(&mut self, visible: bool) -> () {
-        unsafe { ffi::gtk_entry_set_visibility(GTK_ENTRY(self.get_widget()), to_gboolean(visible)); }
+        unsafe { ffi::gtk_entry_set_visibility(GTK_ENTRY(self.unwrap_widget()), to_gboolean(visible)); }
     }
 
     fn set_invisible_char(&mut self, ch: i32) -> () {
         unsafe {
-            ffi::gtk_entry_set_invisible_char(GTK_ENTRY(self.get_widget()), ch as c_int);
+            ffi::gtk_entry_set_invisible_char(GTK_ENTRY(self.unwrap_widget()), ch as c_int);
         }
     }
 
     fn unset_invisible_char(&mut self) -> () {
         unsafe {
-            ffi::gtk_entry_unset_invisible_char(GTK_ENTRY(self.get_widget()));
+            ffi::gtk_entry_unset_invisible_char(GTK_ENTRY(self.unwrap_widget()));
         }
     }
 
     fn set_max_length(&mut self, max_length: i32) -> () {
         unsafe {
-            ffi::gtk_entry_set_max_length(GTK_ENTRY(self.get_widget()), max_length as c_int);
+            ffi::gtk_entry_set_max_length(GTK_ENTRY(self.unwrap_widget()), max_length as c_int);
         }
     }
 
     fn get_activates_default(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_entry_get_activates_default(GTK_ENTRY(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_entry_get_activates_default(GTK_ENTRY(self.unwrap_widget()))) }
     }
 
     fn get_has_frame(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_entry_get_has_frame(GTK_ENTRY(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_entry_get_has_frame(GTK_ENTRY(self.unwrap_widget()))) }
     }
 
     fn get_width_chars(&self) -> i32 {
         unsafe {
-            ffi::gtk_entry_get_width_chars(GTK_ENTRY(self.get_widget()))
+            ffi::gtk_entry_get_width_chars(GTK_ENTRY(self.unwrap_widget()))
         }
     }
 
     fn set_activates_default(&mut self, setting: bool) {
-        unsafe { ffi::gtk_entry_set_activates_default(GTK_ENTRY(self.get_widget()), to_gboolean(setting)); }
+        unsafe { ffi::gtk_entry_set_activates_default(GTK_ENTRY(self.unwrap_widget()), to_gboolean(setting)); }
     }
 
     fn set_has_frame(&mut self, setting: bool) {
-        unsafe { ffi::gtk_entry_set_has_frame(GTK_ENTRY(self.get_widget()), to_gboolean(setting)); }
+        unsafe { ffi::gtk_entry_set_has_frame(GTK_ENTRY(self.unwrap_widget()), to_gboolean(setting)); }
     }
 
     fn set_width_chars(&mut self, n_chars: i32) -> () {
         unsafe {
-            ffi::gtk_entry_set_width_chars(GTK_ENTRY(self.get_widget()), n_chars as c_int);
+            ffi::gtk_entry_set_width_chars(GTK_ENTRY(self.unwrap_widget()), n_chars as c_int);
         }
     }
 
     fn get_invisible_char(&self) -> u32 {
         unsafe {
-            ffi::gtk_entry_get_invisible_char(GTK_ENTRY(self.get_widget())) as u32
+            ffi::gtk_entry_get_invisible_char(GTK_ENTRY(self.unwrap_widget())) as u32
         }
     }
 
     fn set_alignment(&mut self, x_align: f32) -> () {
         unsafe {
-            ffi::gtk_entry_set_alignment(GTK_ENTRY(self.get_widget()), x_align as c_float);
+            ffi::gtk_entry_set_alignment(GTK_ENTRY(self.unwrap_widget()), x_align as c_float);
         }
     }
 
     fn get_alignment(&self) -> f32 {
         unsafe {
-            ffi::gtk_entry_get_alignment(GTK_ENTRY(self.get_widget())) as f32
+            ffi::gtk_entry_get_alignment(GTK_ENTRY(self.unwrap_widget())) as f32
         }
     }
 
@@ -133,13 +133,13 @@ pub trait EntryTrait: gtk::WidgetTrait {
         unsafe {
             let c_str = CString::from_slice(text.as_bytes());
 
-            ffi::gtk_entry_set_placeholder_text(GTK_ENTRY(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_entry_set_placeholder_text(GTK_ENTRY(self.unwrap_widget()), c_str.as_ptr())
         }
     }
 
     fn placeholder(&self) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_entry_get_placeholder_text(GTK_ENTRY(self.get_widget()));
+            let c_str = ffi::gtk_entry_get_placeholder_text(GTK_ENTRY(self.unwrap_widget()));
 
             if c_str.is_null() {
                 None
@@ -150,11 +150,11 @@ pub trait EntryTrait: gtk::WidgetTrait {
     }
 
     fn get_overwrite_mode(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_entry_get_overwrite_mode(GTK_ENTRY(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_entry_get_overwrite_mode(GTK_ENTRY(self.unwrap_widget()))) }
     }
 
     fn set_overwrite_mode(&mut self, overwrite: bool) {
-        unsafe { ffi::gtk_entry_set_overwrite_mode(GTK_ENTRY(self.get_widget()), to_gboolean(overwrite)); }
+        unsafe { ffi::gtk_entry_set_overwrite_mode(GTK_ENTRY(self.unwrap_widget()), to_gboolean(overwrite)); }
     }
 
     fn get_layout_offsets(&self) -> (i32, i32) {
@@ -162,78 +162,78 @@ pub trait EntryTrait: gtk::WidgetTrait {
         let y = 0;
 
         unsafe {
-            ffi::gtk_entry_get_layout_offsets(GTK_ENTRY(self.get_widget()), &x, &y);
+            ffi::gtk_entry_get_layout_offsets(GTK_ENTRY(self.unwrap_widget()), &x, &y);
         }
         (x, y)
     }
 
     fn layout_index_to_text_index(&self, layout_index: i32) -> i32 {
         unsafe {
-            ffi::gtk_entry_layout_index_to_text_index(GTK_ENTRY(self.get_widget()), layout_index as c_int) as i32
+            ffi::gtk_entry_layout_index_to_text_index(GTK_ENTRY(self.unwrap_widget()), layout_index as c_int) as i32
         }
     }
 
     fn text_index_to_layout_index(&self, text_index: i32) -> i32 {
         unsafe {
-            ffi::gtk_entry_text_index_to_layout_index(GTK_ENTRY(self.get_widget()), text_index as c_int) as i32
+            ffi::gtk_entry_text_index_to_layout_index(GTK_ENTRY(self.unwrap_widget()), text_index as c_int) as i32
         }
     }
 
     fn get_max_length(&self) -> i32 {
         unsafe {
-            ffi::gtk_entry_get_max_length(GTK_ENTRY(self.get_widget())) as i32
+            ffi::gtk_entry_get_max_length(GTK_ENTRY(self.unwrap_widget())) as i32
         }
     }
 
     fn get_visibility(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_entry_get_visibility(GTK_ENTRY(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_entry_get_visibility(GTK_ENTRY(self.unwrap_widget()))) }
     }
 
     fn set_cursor_hadjustment(&mut self, adjustment: &gtk::Adjustment) -> () {
         unsafe {
-            ffi::gtk_entry_set_cursor_hadjustment(GTK_ENTRY(self.get_widget()), adjustment.get_pointer())
+            ffi::gtk_entry_set_cursor_hadjustment(GTK_ENTRY(self.unwrap_widget()), adjustment.unwrap_pointer())
         }
     }
 
     fn get_cursor_hadjustment(&self) -> gtk::Adjustment {
         unsafe {
-            gtk::Adjustment::wrap_pointer(ffi::gtk_entry_get_cursor_hadjustment(GTK_ENTRY(self.get_widget())))
+            gtk::Adjustment::wrap_pointer(ffi::gtk_entry_get_cursor_hadjustment(GTK_ENTRY(self.unwrap_widget())))
         }
     }
 
     fn set_progress_fraction(&mut self, fraction: f64) -> () {
         unsafe {
-            ffi::gtk_entry_set_progress_fraction(GTK_ENTRY(self.get_widget()), fraction as c_double);
+            ffi::gtk_entry_set_progress_fraction(GTK_ENTRY(self.unwrap_widget()), fraction as c_double);
         }
     }
 
     fn get_progress_fraction(&mut self) -> f64 {
         unsafe {
-            ffi::gtk_entry_get_progress_fraction(GTK_ENTRY(self.get_widget())) as f64
+            ffi::gtk_entry_get_progress_fraction(GTK_ENTRY(self.unwrap_widget())) as f64
         }
     }
 
     fn set_progress_pulse_step(&mut self, pulse_step: f64) -> () {
         unsafe {
-            ffi::gtk_entry_set_progress_pulse_step(GTK_ENTRY(self.get_widget()), pulse_step as c_double);
+            ffi::gtk_entry_set_progress_pulse_step(GTK_ENTRY(self.unwrap_widget()), pulse_step as c_double);
         }
     }
 
     fn get_progress_pulse_step(&mut self) -> f64 {
         unsafe {
-            ffi::gtk_entry_get_progress_pulse_step(GTK_ENTRY(self.get_widget())) as f64
+            ffi::gtk_entry_get_progress_pulse_step(GTK_ENTRY(self.unwrap_widget())) as f64
         }
     }
 
     fn progress_pulse(&mut self) -> () {
         unsafe {
-            ffi::gtk_entry_progress_pulse(GTK_ENTRY(self.get_widget()));
+            ffi::gtk_entry_progress_pulse(GTK_ENTRY(self.unwrap_widget()));
         }
     }
 
     fn reset_im_context(&mut self) -> () {
         unsafe {
-            ffi::gtk_entry_reset_im_context(GTK_ENTRY(self.get_widget()));
+            ffi::gtk_entry_reset_im_context(GTK_ENTRY(self.unwrap_widget()));
         }
     }
 
@@ -241,7 +241,7 @@ pub trait EntryTrait: gtk::WidgetTrait {
         unsafe {
             let c_str = CString::from_slice(stock_id.as_bytes());
 
-            ffi::gtk_entry_set_icon_from_stock(GTK_ENTRY(self.get_widget()), icon_pos, c_str.as_ptr());
+            ffi::gtk_entry_set_icon_from_stock(GTK_ENTRY(self.unwrap_widget()), icon_pos, c_str.as_ptr());
         }
     }
 
@@ -249,19 +249,19 @@ pub trait EntryTrait: gtk::WidgetTrait {
         unsafe {
             let c_str = CString::from_slice(icon_name.as_bytes());
 
-            ffi::gtk_entry_set_icon_from_icon_name(GTK_ENTRY(self.get_widget()), icon_pos, c_str.as_ptr())
+            ffi::gtk_entry_set_icon_from_icon_name(GTK_ENTRY(self.unwrap_widget()), icon_pos, c_str.as_ptr())
         }
     }
 
     fn get_icon_storage_type(&self, icon_pos: EntryIconPosition) -> ImageType {
         unsafe {
-            ffi::gtk_entry_get_icon_storage_type(GTK_ENTRY(self.get_widget()), icon_pos)
+            ffi::gtk_entry_get_icon_storage_type(GTK_ENTRY(self.unwrap_widget()), icon_pos)
         }
     }
 
     fn get_icon_stock(&self, icon_pos: EntryIconPosition) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_entry_get_icon_stock(GTK_ENTRY(self.get_widget()), icon_pos);
+            let c_str = ffi::gtk_entry_get_icon_stock(GTK_ENTRY(self.unwrap_widget()), icon_pos);
 
             if c_str.is_null() {
                 None
@@ -273,7 +273,7 @@ pub trait EntryTrait: gtk::WidgetTrait {
 
     fn get_icon_name(&self, icon_pos: EntryIconPosition) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_entry_get_icon_name(GTK_ENTRY(self.get_widget()), icon_pos);
+            let c_str = ffi::gtk_entry_get_icon_name(GTK_ENTRY(self.unwrap_widget()), icon_pos);
             
             if c_str.is_null() {
                 None
@@ -284,24 +284,24 @@ pub trait EntryTrait: gtk::WidgetTrait {
     }
 
     fn get_icon_activatable(&self, icon_pos: EntryIconPosition) -> bool {
-        unsafe { to_bool(ffi::gtk_entry_get_icon_activatable(GTK_ENTRY(self.get_widget()), icon_pos)) }
+        unsafe { to_bool(ffi::gtk_entry_get_icon_activatable(GTK_ENTRY(self.unwrap_widget()), icon_pos)) }
     }
 
     fn set_icon_activatable(&mut self, icon_pos: EntryIconPosition, activatable: bool) {
-        unsafe { ffi::gtk_entry_set_icon_activatable(GTK_ENTRY(self.get_widget()), icon_pos, to_gboolean(activatable)); }
+        unsafe { ffi::gtk_entry_set_icon_activatable(GTK_ENTRY(self.unwrap_widget()), icon_pos, to_gboolean(activatable)); }
     }
 
     fn get_icon_sensitive(&self, icon_pos: EntryIconPosition) -> bool {
-        unsafe { to_bool(ffi::gtk_entry_get_icon_sensitive(GTK_ENTRY(self.get_widget()), icon_pos)) }
+        unsafe { to_bool(ffi::gtk_entry_get_icon_sensitive(GTK_ENTRY(self.unwrap_widget()), icon_pos)) }
     }
 
     fn set_icon_sensitive(&mut self, icon_pos: EntryIconPosition, sensitive: bool) {
-        unsafe { ffi::gtk_entry_set_icon_sensitive(GTK_ENTRY(self.get_widget()), icon_pos, to_gboolean(sensitive)); }
+        unsafe { ffi::gtk_entry_set_icon_sensitive(GTK_ENTRY(self.unwrap_widget()), icon_pos, to_gboolean(sensitive)); }
     }
 
     fn get_icon_at_pos(&self, x: i32, y: i32) -> i32 {
         unsafe {
-            ffi::gtk_entry_get_icon_at_pos(GTK_ENTRY(self.get_widget()), x, y) as i32
+            ffi::gtk_entry_get_icon_at_pos(GTK_ENTRY(self.unwrap_widget()), x, y) as i32
         }
     }
 
@@ -309,13 +309,13 @@ pub trait EntryTrait: gtk::WidgetTrait {
         unsafe {
             let c_str = CString::from_slice(tooltip.as_bytes());
 
-            ffi::gtk_entry_set_icon_tooltip_text(GTK_ENTRY(self.get_widget()), icon_pos, c_str.as_ptr())
+            ffi::gtk_entry_set_icon_tooltip_text(GTK_ENTRY(self.unwrap_widget()), icon_pos, c_str.as_ptr())
         }
     }
 
     fn get_icon_tooltip_text(&self, icon_pos: EntryIconPosition) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_entry_get_icon_tooltip_text(GTK_ENTRY(self.get_widget()), icon_pos);
+            let c_str = ffi::gtk_entry_get_icon_tooltip_text(GTK_ENTRY(self.unwrap_widget()), icon_pos);
             let ret = if c_str.is_null() {
                 None
             } else {
@@ -331,13 +331,13 @@ pub trait EntryTrait: gtk::WidgetTrait {
         unsafe {
             let c_str = CString::from_slice(tooltip.as_bytes());
 
-            ffi::gtk_entry_set_icon_tooltip_markup(GTK_ENTRY(self.get_widget()), icon_pos, c_str.as_ptr())
+            ffi::gtk_entry_set_icon_tooltip_markup(GTK_ENTRY(self.unwrap_widget()), icon_pos, c_str.as_ptr())
         }
     }
 
     fn get_icon_tooltip_markup(&self, icon_pos: EntryIconPosition) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_entry_get_icon_tooltip_markup(GTK_ENTRY(self.get_widget()), icon_pos);
+            let c_str = ffi::gtk_entry_get_icon_tooltip_markup(GTK_ENTRY(self.unwrap_widget()), icon_pos);
             let ret = if c_str.is_null() {
                 None
             } else {
@@ -351,31 +351,31 @@ pub trait EntryTrait: gtk::WidgetTrait {
 
     fn get_current_icon_draw_source(&self) -> i32 {
         unsafe {
-            ffi::gtk_entry_get_current_icon_drag_source(GTK_ENTRY(self.get_widget())) as i32
+            ffi::gtk_entry_get_current_icon_drag_source(GTK_ENTRY(self.unwrap_widget())) as i32
         }
     }
 
     fn set_input_purpose(&mut self, purpose: InputPurpose) -> () {
         unsafe {
-            ffi::gtk_entry_set_input_purpose(GTK_ENTRY(self.get_widget()), purpose)
+            ffi::gtk_entry_set_input_purpose(GTK_ENTRY(self.unwrap_widget()), purpose)
         }
     }
 
     fn get_input_purpose(&self) -> InputPurpose {
         unsafe {
-            ffi::gtk_entry_get_input_purpose(GTK_ENTRY(self.get_widget()))
+            ffi::gtk_entry_get_input_purpose(GTK_ENTRY(self.unwrap_widget()))
         }
     }
 
     fn set_input_hints(&mut self, hints: InputHints) -> () {
         unsafe {
-            ffi::gtk_entry_set_input_hints(GTK_ENTRY(self.get_widget()), hints)
+            ffi::gtk_entry_set_input_hints(GTK_ENTRY(self.unwrap_widget()), hints)
         }
     }
 
     fn get_input_hints(&self) -> InputHints {
         unsafe {
-            ffi::gtk_entry_get_input_hints(GTK_ENTRY(self.get_widget()))
+            ffi::gtk_entry_get_input_hints(GTK_ENTRY(self.unwrap_widget()))
         }
     }
 }

--- a/src/gtk/traits/file_chooser.rs
+++ b/src/gtk/traits/file_chooser.rs
@@ -23,64 +23,64 @@ use libc::c_char;
 
 pub trait FileChooserTrait: gtk::WidgetTrait {
     fn set_action(&self, action: gtk::FileChooserAction) -> () {
-        unsafe { ffi::gtk_file_chooser_set_action(GTK_FILE_CHOOSER(self.get_widget()), action) }
+        unsafe { ffi::gtk_file_chooser_set_action(GTK_FILE_CHOOSER(self.unwrap_widget()), action) }
     }
 
     fn get_action(&self) -> gtk::FileChooserAction {
-        unsafe { ffi::gtk_file_chooser_get_action(GTK_FILE_CHOOSER(self.get_widget())) }
+        unsafe { ffi::gtk_file_chooser_get_action(GTK_FILE_CHOOSER(self.unwrap_widget())) }
     }
 
     fn set_local_only(&self, local_only: bool) -> () {
-        unsafe { ffi::gtk_file_chooser_set_local_only(GTK_FILE_CHOOSER(self.get_widget()), to_gboolean(local_only)) }
+        unsafe { ffi::gtk_file_chooser_set_local_only(GTK_FILE_CHOOSER(self.unwrap_widget()), to_gboolean(local_only)) }
     }
 
     fn get_local_only(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_file_chooser_get_local_only(GTK_FILE_CHOOSER(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_file_chooser_get_local_only(GTK_FILE_CHOOSER(self.unwrap_widget()))) }
     }
 
     fn set_select_multiple(&self, select_multiple: bool) -> () {
-        unsafe { ffi::gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(self.get_widget()), to_gboolean(select_multiple)) }
+        unsafe { ffi::gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(self.unwrap_widget()), to_gboolean(select_multiple)) }
     }
 
     fn get_select_multiple(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_file_chooser_get_select_multiple(GTK_FILE_CHOOSER(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_file_chooser_get_select_multiple(GTK_FILE_CHOOSER(self.unwrap_widget()))) }
     }
 
     fn set_show_hidden(&self, show_hidden: bool) -> () {
-        unsafe { ffi::gtk_file_chooser_set_show_hidden(GTK_FILE_CHOOSER(self.get_widget()), to_gboolean(show_hidden)) }
+        unsafe { ffi::gtk_file_chooser_set_show_hidden(GTK_FILE_CHOOSER(self.unwrap_widget()), to_gboolean(show_hidden)) }
     }
 
     fn get_show_hidden(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_file_chooser_get_show_hidden(GTK_FILE_CHOOSER(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_file_chooser_get_show_hidden(GTK_FILE_CHOOSER(self.unwrap_widget()))) }
     }
 
     fn set_do_overwrite_confirmation(&self, do_overwrite_confirmation: bool) -> () {
-        unsafe { ffi::gtk_file_chooser_set_do_overwrite_confirmation(GTK_FILE_CHOOSER(self.get_widget()), to_gboolean(do_overwrite_confirmation)) }
+        unsafe { ffi::gtk_file_chooser_set_do_overwrite_confirmation(GTK_FILE_CHOOSER(self.unwrap_widget()), to_gboolean(do_overwrite_confirmation)) }
     }
 
     fn get_do_overwrite_confirmation(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_file_chooser_get_do_overwrite_confirmation(GTK_FILE_CHOOSER(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_file_chooser_get_do_overwrite_confirmation(GTK_FILE_CHOOSER(self.unwrap_widget()))) }
     }
 
     fn set_create_folders(&self, create_folders: bool) -> () {
-        unsafe { ffi::gtk_file_chooser_set_create_folders(GTK_FILE_CHOOSER(self.get_widget()), to_gboolean(create_folders)) }
+        unsafe { ffi::gtk_file_chooser_set_create_folders(GTK_FILE_CHOOSER(self.unwrap_widget()), to_gboolean(create_folders)) }
     }
 
     fn get_create_folders(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_file_chooser_get_create_folders(GTK_FILE_CHOOSER(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_file_chooser_get_create_folders(GTK_FILE_CHOOSER(self.unwrap_widget()))) }
     }
 
     fn set_current_name(&self, name: &str) -> () {
         unsafe {
             let c_str = CString::from_slice(name.as_bytes());
 
-            ffi::gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(self.unwrap_widget()), c_str.as_ptr())
         }
     }
 
     fn get_current_name(&self) -> Option<String> {
         unsafe {
-            let name = ffi::gtk_file_chooser_get_current_name(GTK_FILE_CHOOSER(self.get_widget()));
+            let name = ffi::gtk_file_chooser_get_current_name(GTK_FILE_CHOOSER(self.unwrap_widget()));
 
             if name.is_null() {
                 None
@@ -94,13 +94,13 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
         unsafe {
             let c_str = CString::from_slice(filename.as_bytes());
 
-            to_bool(ffi::gtk_file_chooser_set_filename(GTK_FILE_CHOOSER(self.get_widget()), c_str.as_ptr()))
+            to_bool(ffi::gtk_file_chooser_set_filename(GTK_FILE_CHOOSER(self.unwrap_widget()), c_str.as_ptr()))
         }
     }
 
     fn get_filename(&self) -> Option<String> {
         unsafe {
-            let filename = ffi::gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(self.get_widget()));
+            let filename = ffi::gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(self.unwrap_widget()));
 
             if filename.is_null() {
                 None
@@ -114,7 +114,7 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
         unsafe {
             let c_str = CString::from_slice(filename.as_bytes());
 
-            to_bool(ffi::gtk_file_chooser_select_filename(GTK_FILE_CHOOSER(self.get_widget()), c_str.as_ptr()))
+            to_bool(ffi::gtk_file_chooser_select_filename(GTK_FILE_CHOOSER(self.unwrap_widget()), c_str.as_ptr()))
         }
     }
 
@@ -122,20 +122,20 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
         unsafe {
             let c_str = CString::from_slice(filename.as_bytes());
 
-            ffi::gtk_file_chooser_unselect_filename(GTK_FILE_CHOOSER(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_file_chooser_unselect_filename(GTK_FILE_CHOOSER(self.unwrap_widget()), c_str.as_ptr())
         }
     }
 
     fn select_all(&self) -> () {
-        unsafe { ffi::gtk_file_chooser_select_all(GTK_FILE_CHOOSER(self.get_widget())) }
+        unsafe { ffi::gtk_file_chooser_select_all(GTK_FILE_CHOOSER(self.unwrap_widget())) }
     }
 
     fn unselect_all(&self) -> () {
-        unsafe { ffi::gtk_file_chooser_unselect_all(GTK_FILE_CHOOSER(self.get_widget())) }
+        unsafe { ffi::gtk_file_chooser_unselect_all(GTK_FILE_CHOOSER(self.unwrap_widget())) }
     }
 
     fn get_filenames(&self) -> glib::SList<String> {
-        let tmp_pointer = unsafe { ffi::gtk_file_chooser_get_filenames(GTK_FILE_CHOOSER(self.get_widget())) };
+        let tmp_pointer = unsafe { ffi::gtk_file_chooser_get_filenames(GTK_FILE_CHOOSER(self.unwrap_widget())) };
 
         if tmp_pointer.is_null() {
             glib::SList::new()
@@ -156,13 +156,13 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
         unsafe {
             let c_str = CString::from_slice(filename.as_bytes());
 
-            to_bool(ffi::gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(self.get_widget()), c_str.as_ptr()))
+            to_bool(ffi::gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(self.unwrap_widget()), c_str.as_ptr()))
         }
     }
 
     fn get_current_folder(&self) -> Option<String> {
         unsafe {
-            let filename = ffi::gtk_file_chooser_get_current_folder(GTK_FILE_CHOOSER(self.get_widget()));
+            let filename = ffi::gtk_file_chooser_get_current_folder(GTK_FILE_CHOOSER(self.unwrap_widget()));
 
             if filename.is_null() {
                 None
@@ -176,13 +176,13 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
         unsafe {
             let c_str = CString::from_slice(uri.as_bytes());
 
-            to_bool(ffi::gtk_file_chooser_set_uri(GTK_FILE_CHOOSER(self.get_widget()), c_str.as_ptr()))
+            to_bool(ffi::gtk_file_chooser_set_uri(GTK_FILE_CHOOSER(self.unwrap_widget()), c_str.as_ptr()))
         }
     }
 
     fn get_uri(&self) -> Option<String> {
         unsafe {
-            let uri = ffi::gtk_file_chooser_get_uri(GTK_FILE_CHOOSER(self.get_widget()));
+            let uri = ffi::gtk_file_chooser_get_uri(GTK_FILE_CHOOSER(self.unwrap_widget()));
 
             if uri.is_null() {
                 None
@@ -196,7 +196,7 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
         unsafe {
             let c_str = CString::from_slice(uri.as_bytes());
 
-            to_bool(ffi::gtk_file_chooser_select_uri(GTK_FILE_CHOOSER(self.get_widget()), c_str.as_ptr()))
+            to_bool(ffi::gtk_file_chooser_select_uri(GTK_FILE_CHOOSER(self.unwrap_widget()), c_str.as_ptr()))
         }
     }
 
@@ -204,12 +204,12 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
         unsafe {
             let c_str = CString::from_slice(uri.as_bytes());
 
-            ffi::gtk_file_chooser_unselect_uri(GTK_FILE_CHOOSER(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_file_chooser_unselect_uri(GTK_FILE_CHOOSER(self.unwrap_widget()), c_str.as_ptr())
         }
     }
 
     fn get_uris(&self) -> glib::SList<String> {
-        let tmp_pointer = unsafe { ffi::gtk_file_chooser_get_uris(GTK_FILE_CHOOSER(self.get_widget())) };
+        let tmp_pointer = unsafe { ffi::gtk_file_chooser_get_uris(GTK_FILE_CHOOSER(self.unwrap_widget())) };
 
         if tmp_pointer.is_null() {
             glib::SList::new()
@@ -230,13 +230,13 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
         unsafe {
             let c_str = CString::from_slice(uri.as_bytes());
 
-            to_bool(ffi::gtk_file_chooser_set_current_folder_uri(GTK_FILE_CHOOSER(self.get_widget()), c_str.as_ptr()))
+            to_bool(ffi::gtk_file_chooser_set_current_folder_uri(GTK_FILE_CHOOSER(self.unwrap_widget()), c_str.as_ptr()))
         }
     }
 
     fn get_current_folder_uri(&self) -> Option<String> {
         unsafe {
-            let uri = ffi::gtk_file_chooser_get_current_folder_uri(GTK_FILE_CHOOSER(self.get_widget()));
+            let uri = ffi::gtk_file_chooser_get_current_folder_uri(GTK_FILE_CHOOSER(self.unwrap_widget()));
 
             if uri.is_null() {
                 None
@@ -247,40 +247,40 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
     }
 
     fn set_preview_widget<T: gtk::WidgetTrait>(&self, preview_widget: &T) -> () {
-        unsafe { ffi::gtk_file_chooser_set_preview_widget(GTK_FILE_CHOOSER(self.get_widget()), preview_widget.get_widget()) }
+        unsafe { ffi::gtk_file_chooser_set_preview_widget(GTK_FILE_CHOOSER(self.unwrap_widget()), preview_widget.unwrap_widget()) }
     }
 
     fn get_preview_widget<T: gtk::WidgetTrait>(&self) -> Option<T> {
         unsafe {
-            let tmp_pointer = ffi::gtk_file_chooser_get_preview_widget(GTK_FILE_CHOOSER(self.get_widget()));
+            let tmp_pointer = ffi::gtk_file_chooser_get_preview_widget(GTK_FILE_CHOOSER(self.unwrap_widget()));
 
             if tmp_pointer.is_null() {
                 None
             } else {
-                Some(gtk::FFIWidget::wrap(tmp_pointer))
+                Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
             }
         }
     }
 
     fn set_preview_widget_active(&self, preview_widget_active: bool) -> () {
-        unsafe { ffi::gtk_file_chooser_set_preview_widget_active(GTK_FILE_CHOOSER(self.get_widget()), to_gboolean(preview_widget_active)) }
+        unsafe { ffi::gtk_file_chooser_set_preview_widget_active(GTK_FILE_CHOOSER(self.unwrap_widget()), to_gboolean(preview_widget_active)) }
     }
 
     fn get_preview_widget_active(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_file_chooser_get_preview_widget_active(GTK_FILE_CHOOSER(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_file_chooser_get_preview_widget_active(GTK_FILE_CHOOSER(self.unwrap_widget()))) }
     }
 
     fn set_use_preview_label(&self, use_label: bool) -> () {
-        unsafe { ffi::gtk_file_chooser_set_use_preview_label(GTK_FILE_CHOOSER(self.get_widget()), to_gboolean(use_label)) }
+        unsafe { ffi::gtk_file_chooser_set_use_preview_label(GTK_FILE_CHOOSER(self.unwrap_widget()), to_gboolean(use_label)) }
     }
 
     fn get_use_preview_label(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_file_chooser_get_use_preview_label(GTK_FILE_CHOOSER(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_file_chooser_get_use_preview_label(GTK_FILE_CHOOSER(self.unwrap_widget()))) }
     }
 
     fn get_preview_filename(&self) -> Option<String> {
         unsafe {
-            let filename = ffi::gtk_file_chooser_get_preview_filename(GTK_FILE_CHOOSER(self.get_widget()));
+            let filename = ffi::gtk_file_chooser_get_preview_filename(GTK_FILE_CHOOSER(self.unwrap_widget()));
 
             if filename.is_null() {
                 None
@@ -292,7 +292,7 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
 
     fn get_preview_uri(&self) -> Option<String> {
         unsafe {
-            let uri = ffi::gtk_file_chooser_get_preview_uri(GTK_FILE_CHOOSER(self.get_widget()));
+            let uri = ffi::gtk_file_chooser_get_preview_uri(GTK_FILE_CHOOSER(self.unwrap_widget()));
 
             if uri.is_null() {
                 None
@@ -303,35 +303,35 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
     }
 
     fn set_extra_widget<T: gtk::WidgetTrait>(&self, extra_widget: &T) -> () {
-        unsafe { ffi::gtk_file_chooser_set_extra_widget(GTK_FILE_CHOOSER(self.get_widget()), extra_widget.get_widget()) }
+        unsafe { ffi::gtk_file_chooser_set_extra_widget(GTK_FILE_CHOOSER(self.unwrap_widget()), extra_widget.unwrap_widget()) }
     }
 
     fn get_extra_widget<T: gtk::WidgetTrait>(&self) -> Option<T> {
         unsafe {
-            let tmp = ffi::gtk_file_chooser_get_extra_widget(GTK_FILE_CHOOSER(self.get_widget()));
+            let tmp = ffi::gtk_file_chooser_get_extra_widget(GTK_FILE_CHOOSER(self.unwrap_widget()));
 
             if tmp.is_null() {
                 None
             } else {
-                Some(gtk::FFIWidget::wrap(tmp))
+                Some(gtk::FFIWidget::wrap_widget(tmp))
             }
         }
     }
 
     fn add_filter(&self, filter: &gtk::FileFilter) -> () {
-        unsafe { ffi::gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(self.get_widget()), filter.get_pointer()) }
+        unsafe { ffi::gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(self.unwrap_widget()), filter.unwrap_pointer()) }
     }
 
     fn remove_filter(&self, filter: &gtk::FileFilter) -> () {
-        unsafe { ffi::gtk_file_chooser_remove_filter(GTK_FILE_CHOOSER(self.get_widget()), filter.get_pointer()) }
+        unsafe { ffi::gtk_file_chooser_remove_filter(GTK_FILE_CHOOSER(self.unwrap_widget()), filter.unwrap_pointer()) }
     }
 
     fn set_filter(&self, filter: &gtk::FileFilter) -> () {
-        unsafe { ffi::gtk_file_chooser_set_filter(GTK_FILE_CHOOSER(self.get_widget()), filter.get_pointer()) }
+        unsafe { ffi::gtk_file_chooser_set_filter(GTK_FILE_CHOOSER(self.unwrap_widget()), filter.unwrap_pointer()) }
     }
 
     fn get_filter(&self) -> Option<gtk::FileFilter> {
-        let tmp = unsafe { ffi::gtk_file_chooser_get_filter(GTK_FILE_CHOOSER(self.get_widget())) };
+        let tmp = unsafe { ffi::gtk_file_chooser_get_filter(GTK_FILE_CHOOSER(self.unwrap_widget())) };
 
         gtk::FileFilter::wrap(tmp)
     }
@@ -340,7 +340,7 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
         unsafe {
             let c_str = CString::from_slice(folder.as_bytes());
 
-            to_bool(ffi::gtk_file_chooser_add_shortcut_folder(GTK_FILE_CHOOSER(self.get_widget()), c_str.as_ptr(), &mut error.unwrap()))
+            to_bool(ffi::gtk_file_chooser_add_shortcut_folder(GTK_FILE_CHOOSER(self.unwrap_widget()), c_str.as_ptr(), &mut error.unwrap()))
         }
     }
 
@@ -348,7 +348,7 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
         unsafe {
             let c_str = CString::from_slice(folder.as_bytes());
 
-            to_bool(ffi::gtk_file_chooser_remove_shortcut_folder(GTK_FILE_CHOOSER(self.get_widget()), c_str.as_ptr(), &mut error.unwrap()))
+            to_bool(ffi::gtk_file_chooser_remove_shortcut_folder(GTK_FILE_CHOOSER(self.unwrap_widget()), c_str.as_ptr(), &mut error.unwrap()))
         }
     }
 
@@ -356,7 +356,7 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
         unsafe {
             let c_str = CString::from_slice(uri.as_bytes());
 
-            to_bool(ffi::gtk_file_chooser_add_shortcut_folder(GTK_FILE_CHOOSER(self.get_widget()), c_str.as_ptr(), &mut error.unwrap()))
+            to_bool(ffi::gtk_file_chooser_add_shortcut_folder(GTK_FILE_CHOOSER(self.unwrap_widget()), c_str.as_ptr(), &mut error.unwrap()))
         }
     }
 
@@ -364,7 +364,7 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
         unsafe {
             let c_str = CString::from_slice(uri.as_bytes());
 
-            to_bool(ffi::gtk_file_chooser_remove_shortcut_folder(GTK_FILE_CHOOSER(self.get_widget()), c_str.as_ptr(), &mut error.unwrap()))
+            to_bool(ffi::gtk_file_chooser_remove_shortcut_folder(GTK_FILE_CHOOSER(self.unwrap_widget()), c_str.as_ptr(), &mut error.unwrap()))
         }
     }
 }

--- a/src/gtk/traits/font_chooser.rs
+++ b/src/gtk/traits/font_chooser.rs
@@ -22,11 +22,11 @@ use libc::c_char;
 
 pub trait FontChooserTrait: gtk::WidgetTrait {
     fn get_font_size(&self) -> i32 {
-        unsafe { ffi::gtk_font_chooser_get_font_size(GTK_FONT_CHOOSER(self.get_widget())) }
+        unsafe { ffi::gtk_font_chooser_get_font_size(GTK_FONT_CHOOSER(self.unwrap_widget())) }
     }
 
     fn get_font(&self) -> Option<String> {
-        let tmp = unsafe { ffi::gtk_font_chooser_get_font(GTK_FONT_CHOOSER(self.get_widget())) as *const c_char };
+        let tmp = unsafe { ffi::gtk_font_chooser_get_font(GTK_FONT_CHOOSER(self.unwrap_widget())) as *const c_char };
 
         if tmp.is_null() {
             None
@@ -39,13 +39,13 @@ pub trait FontChooserTrait: gtk::WidgetTrait {
         unsafe {
             let c_str = CString::from_slice(font_name.as_bytes());
 
-            ffi::gtk_font_chooser_set_font(GTK_FONT_CHOOSER(self.get_widget()), c_str.as_ptr() as *mut c_char)
+            ffi::gtk_font_chooser_set_font(GTK_FONT_CHOOSER(self.unwrap_widget()), c_str.as_ptr() as *mut c_char)
         }
     }
 
     fn get_preview_text(&self) -> Option<String> {
         unsafe {
-            let tmp = ffi::gtk_font_chooser_get_preview_text(GTK_FONT_CHOOSER(self.get_widget()));
+            let tmp = ffi::gtk_font_chooser_get_preview_text(GTK_FONT_CHOOSER(self.unwrap_widget()));
 
             if tmp.is_null() {
                 None
@@ -59,16 +59,16 @@ pub trait FontChooserTrait: gtk::WidgetTrait {
         unsafe {
             let c_str = CString::from_slice(text.as_bytes());
 
-            ffi::gtk_font_chooser_set_preview_text(GTK_FONT_CHOOSER(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_font_chooser_set_preview_text(GTK_FONT_CHOOSER(self.unwrap_widget()), c_str.as_ptr())
         }
     }
 
     fn get_show_preview_entry(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_font_chooser_get_show_preview_entry(GTK_FONT_CHOOSER(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_font_chooser_get_show_preview_entry(GTK_FONT_CHOOSER(self.unwrap_widget()))) }
     }
 
     fn set_show_preview_entry(&self, show_preview_entry: bool) {
-        unsafe { ffi::gtk_font_chooser_set_show_preview_entry(GTK_FONT_CHOOSER(self.get_widget()),
+        unsafe { ffi::gtk_font_chooser_set_show_preview_entry(GTK_FONT_CHOOSER(self.unwrap_widget()),
                                                               to_gboolean(show_preview_entry));
         }
     }

--- a/src/gtk/traits/frame.rs
+++ b/src/gtk/traits/frame.rs
@@ -27,21 +27,21 @@ pub trait FrameTrait: gtk::WidgetTrait + gtk::ContainerTrait {
             Some(l) => unsafe {
                 let c_str = CString::from_slice(l.as_bytes());
 
-                ffi::gtk_frame_set_label(GTK_FRAME(self.get_widget()), c_str.as_ptr())
+                ffi::gtk_frame_set_label(GTK_FRAME(self.unwrap_widget()), c_str.as_ptr())
             },
-            None    => unsafe { ffi::gtk_frame_set_label(GTK_FRAME(self.get_widget()), ptr::null()) }
+            None    => unsafe { ffi::gtk_frame_set_label(GTK_FRAME(self.unwrap_widget()), ptr::null()) }
         };
     }
 
     fn set_label_widget<T: gtk::WidgetTrait>(&mut self, label_widget: &T) -> () {
         unsafe {
-            ffi::gtk_frame_set_label_widget(GTK_FRAME(self.get_widget()), label_widget.get_widget());
+            ffi::gtk_frame_set_label_widget(GTK_FRAME(self.unwrap_widget()), label_widget.unwrap_widget());
         }
     }
 
     fn set_label_align(&mut self, x_align: f32, y_align: f32) -> () {
         unsafe {
-            ffi::gtk_frame_set_label_align(GTK_FRAME(self.get_widget()), x_align as c_float, y_align as c_float);
+            ffi::gtk_frame_set_label_align(GTK_FRAME(self.unwrap_widget()), x_align as c_float, y_align as c_float);
         }
     }
 
@@ -49,19 +49,19 @@ pub trait FrameTrait: gtk::WidgetTrait + gtk::ContainerTrait {
         let mut x_align = 0.;
         let mut y_align = 0.;
         unsafe {
-            ffi::gtk_frame_get_label_align(GTK_FRAME(self.get_widget()), &mut x_align, &mut y_align);
+            ffi::gtk_frame_get_label_align(GTK_FRAME(self.unwrap_widget()), &mut x_align, &mut y_align);
         }
         (x_align as f32, y_align as f32)
     }
 
     fn set_shadow_type(&mut self, st_type: ShadowType) -> () {
         unsafe {
-            ffi::gtk_frame_set_shadow_type(GTK_FRAME(self.get_widget()), st_type);
+            ffi::gtk_frame_set_shadow_type(GTK_FRAME(self.unwrap_widget()), st_type);
         }
     }
 
     fn get_label(&self) -> Option<String> {
-        let c_str = unsafe { ffi::gtk_frame_get_label(GTK_FRAME(self.get_widget())) };
+        let c_str = unsafe { ffi::gtk_frame_get_label(GTK_FRAME(self.unwrap_widget())) };
         
         if c_str.is_null() {
             None
@@ -72,7 +72,7 @@ pub trait FrameTrait: gtk::WidgetTrait + gtk::ContainerTrait {
 
     fn gtk_frame_get_shadow_type(&self) -> ShadowType {
         unsafe {
-            ffi::gtk_frame_get_shadow_type(GTK_FRAME(self.get_widget()))
+            ffi::gtk_frame_get_shadow_type(GTK_FRAME(self.unwrap_widget()))
         }
     }
 }

--- a/src/gtk/traits/label.rs
+++ b/src/gtk/traits/label.rs
@@ -26,7 +26,7 @@ pub trait LabelTrait: gtk::WidgetTrait {
         unsafe {
             let c_str = CString::from_slice(text.as_bytes());
 
-            ffi::gtk_label_set_label(GTK_LABEL(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_label_set_label(GTK_LABEL(self.unwrap_widget()), c_str.as_ptr())
         }
     }
 
@@ -34,13 +34,13 @@ pub trait LabelTrait: gtk::WidgetTrait {
         unsafe {
             let c_str = CString::from_slice(text.as_bytes());
 
-	    ffi::gtk_label_set_text(GTK_LABEL(self.get_widget()), c_str.as_ptr())
+	    ffi::gtk_label_set_text(GTK_LABEL(self.unwrap_widget()), c_str.as_ptr())
         }
     }
 
     fn set_justify(&mut self, jtype: Justification) -> () {
         unsafe {
-            ffi::gtk_label_set_justify(GTK_LABEL(self.get_widget()), jtype);
+            ffi::gtk_label_set_justify(GTK_LABEL(self.unwrap_widget()), jtype);
         }
     }
 
@@ -48,7 +48,7 @@ pub trait LabelTrait: gtk::WidgetTrait {
         unsafe {
             let c_str = CString::from_slice(text.as_bytes());
 
-            ffi::gtk_label_set_markup(GTK_LABEL(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_label_set_markup(GTK_LABEL(self.unwrap_widget()), c_str.as_ptr())
         }
     }
 
@@ -56,7 +56,7 @@ pub trait LabelTrait: gtk::WidgetTrait {
         unsafe {
             let c_str = CString::from_slice(text.as_bytes());
 
-            ffi::gtk_label_set_markup_with_mnemonic(GTK_LABEL(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_label_set_markup_with_mnemonic(GTK_LABEL(self.unwrap_widget()), c_str.as_ptr())
         }
     }
 
@@ -64,7 +64,7 @@ pub trait LabelTrait: gtk::WidgetTrait {
         unsafe {
             let c_str = CString::from_slice(text.as_bytes());
 
-            ffi::gtk_label_set_pattern(GTK_LABEL(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_label_set_pattern(GTK_LABEL(self.unwrap_widget()), c_str.as_ptr())
         }
     }
 
@@ -72,41 +72,41 @@ pub trait LabelTrait: gtk::WidgetTrait {
         unsafe {
             let c_str = CString::from_slice(text.as_bytes());
 
-            ffi::gtk_label_set_text_with_mnemonic(GTK_LABEL(self.get_widget()), c_str.as_ptr());
+            ffi::gtk_label_set_text_with_mnemonic(GTK_LABEL(self.unwrap_widget()), c_str.as_ptr());
         }
     }
 
     fn set_width_chars(&mut self, n_chars: i32) -> () {
         unsafe {
-            ffi::gtk_label_set_width_chars(GTK_LABEL(self.get_widget()), n_chars as c_int);
+            ffi::gtk_label_set_width_chars(GTK_LABEL(self.unwrap_widget()), n_chars as c_int);
         }
     }
 
     fn set_max_width_chars(&mut self, n_chars: i32) -> () {
         unsafe {
-            ffi::gtk_label_set_max_width_chars(GTK_LABEL(self.get_widget()), n_chars as c_int);
+            ffi::gtk_label_set_max_width_chars(GTK_LABEL(self.unwrap_widget()), n_chars as c_int);
         }
     }
 
     fn set_line_wrap(&mut self, wrap: bool) -> () {
-        unsafe { ffi::gtk_label_set_line_wrap(GTK_LABEL(self.get_widget()), to_gboolean(wrap)); }
+        unsafe { ffi::gtk_label_set_line_wrap(GTK_LABEL(self.unwrap_widget()), to_gboolean(wrap)); }
     }
 
     fn get_line_wrap(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_label_get_line_wrap(GTK_LABEL(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_label_get_line_wrap(GTK_LABEL(self.unwrap_widget()))) }
     }
 
     #[cfg(any(feature = "GTK_3_10",feature = "GTK_3_12", feature = "GTK_3_14"))]
     fn set_lines(&mut self, lines: i32) -> () {
         unsafe {
-            ffi::gtk_label_set_lines(GTK_LABEL(self.get_widget()), lines as c_int);
+            ffi::gtk_label_set_lines(GTK_LABEL(self.unwrap_widget()), lines as c_int);
         }
     }
 
     #[cfg(any(feature = "GTK_3_10",feature = "GTK_3_12", feature = "GTK_3_14"))]
     fn get_lines(&self) -> i32 {
         unsafe {
-            ffi::gtk_label_get_lines(GTK_LABEL(self.get_widget())) as c_int
+            ffi::gtk_label_get_lines(GTK_LABEL(self.unwrap_widget())) as c_int
         }
     }
 
@@ -114,60 +114,60 @@ pub trait LabelTrait: gtk::WidgetTrait {
         let x = 0;
         let y = 0;
         unsafe {
-            ffi::gtk_label_get_layout_offsets(GTK_LABEL(self.get_widget()), &x, &y);
+            ffi::gtk_label_get_layout_offsets(GTK_LABEL(self.unwrap_widget()), &x, &y);
         }
         (x, y)
     }
 
     fn get_mnemonic_keyval(&self) -> u32 {
         unsafe {
-            ffi::gtk_label_get_mnemonic_keyval(GTK_LABEL(self.get_widget())) as u32
+            ffi::gtk_label_get_mnemonic_keyval(GTK_LABEL(self.unwrap_widget())) as u32
         }
     }
 
     fn set_selectable(&mut self, selectable: bool) -> () {
-        unsafe { ffi::gtk_label_set_selectable(GTK_LABEL(self.get_widget()), to_gboolean(selectable)); }
+        unsafe { ffi::gtk_label_set_selectable(GTK_LABEL(self.unwrap_widget()), to_gboolean(selectable)); }
     }
 
     fn get_selectable(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_label_get_selectable(GTK_LABEL(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_label_get_selectable(GTK_LABEL(self.unwrap_widget()))) }
     }
 
     fn set_use_markup(&mut self, use_markup: bool) -> () {
-        unsafe { ffi::gtk_label_set_use_markup(GTK_LABEL(self.get_widget()), to_gboolean(use_markup)); }
+        unsafe { ffi::gtk_label_set_use_markup(GTK_LABEL(self.unwrap_widget()), to_gboolean(use_markup)); }
     }
 
     fn get_use_markup(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_label_get_use_markup(GTK_LABEL(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_label_get_use_markup(GTK_LABEL(self.unwrap_widget()))) }
     }
 
     fn set_use_underline(&mut self, use_underline: bool) -> () {
-        unsafe { ffi::gtk_label_set_use_underline(GTK_LABEL(self.get_widget()), to_gboolean(use_underline)); }
+        unsafe { ffi::gtk_label_set_use_underline(GTK_LABEL(self.unwrap_widget()), to_gboolean(use_underline)); }
     }
 
     fn get_use_underline(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_label_get_use_underline(GTK_LABEL(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_label_get_use_underline(GTK_LABEL(self.unwrap_widget()))) }
     }
 
     fn set_single_line_mode(&mut self, single_line_mode: bool) -> () {
-        unsafe { ffi::gtk_label_set_single_line_mode(GTK_LABEL(self.get_widget()), to_gboolean(single_line_mode)); }
+        unsafe { ffi::gtk_label_set_single_line_mode(GTK_LABEL(self.unwrap_widget()), to_gboolean(single_line_mode)); }
     }
 
     fn get_single_line_mode(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_label_get_single_line_mode(GTK_LABEL(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_label_get_single_line_mode(GTK_LABEL(self.unwrap_widget()))) }
     }
 
     fn set_track_visited_links(&mut self, track_visited_links: bool) -> () {
-        unsafe { ffi::gtk_label_set_track_visited_links(GTK_LABEL(self.get_widget()), to_gboolean(track_visited_links)); }
+        unsafe { ffi::gtk_label_set_track_visited_links(GTK_LABEL(self.unwrap_widget()), to_gboolean(track_visited_links)); }
     }
 
     fn get_track_visited_links(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_label_get_track_visited_links(GTK_LABEL(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_label_get_track_visited_links(GTK_LABEL(self.unwrap_widget()))) }
     }
 
     fn get_text(&self) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_label_get_text(GTK_LABEL(self.get_widget()));
+            let c_str = ffi::gtk_label_get_text(GTK_LABEL(self.unwrap_widget()));
 
             if c_str.is_null() {
                 None
@@ -179,7 +179,7 @@ pub trait LabelTrait: gtk::WidgetTrait {
 
     fn get_label(&self) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_label_get_label(GTK_LABEL(self.get_widget()));
+            let c_str = ffi::gtk_label_get_label(GTK_LABEL(self.unwrap_widget()));
             if c_str.is_null() {
                 None
             } else {
@@ -190,7 +190,7 @@ pub trait LabelTrait: gtk::WidgetTrait {
 
     fn get_current_uri(&self) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_label_get_current_uri(GTK_LABEL(self.get_widget()));
+            let c_str = ffi::gtk_label_get_current_uri(GTK_LABEL(self.unwrap_widget()));
             if c_str.is_null() {
                 None
             } else {
@@ -201,25 +201,25 @@ pub trait LabelTrait: gtk::WidgetTrait {
 
     fn select_region(&mut self, start_offset: i32, end_offset: i32) -> () {
         unsafe {
-            ffi::gtk_label_select_region(GTK_LABEL(self.get_widget()), start_offset as c_int, end_offset as c_int);
+            ffi::gtk_label_select_region(GTK_LABEL(self.unwrap_widget()), start_offset as c_int, end_offset as c_int);
         }
     }
 
     fn get_justify(&self) -> Justification {
         unsafe {
-            ffi::gtk_label_get_justify(GTK_LABEL(self.get_widget()))
+            ffi::gtk_label_get_justify(GTK_LABEL(self.unwrap_widget()))
         }
     }
 
     fn get_width_chars(&self) -> i32 {
         unsafe {
-            ffi::gtk_label_get_width_chars(GTK_LABEL(self.get_widget())) as i32
+            ffi::gtk_label_get_width_chars(GTK_LABEL(self.unwrap_widget())) as i32
         }
     }
 
     fn get_max_width_chars(&self) -> i32 {
         unsafe {
-            ffi::gtk_label_get_max_width_chars(GTK_LABEL(self.get_widget())) as i32
+            ffi::gtk_label_get_max_width_chars(GTK_LABEL(self.unwrap_widget())) as i32
         }
     }
 
@@ -227,20 +227,20 @@ pub trait LabelTrait: gtk::WidgetTrait {
         let x = 0;
         let y = 0;
         unsafe {
-            ffi::gtk_label_get_selection_bounds(GTK_LABEL(self.get_widget()), &x, &y);
+            ffi::gtk_label_get_selection_bounds(GTK_LABEL(self.unwrap_widget()), &x, &y);
         }
         (x, y)
     }
 
     fn set_angle(&mut self, angle: f64) -> () {
         unsafe {
-            ffi::gtk_label_set_angle(GTK_LABEL(self.get_widget()), angle as c_double);
+            ffi::gtk_label_set_angle(GTK_LABEL(self.unwrap_widget()), angle as c_double);
         }
     }
 
     fn get_angle(&self) -> f64 {
         unsafe {
-            ffi::gtk_label_get_angle(GTK_LABEL(self.get_widget())) as f64
+            ffi::gtk_label_get_angle(GTK_LABEL(self.unwrap_widget())) as f64
         }
     }
 }

--- a/src/gtk/traits/menu_item.rs
+++ b/src/gtk/traits/menu_item.rs
@@ -24,32 +24,32 @@ use glib::{to_bool, to_gboolean};
 pub trait MenuItemTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrait {
     fn set_submenu<T: gtk::WidgetTrait>(&mut self, widget: &mut T) {
         unsafe {
-            ffi::gtk_menu_item_set_submenu(GTK_MENU_ITEM(self.get_widget()),
-                                           widget.get_widget())
+            ffi::gtk_menu_item_set_submenu(GTK_MENU_ITEM(self.unwrap_widget()),
+                                           widget.unwrap_widget())
         }
     }
 
     fn get_submenu<T: gtk::WidgetTrait>(&self) -> T {
         unsafe {
-            gtk::FFIWidget::wrap(ffi::gtk_menu_item_get_submenu(GTK_MENU_ITEM(self.get_widget())))
+            gtk::FFIWidget::wrap_widget(ffi::gtk_menu_item_get_submenu(GTK_MENU_ITEM(self.unwrap_widget())))
         }
     }
 
     fn select(&mut self) {
         unsafe {
-            ffi::gtk_menu_item_select(GTK_MENU_ITEM(self.get_widget()))
+            ffi::gtk_menu_item_select(GTK_MENU_ITEM(self.unwrap_widget()))
         }
     }
 
     fn deselect(&mut self) {
         unsafe {
-            ffi::gtk_menu_item_deselect(GTK_MENU_ITEM(self.get_widget()))
+            ffi::gtk_menu_item_deselect(GTK_MENU_ITEM(self.unwrap_widget()))
         }
     }
 
     fn activate(&mut self) {
         unsafe {
-            ffi::gtk_menu_item_activate(GTK_MENU_ITEM(self.get_widget()))
+            ffi::gtk_menu_item_activate(GTK_MENU_ITEM(self.unwrap_widget()))
         }
     }
 
@@ -57,13 +57,13 @@ pub trait MenuItemTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrait 
         unsafe {
             let c_str = CString::from_slice(accel_path.as_bytes());
 
-            ffi::gtk_menu_item_set_accel_path(GTK_MENU_ITEM(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_menu_item_set_accel_path(GTK_MENU_ITEM(self.unwrap_widget()), c_str.as_ptr())
         }
     }
 
     fn get_accel_path(&self) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_menu_item_get_accel_path(GTK_MENU_ITEM(self.get_widget()));
+            let c_str = ffi::gtk_menu_item_get_accel_path(GTK_MENU_ITEM(self.unwrap_widget()));
 
             if c_str.is_null() {
                 None
@@ -77,13 +77,13 @@ pub trait MenuItemTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrait 
         let c_str = CString::from_slice(label.as_bytes());
 
         unsafe {
-            ffi::gtk_menu_item_set_label(GTK_MENU_ITEM(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_menu_item_set_label(GTK_MENU_ITEM(self.unwrap_widget()), c_str.as_ptr())
         }
     }
 
     fn get_label(&self) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_menu_item_get_label(GTK_MENU_ITEM(self.get_widget()));
+            let c_str = ffi::gtk_menu_item_get_label(GTK_MENU_ITEM(self.unwrap_widget()));
 
             if c_str.is_null() {
                 None
@@ -95,27 +95,27 @@ pub trait MenuItemTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrait 
 
     fn set_use_underline(&mut self, setting: bool) {
         unsafe {
-            ffi::gtk_menu_item_set_use_underline(GTK_MENU_ITEM(self.get_widget()),
+            ffi::gtk_menu_item_set_use_underline(GTK_MENU_ITEM(self.unwrap_widget()),
                                                  to_gboolean(setting))
         }
     }
 
     fn get_use_underline(&self) -> bool {
         unsafe {
-            to_bool(ffi::gtk_menu_item_get_use_underline(GTK_MENU_ITEM(self.get_widget())))
+            to_bool(ffi::gtk_menu_item_get_use_underline(GTK_MENU_ITEM(self.unwrap_widget())))
         }
     }
 
     fn set_reserve_indicator(&mut self, setting: bool) {
         unsafe {
-            ffi::gtk_menu_item_set_reserve_indicator(GTK_MENU_ITEM(self.get_widget()),
+            ffi::gtk_menu_item_set_reserve_indicator(GTK_MENU_ITEM(self.unwrap_widget()),
                                                      to_gboolean(setting))
         }
     }
 
     fn get_reserve_indicator(&self) -> bool {
         unsafe {
-            to_bool(ffi::gtk_menu_item_get_reserve_indicator(GTK_MENU_ITEM(self.get_widget())))
+            to_bool(ffi::gtk_menu_item_get_reserve_indicator(GTK_MENU_ITEM(self.unwrap_widget())))
         }
     }
 }

--- a/src/gtk/traits/menu_shell.rs
+++ b/src/gtk/traits/menu_shell.rs
@@ -23,86 +23,86 @@ use glib::{to_bool, to_gboolean};
 pub trait MenuShellTrait: gtk::WidgetTrait + gtk::ContainerTrait {
     fn append<T: gtk::WidgetTrait>(&mut self, widget: &T) {
         unsafe {
-            ffi::gtk_menu_shell_append(GTK_MENU_SHELL(self.get_widget()), widget.get_widget())
+            ffi::gtk_menu_shell_append(GTK_MENU_SHELL(self.unwrap_widget()), widget.unwrap_widget())
         }
     }
 
     fn prepend<T: gtk::WidgetTrait>(&mut self, widget: &T) {
         unsafe {
-            ffi::gtk_menu_shell_prepend(GTK_MENU_SHELL(self.get_widget()), widget.get_widget())
+            ffi::gtk_menu_shell_prepend(GTK_MENU_SHELL(self.unwrap_widget()), widget.unwrap_widget())
         }
     }
 
     fn insert<T: gtk::WidgetTrait>(&mut self, widget: &T, position: i32) {
         unsafe {
-            ffi::gtk_menu_shell_insert(GTK_MENU_SHELL(self.get_widget()),
-                                       widget.get_widget(),
+            ffi::gtk_menu_shell_insert(GTK_MENU_SHELL(self.unwrap_widget()),
+                                       widget.unwrap_widget(),
                                        position)
         }
     }
 
     fn deactivate(&mut self) {
         unsafe {
-            ffi::gtk_menu_shell_deactivate(GTK_MENU_SHELL(self.get_widget()))
+            ffi::gtk_menu_shell_deactivate(GTK_MENU_SHELL(self.unwrap_widget()))
         }
     }
 
     fn select_item<T: gtk::MenuItemTrait>(&mut self, menu_item: &T) {
         unsafe {
-            ffi::gtk_menu_shell_select_item(GTK_MENU_SHELL(self.get_widget()),
-                                            menu_item.get_widget())
+            ffi::gtk_menu_shell_select_item(GTK_MENU_SHELL(self.unwrap_widget()),
+                                            menu_item.unwrap_widget())
         }
     }
 
     fn deselect(&mut self) {
         unsafe {
-            ffi::gtk_menu_shell_deselect(GTK_MENU_SHELL(self.get_widget()))
+            ffi::gtk_menu_shell_deselect(GTK_MENU_SHELL(self.unwrap_widget()))
         }
     }
 
     fn activate_item<T: gtk::MenuItemTrait>(&mut self, menu_item: &T, force_deactivate: bool) {
         unsafe {
-            ffi::gtk_menu_shell_activate_item(GTK_MENU_SHELL(self.get_widget()),
-                                              menu_item.get_widget(),
+            ffi::gtk_menu_shell_activate_item(GTK_MENU_SHELL(self.unwrap_widget()),
+                                              menu_item.unwrap_widget(),
                                               to_gboolean(force_deactivate))
         }
     }
 
     fn select_first(&mut self, search_sensitive: bool) {
         unsafe {
-            ffi::gtk_menu_shell_select_first(GTK_MENU_SHELL(self.get_widget()),
+            ffi::gtk_menu_shell_select_first(GTK_MENU_SHELL(self.unwrap_widget()),
                                              to_gboolean(search_sensitive))
         }
     }
 
     fn cancel(&mut self) {
         unsafe {
-            ffi::gtk_menu_shell_cancel(GTK_MENU_SHELL(self.get_widget()))
+            ffi::gtk_menu_shell_cancel(GTK_MENU_SHELL(self.unwrap_widget()))
         }
     }
 
     fn get_take_focus(&self) -> bool {
         unsafe {
-            to_bool(ffi::gtk_menu_shell_get_take_focus(GTK_MENU_SHELL(self.get_widget())))
+            to_bool(ffi::gtk_menu_shell_get_take_focus(GTK_MENU_SHELL(self.unwrap_widget())))
         }
     }
 
     fn set_take_focus(&mut self, take_focus: bool) {
         unsafe {
-            ffi::gtk_menu_shell_set_take_focus(GTK_MENU_SHELL(self.get_widget()),
+            ffi::gtk_menu_shell_set_take_focus(GTK_MENU_SHELL(self.unwrap_widget()),
                                                to_gboolean(take_focus))
         }
     }
 
     fn get_selected_item<T: gtk::WidgetTrait>(&self) -> T {
         unsafe {
-            gtk::FFIWidget::wrap(ffi::gtk_menu_shell_get_selected_item(GTK_MENU_SHELL(self.get_widget())))
+            gtk::FFIWidget::wrap_widget(ffi::gtk_menu_shell_get_selected_item(GTK_MENU_SHELL(self.unwrap_widget())))
         }
     }
 
     fn get_parent_shell<T: gtk::MenuShellTrait>(&self) -> T {
         unsafe {
-            gtk::FFIWidget::wrap(ffi::gtk_menu_shell_get_parent_shell(GTK_MENU_SHELL(self.get_widget())))
+            gtk::FFIWidget::wrap_widget(ffi::gtk_menu_shell_get_parent_shell(GTK_MENU_SHELL(self.unwrap_widget())))
         }
     }
 }

--- a/src/gtk/traits/misc.rs
+++ b/src/gtk/traits/misc.rs
@@ -20,13 +20,13 @@ use gtk::{self, ffi};
 pub trait MiscTrait: gtk::WidgetTrait {
     fn set_alignment(&mut self, x_align: f32, y_align: f32) -> () {
         unsafe {
-            ffi::gtk_misc_set_alignment(GTK_MISC(self.get_widget()), x_align as c_float, y_align as c_float);
+            ffi::gtk_misc_set_alignment(GTK_MISC(self.unwrap_widget()), x_align as c_float, y_align as c_float);
         }
     }
 
     fn set_padding(&mut self, x_pad: i32, y_pad: i32) -> () {
         unsafe {
-            ffi::gtk_misc_set_padding(GTK_MISC(self.get_widget()), x_pad as c_int, y_pad as c_int);
+            ffi::gtk_misc_set_padding(GTK_MISC(self.unwrap_widget()), x_pad as c_int, y_pad as c_int);
         }
     }
 
@@ -34,7 +34,7 @@ pub trait MiscTrait: gtk::WidgetTrait {
         let x: c_float = 0.;
         let y: c_float = 0.;
         unsafe {
-            ffi::gtk_misc_get_alignment(GTK_MISC(self.get_widget()), &x, &y);
+            ffi::gtk_misc_get_alignment(GTK_MISC(self.unwrap_widget()), &x, &y);
         }
         (x as f32, y as f32)
     }
@@ -43,7 +43,7 @@ pub trait MiscTrait: gtk::WidgetTrait {
         let x: c_int = 0;
         let y: c_int = 0;
         unsafe {
-            ffi::gtk_misc_get_padding(GTK_MISC(self.get_widget()), &x, &y);
+            ffi::gtk_misc_get_padding(GTK_MISC(self.unwrap_widget()), &x, &y);
         }
         (x as i32, y as i32)
     }

--- a/src/gtk/traits/orientable.rs
+++ b/src/gtk/traits/orientable.rs
@@ -20,13 +20,13 @@ use gtk::{self, ffi};
 pub trait OrientableTrait: gtk::WidgetTrait {
     fn get_orientation(&self) -> Orientation {
         unsafe {
-            ffi::gtk_orientable_get_orientation(GTK_ORIENTABLE(self.get_widget()))
+            ffi::gtk_orientable_get_orientation(GTK_ORIENTABLE(self.unwrap_widget()))
         }
     }
 
     fn set_orientation(&mut self, orientation: Orientation) -> () {
         unsafe {
-            ffi::gtk_orientable_set_orientation(GTK_ORIENTABLE(self.get_widget()), orientation)
+            ffi::gtk_orientable_set_orientation(GTK_ORIENTABLE(self.unwrap_widget()), orientation)
         }
     }
 }

--- a/src/gtk/traits/range.rs
+++ b/src/gtk/traits/range.rs
@@ -19,13 +19,13 @@ use gtk::{self, ffi};
 pub trait RangeTrait: gtk::WidgetTrait {
     fn set_adjustment(&mut self, adjustment: &gtk::Adjustment) -> () {
         unsafe {
-            ffi::gtk_range_set_adjustment(GTK_RANGE(self.get_widget()), adjustment.get_pointer());
+            ffi::gtk_range_set_adjustment(GTK_RANGE(self.unwrap_widget()), adjustment.unwrap_pointer());
         }
     }
 
     fn get_adjustment(&self) -> gtk::Adjustment {
         unsafe {
-            gtk::Adjustment::wrap_pointer(ffi::gtk_range_get_adjustment(GTK_RANGE(self.get_widget())))
+            gtk::Adjustment::wrap_pointer(ffi::gtk_range_get_adjustment(GTK_RANGE(self.unwrap_widget())))
         }
     }
 }

--- a/src/gtk/traits/recent_chooser.rs
+++ b/src/gtk/traits/recent_chooser.rs
@@ -23,72 +23,72 @@ use libc::c_char;
 
 pub trait RecentChooserTrait: gtk::WidgetTrait + FFIWidget {
     fn set_show_private(&self, show_private: bool) {
-        unsafe { ffi::gtk_recent_chooser_set_show_private(GTK_RECENT_CHOOSER(self.get_widget()), to_gboolean(show_private)) }
+        unsafe { ffi::gtk_recent_chooser_set_show_private(GTK_RECENT_CHOOSER(self.unwrap_widget()), to_gboolean(show_private)) }
     }
 
     fn get_show_private(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_recent_chooser_get_show_private(GTK_RECENT_CHOOSER(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_recent_chooser_get_show_private(GTK_RECENT_CHOOSER(self.unwrap_widget()))) }
     }
 
     fn set_show_not_found(&self, show_not_found: bool) {
-        unsafe { ffi::gtk_recent_chooser_set_show_not_found(GTK_RECENT_CHOOSER(self.get_widget()), to_gboolean(show_not_found)) }
+        unsafe { ffi::gtk_recent_chooser_set_show_not_found(GTK_RECENT_CHOOSER(self.unwrap_widget()), to_gboolean(show_not_found)) }
     }
 
     fn get_show_not_found(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_recent_chooser_get_show_not_found(GTK_RECENT_CHOOSER(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_recent_chooser_get_show_not_found(GTK_RECENT_CHOOSER(self.unwrap_widget()))) }
     }
 
     fn set_show_icons(&self, show_icons: bool) {
-        unsafe { ffi::gtk_recent_chooser_set_show_icons(GTK_RECENT_CHOOSER(self.get_widget()), to_gboolean(show_icons)) }
+        unsafe { ffi::gtk_recent_chooser_set_show_icons(GTK_RECENT_CHOOSER(self.unwrap_widget()), to_gboolean(show_icons)) }
     }
 
     fn get_show_icons(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_recent_chooser_get_show_icons(GTK_RECENT_CHOOSER(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_recent_chooser_get_show_icons(GTK_RECENT_CHOOSER(self.unwrap_widget()))) }
     }
 
     fn set_select_multiple(&self, select_multiple: bool) {
-        unsafe { ffi::gtk_recent_chooser_set_select_multiple(GTK_RECENT_CHOOSER(self.get_widget()), to_gboolean(select_multiple)) }
+        unsafe { ffi::gtk_recent_chooser_set_select_multiple(GTK_RECENT_CHOOSER(self.unwrap_widget()), to_gboolean(select_multiple)) }
     }
 
     fn get_select_multiple(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_recent_chooser_get_select_multiple(GTK_RECENT_CHOOSER(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_recent_chooser_get_select_multiple(GTK_RECENT_CHOOSER(self.unwrap_widget()))) }
     }
 
     fn set_local_only(&self, local_only: bool) {
-        unsafe { ffi::gtk_recent_chooser_set_local_only(GTK_RECENT_CHOOSER(self.get_widget()), to_gboolean(local_only)) }
+        unsafe { ffi::gtk_recent_chooser_set_local_only(GTK_RECENT_CHOOSER(self.unwrap_widget()), to_gboolean(local_only)) }
     }
 
     fn get_local_only(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_recent_chooser_get_local_only(GTK_RECENT_CHOOSER(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_recent_chooser_get_local_only(GTK_RECENT_CHOOSER(self.unwrap_widget()))) }
     }
 
     fn set_limit(&self, limit: i32) {
-        unsafe { ffi::gtk_recent_chooser_set_limit(GTK_RECENT_CHOOSER(self.get_widget()), limit) }
+        unsafe { ffi::gtk_recent_chooser_set_limit(GTK_RECENT_CHOOSER(self.unwrap_widget()), limit) }
     }
 
     fn get_limit(&self) -> i32 {
-        unsafe { ffi::gtk_recent_chooser_get_limit(GTK_RECENT_CHOOSER(self.get_widget())) }
+        unsafe { ffi::gtk_recent_chooser_get_limit(GTK_RECENT_CHOOSER(self.unwrap_widget())) }
     }
 
     fn set_show_tips(&self, show_tips: bool) {
-        unsafe { ffi::gtk_recent_chooser_set_show_tips(GTK_RECENT_CHOOSER(self.get_widget()), to_gboolean(show_tips)) }
+        unsafe { ffi::gtk_recent_chooser_set_show_tips(GTK_RECENT_CHOOSER(self.unwrap_widget()), to_gboolean(show_tips)) }
     }
 
     fn get_show_tips(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_recent_chooser_get_show_tips(GTK_RECENT_CHOOSER(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_recent_chooser_get_show_tips(GTK_RECENT_CHOOSER(self.unwrap_widget()))) }
     }
 
     fn set_sort_type(&self, sort_type: gtk::RecentSortType) {
-        unsafe { ffi::gtk_recent_chooser_set_sort_type(GTK_RECENT_CHOOSER(self.get_widget()), sort_type) }
+        unsafe { ffi::gtk_recent_chooser_set_sort_type(GTK_RECENT_CHOOSER(self.unwrap_widget()), sort_type) }
     }
 
     fn get_sort_type(&self) -> gtk::RecentSortType {
-        unsafe { ffi::gtk_recent_chooser_get_sort_type(GTK_RECENT_CHOOSER(self.get_widget())) }
+        unsafe { ffi::gtk_recent_chooser_get_sort_type(GTK_RECENT_CHOOSER(self.unwrap_widget())) }
     }
 
     fn get_current_uri(&self) -> Option<String> {
         unsafe {
-            let tmp = ffi::gtk_recent_chooser_get_current_uri(GTK_RECENT_CHOOSER(self.get_widget()));
+            let tmp = ffi::gtk_recent_chooser_get_current_uri(GTK_RECENT_CHOOSER(self.unwrap_widget()));
 
             if tmp.is_null() {
                 None
@@ -99,12 +99,12 @@ pub trait RecentChooserTrait: gtk::WidgetTrait + FFIWidget {
     }
 
     fn get_current_item(&self) -> Option<gtk::RecentInfo> {
-        let tmp = unsafe { ffi::gtk_recent_chooser_get_current_item(GTK_RECENT_CHOOSER(self.get_widget())) };
+        let tmp = unsafe { ffi::gtk_recent_chooser_get_current_item(GTK_RECENT_CHOOSER(self.unwrap_widget())) };
 
         if tmp.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp as *mut ffi::C_GtkWidget))
+            Some(gtk::FFIWidget::wrap_widget(tmp as *mut ffi::C_GtkWidget))
         }
     }
 
@@ -112,20 +112,20 @@ pub trait RecentChooserTrait: gtk::WidgetTrait + FFIWidget {
         unsafe {
             let c_str = CString::from_slice(uri.as_bytes());
 
-            to_bool(ffi::gtk_recent_chooser_unselect_uri(GTK_RECENT_CHOOSER(self.get_widget()), c_str.as_ptr()))
+            to_bool(ffi::gtk_recent_chooser_unselect_uri(GTK_RECENT_CHOOSER(self.unwrap_widget()), c_str.as_ptr()))
         }
     }
 
     fn select_all(&self) {
-        unsafe { ffi::gtk_recent_chooser_select_all(GTK_RECENT_CHOOSER(self.get_widget())) }
+        unsafe { ffi::gtk_recent_chooser_select_all(GTK_RECENT_CHOOSER(self.unwrap_widget())) }
     }
 
     fn unselect_all(&self) {
-        unsafe { ffi::gtk_recent_chooser_unselect_all(GTK_RECENT_CHOOSER(self.get_widget())) }
+        unsafe { ffi::gtk_recent_chooser_unselect_all(GTK_RECENT_CHOOSER(self.unwrap_widget())) }
     }
 
     fn get_items(&self) -> glib::List<Box<gtk::RecentInfo>> {
-        let tmp = unsafe { ffi::gtk_recent_chooser_get_items(GTK_RECENT_CHOOSER(self.get_widget())) };
+        let tmp = unsafe { ffi::gtk_recent_chooser_get_items(GTK_RECENT_CHOOSER(self.unwrap_widget())) };
 
         if tmp.is_null() {
             glib::List::new()
@@ -134,7 +134,7 @@ pub trait RecentChooserTrait: gtk::WidgetTrait + FFIWidget {
             let mut tmp_vec : glib::List<Box<gtk::RecentInfo>> = glib::List::new();
 
             for it in old_list.iter() {
-                tmp_vec.append(Box::new(gtk::FFIWidget::wrap(*it as *mut gtk::ffi::C_GtkWidget)));
+                tmp_vec.append(Box::new(gtk::FFIWidget::wrap_widget(*it as *mut gtk::ffi::C_GtkWidget)));
             }
             tmp_vec
         }
@@ -142,7 +142,7 @@ pub trait RecentChooserTrait: gtk::WidgetTrait + FFIWidget {
 
     fn get_uris(&self) -> Option<Vec<String>> {
         let mut length = 0;
-        let tmp = unsafe { ffi::gtk_recent_chooser_get_uris(GTK_RECENT_CHOOSER(self.get_widget()), &mut length) };
+        let tmp = unsafe { ffi::gtk_recent_chooser_get_uris(GTK_RECENT_CHOOSER(self.unwrap_widget()), &mut length) };
 
         if tmp.is_null() {
             None
@@ -161,15 +161,15 @@ pub trait RecentChooserTrait: gtk::WidgetTrait + FFIWidget {
     }
 
     fn add_filter(&self, filter: &gtk::RecentFilter) {
-        unsafe { ffi::gtk_recent_chooser_add_filter(GTK_RECENT_CHOOSER(self.get_widget()), filter.get_pointer()) }
+        unsafe { ffi::gtk_recent_chooser_add_filter(GTK_RECENT_CHOOSER(self.unwrap_widget()), filter.unwrap_pointer()) }
     }
 
     fn remove_filter(&self, filter: &gtk::RecentFilter) {
-        unsafe { ffi::gtk_recent_chooser_remove_filter(GTK_RECENT_CHOOSER(self.get_widget()), filter.get_pointer()) }
+        unsafe { ffi::gtk_recent_chooser_remove_filter(GTK_RECENT_CHOOSER(self.unwrap_widget()), filter.unwrap_pointer()) }
     }
 
     // fn list_filters(&self) -> glib::SList<Box<gtk::RecentFilter>> {
-    //     let tmp = unsafe { ffi::gtk_recent_chooser_list_filters(self.get_pointer()) };
+    //     let tmp = unsafe { ffi::gtk_recent_chooser_list_filters(self.unwrap_pointer()) };
 
     //     if tmp.is_null() {
     //         glib::SList::new()
@@ -188,11 +188,11 @@ pub trait RecentChooserTrait: gtk::WidgetTrait + FFIWidget {
     // }
 
     fn set_filter(&self, filter: &gtk::RecentFilter) {
-        unsafe { ffi::gtk_recent_chooser_set_filter(GTK_RECENT_CHOOSER(self.get_widget()), filter.get_pointer()) }
+        unsafe { ffi::gtk_recent_chooser_set_filter(GTK_RECENT_CHOOSER(self.unwrap_widget()), filter.unwrap_pointer()) }
     }
 
     fn get_filter(&self) -> Option<gtk::RecentFilter> {
-        let tmp = unsafe { ffi::gtk_recent_chooser_get_filter(GTK_RECENT_CHOOSER(self.get_widget())) };
+        let tmp = unsafe { ffi::gtk_recent_chooser_get_filter(GTK_RECENT_CHOOSER(self.unwrap_widget())) };
 
         gtk::RecentFilter::wrap(tmp)
     }

--- a/src/gtk/traits/scale_button.rs
+++ b/src/gtk/traits/scale_button.rs
@@ -21,25 +21,25 @@ use gtk::{self, ffi};
 pub trait ScaleButtonTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::ButtonTrait {
     fn set_adjustment(&mut self, adjustment: &gtk::Adjustment) -> () {
         unsafe {
-            ffi::gtk_scale_button_set_adjustment(GTK_SCALEBUTTON(self.get_widget()), adjustment.get_pointer());
+            ffi::gtk_scale_button_set_adjustment(GTK_SCALEBUTTON(self.unwrap_widget()), adjustment.unwrap_pointer());
         }
     }
 
     fn set_value(&mut self, value: f64) -> () {
         unsafe {
-            ffi::gtk_scale_button_set_value(GTK_SCALEBUTTON(self.get_widget()), value as c_double);
+            ffi::gtk_scale_button_set_value(GTK_SCALEBUTTON(self.unwrap_widget()), value as c_double);
         }
     }
 
     fn get_value(&self) -> f64 {
         unsafe {
-            ffi::gtk_scale_button_get_value(GTK_SCALEBUTTON(self.get_widget())) as f64
+            ffi::gtk_scale_button_get_value(GTK_SCALEBUTTON(self.unwrap_widget())) as f64
         }
     }
 
     fn get_adjustment(&self) -> gtk::Adjustment {
         unsafe {
-            gtk::Adjustment::wrap_pointer(ffi::gtk_scale_button_get_adjustment(GTK_SCALEBUTTON(self.get_widget())))
+            gtk::Adjustment::wrap_pointer(ffi::gtk_scale_button_get_adjustment(GTK_SCALEBUTTON(self.unwrap_widget())))
         }
     }
 }

--- a/src/gtk/traits/scrollable.rs
+++ b/src/gtk/traits/scrollable.rs
@@ -22,52 +22,52 @@ use gtk::{self, ffi};
 pub trait ScrollableTrait: gtk::WidgetTrait {
     fn get_hadjustment(&self) -> gtk::Adjustment {
         unsafe {
-            gtk::Adjustment::wrap_pointer(ffi::gtk_scrollable_get_hadjustment(GTK_SCROLLABLE(self.get_widget())))
+            gtk::Adjustment::wrap_pointer(ffi::gtk_scrollable_get_hadjustment(GTK_SCROLLABLE(self.unwrap_widget())))
         }
     }
 
     fn set_hadjustment(&mut self, hadjustment: gtk::Adjustment) {
         unsafe {
-            ffi::gtk_scrollable_set_hadjustment(GTK_SCROLLABLE(self.get_widget()),
-                                                hadjustment.get_pointer())
+            ffi::gtk_scrollable_set_hadjustment(GTK_SCROLLABLE(self.unwrap_widget()),
+                                                hadjustment.unwrap_pointer())
         }
     }
 
     fn get_vadjustment(&self) -> gtk::Adjustment {
         unsafe {
-            gtk::Adjustment::wrap_pointer(ffi::gtk_scrollable_get_vadjustment(GTK_SCROLLABLE(self.get_widget())))
+            gtk::Adjustment::wrap_pointer(ffi::gtk_scrollable_get_vadjustment(GTK_SCROLLABLE(self.unwrap_widget())))
         }
     }
 
     fn set_vadjustment(&mut self, vadjustment: gtk::Adjustment) {
         unsafe {
-            ffi::gtk_scrollable_set_vadjustment(GTK_SCROLLABLE(self.get_widget()),
-                                                vadjustment.get_pointer())
+            ffi::gtk_scrollable_set_vadjustment(GTK_SCROLLABLE(self.unwrap_widget()),
+                                                vadjustment.unwrap_pointer())
         }
     }
 
     fn get_hscroll_policy(&self) -> gtk::ScrollablePolicy {
         unsafe {
-            ffi::gtk_scrollable_get_hscroll_policy(GTK_SCROLLABLE(self.get_widget()))
+            ffi::gtk_scrollable_get_hscroll_policy(GTK_SCROLLABLE(self.unwrap_widget()))
         }
     }
 
     fn set_hscroll_policy(&mut self, policy: gtk::ScrollablePolicy) {
         unsafe {
-            ffi::gtk_scrollable_set_hscroll_policy(GTK_SCROLLABLE(self.get_widget()),
+            ffi::gtk_scrollable_set_hscroll_policy(GTK_SCROLLABLE(self.unwrap_widget()),
                                                    policy)
         }
     }
 
     fn get_vscroll_policy(&self) -> gtk::ScrollablePolicy {
         unsafe {
-            ffi::gtk_scrollable_get_vscroll_policy(GTK_SCROLLABLE(self.get_widget()))
+            ffi::gtk_scrollable_get_vscroll_policy(GTK_SCROLLABLE(self.unwrap_widget()))
         }
     }
 
     fn set_vscroll_policy(&mut self, policy: gtk::ScrollablePolicy) {
         unsafe {
-            ffi::gtk_scrollable_set_vscroll_policy(GTK_SCROLLABLE(self.get_widget()),
+            ffi::gtk_scrollable_set_vscroll_policy(GTK_SCROLLABLE(self.unwrap_widget()),
                                                    policy)
         }
     }

--- a/src/gtk/traits/scrolled_window.rs
+++ b/src/gtk/traits/scrolled_window.rs
@@ -20,7 +20,7 @@ use gtk::FFIWidget;
 pub trait ScrolledWindowTrait: gtk::WidgetTrait {
     fn set_policy(&self, h_scrollbar_policy: gtk::PolicyType, v_scrollbar_policy: gtk::PolicyType) {
         unsafe {
-            ffi::gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(self.get_widget()), h_scrollbar_policy, v_scrollbar_policy);
+            ffi::gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(self.unwrap_widget()), h_scrollbar_policy, v_scrollbar_policy);
         }
     }
 }

--- a/src/gtk/traits/text_buffer.rs
+++ b/src/gtk/traits/text_buffer.rs
@@ -22,7 +22,7 @@ pub trait TextBufferTrait: gtk::WidgetTrait {
         unsafe {
         	let c_str = CString::from_slice(text.as_bytes());
 
-            ffi::gtk_text_buffer_set_text(GTK_TEXT_BUFFER(self.get_widget()), c_str.as_ptr(), text.len() as i32)
+            ffi::gtk_text_buffer_set_text(GTK_TEXT_BUFFER(self.unwrap_widget()), c_str.as_ptr(), text.len() as i32)
         }
     }
 

--- a/src/gtk/traits/toggle_button.rs
+++ b/src/gtk/traits/toggle_button.rs
@@ -19,33 +19,33 @@ use glib::{to_bool, to_gboolean};
 
 pub trait ToggleButtonTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::ButtonTrait {
     fn set_mode(&mut self, draw_indicate: bool) {
-        unsafe { ffi::gtk_toggle_button_set_mode(GTK_TOGGLEBUTTON(self.get_widget()), to_gboolean(draw_indicate)); }
+        unsafe { ffi::gtk_toggle_button_set_mode(GTK_TOGGLEBUTTON(self.unwrap_widget()), to_gboolean(draw_indicate)); }
     }
 
     fn get_mode(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_toggle_button_get_mode(GTK_TOGGLEBUTTON(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_toggle_button_get_mode(GTK_TOGGLEBUTTON(self.unwrap_widget()))) }
     }
 
     fn toggled(&mut self) -> () {
         unsafe {
-            ffi::gtk_toggle_button_toggled(GTK_TOGGLEBUTTON(self.get_widget()))
+            ffi::gtk_toggle_button_toggled(GTK_TOGGLEBUTTON(self.unwrap_widget()))
         }
     }
 
     fn set_active(&mut self, is_active: bool) {
-        unsafe { ffi::gtk_toggle_button_set_active(GTK_TOGGLEBUTTON(self.get_widget()), to_gboolean(is_active)); }
+        unsafe { ffi::gtk_toggle_button_set_active(GTK_TOGGLEBUTTON(self.unwrap_widget()), to_gboolean(is_active)); }
     }
 
     fn get_active(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_toggle_button_get_active(GTK_TOGGLEBUTTON(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_toggle_button_get_active(GTK_TOGGLEBUTTON(self.unwrap_widget()))) }
     }
 
     fn set_inconsistent(&mut self, setting: bool) {
-        unsafe { ffi::gtk_toggle_button_set_inconsistent(GTK_TOGGLEBUTTON(self.get_widget()), to_gboolean(setting)); }
+        unsafe { ffi::gtk_toggle_button_set_inconsistent(GTK_TOGGLEBUTTON(self.unwrap_widget()), to_gboolean(setting)); }
     }
 
     fn get_inconsistent(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_toggle_button_get_inconsistent(GTK_TOGGLEBUTTON(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_toggle_button_get_inconsistent(GTK_TOGGLEBUTTON(self.unwrap_widget()))) }
     }
 }
 

--- a/src/gtk/traits/toggle_tool_button.rs
+++ b/src/gtk/traits/toggle_tool_button.rs
@@ -24,10 +24,10 @@ pub trait ToggleToolButtonTrait: gtk::WidgetTrait +
                                  gtk::ToolButtonTrait {
 
     fn get_active(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_toggle_tool_button_get_active(GTK_TOGGLETOOLBUTTON(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_toggle_tool_button_get_active(GTK_TOGGLETOOLBUTTON(self.unwrap_widget()))) }
     }
 
     fn set_active(&mut self, set_underline: bool) -> () {
-         unsafe { ffi::gtk_toggle_tool_button_set_active(GTK_TOGGLETOOLBUTTON(self.get_widget()), to_gboolean(set_underline)); }
+         unsafe { ffi::gtk_toggle_tool_button_set_active(GTK_TOGGLETOOLBUTTON(self.unwrap_widget()), to_gboolean(set_underline)); }
     }
 }

--- a/src/gtk/traits/tool_button.rs
+++ b/src/gtk/traits/tool_button.rs
@@ -23,7 +23,7 @@ pub trait ToolButtonTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrai
         unsafe {
             let c_str = CString::from_slice(label.as_bytes());
 
-            ffi::gtk_tool_button_set_label(GTK_TOOLBUTTON(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_tool_button_set_label(GTK_TOOLBUTTON(self.unwrap_widget()), c_str.as_ptr())
         }
     }
 
@@ -31,7 +31,7 @@ pub trait ToolButtonTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrai
         unsafe {
             let c_str = CString::from_slice(stock_id.as_bytes());
 
-            ffi::gtk_tool_button_set_stock_id(GTK_TOOLBUTTON(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_tool_button_set_stock_id(GTK_TOOLBUTTON(self.unwrap_widget()), c_str.as_ptr())
         }
     }
 
@@ -39,13 +39,13 @@ pub trait ToolButtonTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrai
         let c_str = CString::from_slice(icon_name.as_bytes());
 
         unsafe {
-            ffi::gtk_tool_button_set_icon_name(GTK_TOOLBUTTON(self.get_widget()), c_str.as_ptr());
+            ffi::gtk_tool_button_set_icon_name(GTK_TOOLBUTTON(self.unwrap_widget()), c_str.as_ptr());
         }
     }
 
     fn get_label(&self) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_tool_button_get_label(GTK_TOOLBUTTON(self.get_widget()));
+            let c_str = ffi::gtk_tool_button_get_label(GTK_TOOLBUTTON(self.unwrap_widget()));
 
             if c_str.is_null() {
                 None
@@ -57,7 +57,7 @@ pub trait ToolButtonTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrai
 
     fn get_stock_id(&self) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_tool_button_get_stock_id(GTK_TOOLBUTTON(self.get_widget()));
+            let c_str = ffi::gtk_tool_button_get_stock_id(GTK_TOOLBUTTON(self.unwrap_widget()));
 
             if c_str.is_null() {
                 None
@@ -69,7 +69,7 @@ pub trait ToolButtonTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrai
 
     fn get_icon_name(&self) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_tool_button_get_icon_name(GTK_TOOLBUTTON(self.get_widget()));
+            let c_str = ffi::gtk_tool_button_get_icon_name(GTK_TOOLBUTTON(self.unwrap_widget()));
 
             if c_str.is_null() {
                 None
@@ -80,26 +80,26 @@ pub trait ToolButtonTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrai
     }
 
     fn get_use_underline(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_tool_button_get_use_underline(GTK_TOOLBUTTON(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_tool_button_get_use_underline(GTK_TOOLBUTTON(self.unwrap_widget()))) }
     }
 
     fn set_use_underline(&mut self, set_underline: bool) -> () {
-         unsafe { ffi::gtk_tool_button_set_use_underline(GTK_TOOLBUTTON(self.get_widget()), to_gboolean(set_underline)); }
+         unsafe { ffi::gtk_tool_button_set_use_underline(GTK_TOOLBUTTON(self.unwrap_widget()), to_gboolean(set_underline)); }
     }
 
     fn set_label_widget<T: gtk::LabelTrait>(&mut self, label: &T) -> () {
         unsafe {
-            ffi::gtk_tool_button_set_label_widget(GTK_TOOLBUTTON(self.get_widget()), label.get_widget())
+            ffi::gtk_tool_button_set_label_widget(GTK_TOOLBUTTON(self.unwrap_widget()), label.unwrap_widget())
         }
     }
 
     fn get_label_widget(&self) -> Option<gtk::Label> {
         unsafe {
-            let tmp_pointer = ffi::gtk_tool_button_get_label_widget(GTK_TOOLBUTTON(self.get_widget()));
+            let tmp_pointer = ffi::gtk_tool_button_get_label_widget(GTK_TOOLBUTTON(self.unwrap_widget()));
             if tmp_pointer.is_null() {
                 None
             } else {
-                Some(gtk::FFIWidget::wrap(tmp_pointer))
+                Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
             }
         }
     }

--- a/src/gtk/traits/tool_item.rs
+++ b/src/gtk/traits/tool_item.rs
@@ -21,58 +21,58 @@ use gtk::{IconSize, Orientation, ReliefStyle, ToolbarStyle};
 
 pub trait ToolItemTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrait {
     fn set_homogeneous(&mut self, homogeneous: bool) -> () {
-         unsafe { ffi::gtk_tool_item_set_homogeneous(GTK_TOOLITEM(self.get_widget()), to_gboolean(homogeneous)); }
+         unsafe { ffi::gtk_tool_item_set_homogeneous(GTK_TOOLITEM(self.unwrap_widget()), to_gboolean(homogeneous)); }
     }
 
     fn get_homogeneous(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_tool_item_get_homogeneous(GTK_TOOLITEM(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_tool_item_get_homogeneous(GTK_TOOLITEM(self.unwrap_widget()))) }
     }
 
     fn set_expand(&mut self, expand: bool) -> () {
-         unsafe { ffi::gtk_tool_item_set_expand(GTK_TOOLITEM(self.get_widget()), to_gboolean(expand)); }
+         unsafe { ffi::gtk_tool_item_set_expand(GTK_TOOLITEM(self.unwrap_widget()), to_gboolean(expand)); }
     }
 
     fn get_expand(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_tool_item_get_expand(GTK_TOOLITEM(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_tool_item_get_expand(GTK_TOOLITEM(self.unwrap_widget()))) }
     }
 
     fn set_use_drag_window(&mut self, use_drag_window: bool) -> () {
-         unsafe { ffi::gtk_tool_item_set_use_drag_window(GTK_TOOLITEM(self.get_widget()), to_gboolean(use_drag_window)); }
+         unsafe { ffi::gtk_tool_item_set_use_drag_window(GTK_TOOLITEM(self.unwrap_widget()), to_gboolean(use_drag_window)); }
     }
 
     fn get_use_drag_window(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_tool_item_get_use_drag_window(GTK_TOOLITEM(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_tool_item_get_use_drag_window(GTK_TOOLITEM(self.unwrap_widget()))) }
     }
 
     fn set_visible_horizontal(&mut self, visible_horizontal: bool) -> () {
-         unsafe { ffi::gtk_tool_item_set_visible_horizontal(GTK_TOOLITEM(self.get_widget()), to_gboolean(visible_horizontal)); }
+         unsafe { ffi::gtk_tool_item_set_visible_horizontal(GTK_TOOLITEM(self.unwrap_widget()), to_gboolean(visible_horizontal)); }
     }
 
     fn get_visible_horizontal(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_tool_item_get_visible_horizontal(GTK_TOOLITEM(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_tool_item_get_visible_horizontal(GTK_TOOLITEM(self.unwrap_widget()))) }
     }
 
     fn set_visible_vertical(&mut self, visible_vertical: bool) -> () {
-         unsafe { ffi::gtk_tool_item_set_visible_vertical(GTK_TOOLITEM(self.get_widget()), to_gboolean(visible_vertical)); }
+         unsafe { ffi::gtk_tool_item_set_visible_vertical(GTK_TOOLITEM(self.unwrap_widget()), to_gboolean(visible_vertical)); }
     }
 
     fn get_visible_vertical(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_tool_item_get_visible_vertical(GTK_TOOLITEM(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_tool_item_get_visible_vertical(GTK_TOOLITEM(self.unwrap_widget()))) }
     }
 
     fn set_is_important(&mut self, is_important: bool) -> () {
-         unsafe { ffi::gtk_tool_item_set_is_important(GTK_TOOLITEM(self.get_widget()), to_gboolean(is_important)); }
+         unsafe { ffi::gtk_tool_item_set_is_important(GTK_TOOLITEM(self.unwrap_widget()), to_gboolean(is_important)); }
     }
 
     fn get_is_important(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_tool_item_get_is_important(GTK_TOOLITEM(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_tool_item_get_is_important(GTK_TOOLITEM(self.unwrap_widget()))) }
     }
 
     fn set_tooltip_text(&mut self, text: &str) -> () {
         let c_str = CString::from_slice(text.as_bytes());
 
         unsafe {
-            ffi::gtk_tool_item_set_tooltip_text(GTK_TOOLITEM(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_tool_item_set_tooltip_text(GTK_TOOLITEM(self.unwrap_widget()), c_str.as_ptr())
         }
     }
 
@@ -80,60 +80,60 @@ pub trait ToolItemTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrait 
         unsafe {
             let c_str = CString::from_slice(markup.as_bytes());
 
-            ffi::gtk_tool_item_set_tooltip_markup(GTK_TOOLITEM(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_tool_item_set_tooltip_markup(GTK_TOOLITEM(self.unwrap_widget()), c_str.as_ptr())
         }
     }
 
     fn get_icon_size(&self) -> IconSize {
         unsafe {
-            ffi::gtk_tool_item_get_icon_size(GTK_TOOLITEM(self.get_widget()))
+            ffi::gtk_tool_item_get_icon_size(GTK_TOOLITEM(self.unwrap_widget()))
         }
     }
 
     fn get_orientation(&self) -> Orientation {
         unsafe {
-            ffi::gtk_tool_item_get_orientation(GTK_TOOLITEM(self.get_widget()))
+            ffi::gtk_tool_item_get_orientation(GTK_TOOLITEM(self.unwrap_widget()))
         }
     }
 
     fn get_toolbar_style(&self) -> ToolbarStyle {
         unsafe {
-            ffi::gtk_tool_item_get_toolbar_style(GTK_TOOLITEM(self.get_widget()))
+            ffi::gtk_tool_item_get_toolbar_style(GTK_TOOLITEM(self.unwrap_widget()))
         }
     }
 
     fn get_relief_style(&self) -> ReliefStyle {
         unsafe {
-            ffi::gtk_tool_item_get_relief_style(GTK_TOOLITEM(self.get_widget()))
+            ffi::gtk_tool_item_get_relief_style(GTK_TOOLITEM(self.unwrap_widget()))
         }
     }
 
     fn get_text_alignment(&self) -> f32 {
         unsafe {
-            ffi::gtk_tool_item_get_text_alignment(GTK_TOOLITEM(self.get_widget())) as f32
+            ffi::gtk_tool_item_get_text_alignment(GTK_TOOLITEM(self.unwrap_widget())) as f32
         }
     }
 
     fn get_text_orientation(&self) -> Orientation {
         unsafe {
-            ffi::gtk_tool_item_get_text_orientation(GTK_TOOLITEM(self.get_widget()))
+            ffi::gtk_tool_item_get_text_orientation(GTK_TOOLITEM(self.unwrap_widget()))
         }
     }
 
     fn rebuild_menu(&mut self) -> () {
         unsafe {
-            ffi::gtk_tool_item_rebuild_menu(GTK_TOOLITEM(self.get_widget()))
+            ffi::gtk_tool_item_rebuild_menu(GTK_TOOLITEM(self.unwrap_widget()))
         }
     }
 
     fn toolbar_reconfigured(&mut self) -> () {
         unsafe {
-            ffi::gtk_tool_item_toolbar_reconfigured(GTK_TOOLITEM(self.get_widget()))
+            ffi::gtk_tool_item_toolbar_reconfigured(GTK_TOOLITEM(self.unwrap_widget()))
         }
     }
 
     fn get_text_size_group(&self) -> Option<gtk::SizeGroup> {
-        let tmp_pointer = unsafe { ffi::gtk_tool_item_get_text_size_group(GTK_TOOLITEM(self.get_widget()) as *const ffi::C_GtkToolItem) };
+        let tmp_pointer = unsafe { ffi::gtk_tool_item_get_text_size_group(GTK_TOOLITEM(self.unwrap_widget()) as *const ffi::C_GtkToolItem) };
 
         if tmp_pointer.is_null() {
             None

--- a/src/gtk/traits/tool_shell.rs
+++ b/src/gtk/traits/tool_shell.rs
@@ -20,48 +20,48 @@ use gtk::{IconSize, Orientation, ReliefStyle, ToolbarStyle};
 pub trait ToolShellTrait: gtk::WidgetTrait {
     fn get_icon_size(&self) -> IconSize {
         unsafe {
-            ffi::gtk_tool_shell_get_icon_size(GTK_TOOLSHELL(self.get_widget()))
+            ffi::gtk_tool_shell_get_icon_size(GTK_TOOLSHELL(self.unwrap_widget()))
         }
     }
 
     fn get_orientation(&self) -> Orientation {
         unsafe {
-            ffi::gtk_tool_shell_get_orientation(GTK_TOOLSHELL(self.get_widget()))
+            ffi::gtk_tool_shell_get_orientation(GTK_TOOLSHELL(self.unwrap_widget()))
         }
     }
 
     fn get_relief_style(&self) -> ReliefStyle {
         unsafe {
-            ffi::gtk_tool_shell_get_relief_style(GTK_TOOLSHELL(self.get_widget()))
+            ffi::gtk_tool_shell_get_relief_style(GTK_TOOLSHELL(self.unwrap_widget()))
         }
     }
 
     fn get_style(&self) -> ToolbarStyle {
         unsafe {
-            ffi::gtk_tool_shell_get_style(GTK_TOOLSHELL(self.get_widget()))
+            ffi::gtk_tool_shell_get_style(GTK_TOOLSHELL(self.unwrap_widget()))
         }
     }
 
     fn get_text_alignment(&self) -> f32 {
         unsafe {
-            ffi::gtk_tool_shell_get_text_alignment(GTK_TOOLSHELL(self.get_widget()))
+            ffi::gtk_tool_shell_get_text_alignment(GTK_TOOLSHELL(self.unwrap_widget()))
         }
     }
 
     fn get_text_orientation(&self) -> Orientation {
         unsafe {
-            ffi::gtk_tool_shell_get_text_orientation(GTK_TOOLSHELL(self.get_widget()))
+            ffi::gtk_tool_shell_get_text_orientation(GTK_TOOLSHELL(self.unwrap_widget()))
         }
     }
 
     fn rebuild_menu(&mut self) -> () {
         unsafe {
-            ffi::gtk_tool_shell_rebuild_menu(GTK_TOOLSHELL(self.get_widget()))
+            ffi::gtk_tool_shell_rebuild_menu(GTK_TOOLSHELL(self.unwrap_widget()))
         }
     }
 
     fn get_text_size_group(&self) -> Option<gtk::SizeGroup> {
-        let tmp_pointer = unsafe { ffi::gtk_tool_shell_get_text_size_group(GTK_TOOLSHELL(self.get_widget()) as *const ffi::C_GtkToolShell) };
+        let tmp_pointer = unsafe { ffi::gtk_tool_shell_get_text_size_group(GTK_TOOLSHELL(self.unwrap_widget()) as *const ffi::C_GtkToolShell) };
 
         if tmp_pointer.is_null() {
             None

--- a/src/gtk/traits/widget.rs
+++ b/src/gtk/traits/widget.rs
@@ -26,79 +26,79 @@ use glib::ffi::GType;
 pub trait WidgetTrait: gtk::FFIWidget + gtk::GObjectTrait {
     fn show_all(&mut self) -> () {
         unsafe {
-            ffi::gtk_widget_show_all(self.get_widget());
+            ffi::gtk_widget_show_all(self.unwrap_widget());
         }
     }
 
     fn show_now(&self) {
-        unsafe { ffi::gtk_widget_show_now(self.get_widget()) }
+        unsafe { ffi::gtk_widget_show_now(self.unwrap_widget()) }
     }
 
     fn hide(&self) {
-        unsafe { ffi::gtk_widget_hide(self.get_widget()) }
+        unsafe { ffi::gtk_widget_hide(self.unwrap_widget()) }
     }
 
     fn map(&self) {
-        unsafe { ffi::gtk_widget_map(self.get_widget()) }
+        unsafe { ffi::gtk_widget_map(self.unwrap_widget()) }
     }
 
     fn unmap(&self) {
-        unsafe { ffi::gtk_widget_unmap(self.get_widget()) }
+        unsafe { ffi::gtk_widget_unmap(self.unwrap_widget()) }
     }
 
     fn realize(&self) {
-        unsafe { ffi::gtk_widget_realize(self.get_widget()) }
+        unsafe { ffi::gtk_widget_realize(self.unwrap_widget()) }
     }
 
     fn unrealize(&self) {
-        unsafe { ffi::gtk_widget_unrealize(self.get_widget()) }
+        unsafe { ffi::gtk_widget_unrealize(self.unwrap_widget()) }
     }
 
     fn queue_draw(&self) {
-        unsafe { ffi::gtk_widget_queue_draw(self.get_widget()) }
+        unsafe { ffi::gtk_widget_queue_draw(self.unwrap_widget()) }
     }
 
     fn queue_resize(&self) {
-        unsafe { ffi::gtk_widget_queue_resize(self.get_widget()) }
+        unsafe { ffi::gtk_widget_queue_resize(self.unwrap_widget()) }
     }
 
     fn queue_resize_no_redraw(&self) {
-        unsafe { ffi::gtk_widget_queue_resize_no_redraw(self.get_widget()) }
+        unsafe { ffi::gtk_widget_queue_resize_no_redraw(self.unwrap_widget()) }
     }
 
     fn get_scale_factor(&self) -> i32 {
-        unsafe { ffi::gtk_widget_get_scale_factor(self.get_widget()) }
+        unsafe { ffi::gtk_widget_get_scale_factor(self.unwrap_widget()) }
     }
 
     fn activate(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_activate(self.get_widget())) }
+        unsafe { to_bool(ffi::gtk_widget_activate(self.unwrap_widget())) }
     }
 
     fn reparent<T: WidgetTrait>(&self, new_parent: &T) {
-        unsafe { ffi::gtk_widget_reparent(self.get_widget(), new_parent.get_widget()) }
+        unsafe { ffi::gtk_widget_reparent(self.unwrap_widget(), new_parent.unwrap_widget()) }
     }
 
     fn is_focus(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_is_focus(self.get_widget())) }
+        unsafe { to_bool(ffi::gtk_widget_is_focus(self.unwrap_widget())) }
     }
 
     fn grab_focus(&self) {
-        unsafe { ffi::gtk_widget_grab_focus(self.get_widget()) }
+        unsafe { ffi::gtk_widget_grab_focus(self.unwrap_widget()) }
     }
 
     fn grab_default(&self) {
-        unsafe { ffi::gtk_widget_grab_default(self.get_widget()) }
+        unsafe { ffi::gtk_widget_grab_default(self.unwrap_widget()) }
     }
 
     fn set_name(&self, name: &str) {
         let c_str = CString::from_slice(name.as_bytes());
 
-        unsafe { ffi::gtk_widget_set_name(self.get_widget(), c_str.as_ptr()) }
+        unsafe { ffi::gtk_widget_set_name(self.unwrap_widget(), c_str.as_ptr()) }
     }
 
     fn get_name(&self) -> Option<String> {
         unsafe {
-            let tmp = ffi::gtk_widget_get_name(self.get_widget());
+            let tmp = ffi::gtk_widget_get_name(self.unwrap_widget());
 
             if tmp.is_null() {
                 None
@@ -109,51 +109,51 @@ pub trait WidgetTrait: gtk::FFIWidget + gtk::GObjectTrait {
     }
 
     fn set_sensitive(&self, sensitive: bool) {
-        unsafe { ffi::gtk_widget_set_sensitive(self.get_widget(), to_gboolean(sensitive)) }
+        unsafe { ffi::gtk_widget_set_sensitive(self.unwrap_widget(), to_gboolean(sensitive)) }
     }
 
     fn set_parent<T: WidgetTrait>(&self, parent: &T) {
-        unsafe { ffi::gtk_widget_set_parent(self.get_widget(), parent.get_widget()) }
+        unsafe { ffi::gtk_widget_set_parent(self.unwrap_widget(), parent.unwrap_widget()) }
     }
 
     /*fn set_parent_window(&self, parent: &Widget) {
-        unsafe { gtk_widget_set_parent_window(self.get_widget(), parent.get_widget()) }
+        unsafe { gtk_widget_set_parent_window(self.unwrap_widget(), parent.unwrap_widget()) }
     }*/
 
     fn get_toplevel(&self) -> Option<Self> {
-        let tmp = unsafe { ffi::gtk_widget_get_toplevel(self.get_widget()) };
+        let tmp = unsafe { ffi::gtk_widget_get_toplevel(self.unwrap_widget()) };
 
         if tmp.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp))
+            Some(gtk::FFIWidget::wrap_widget(tmp))
         }
     }
 
     fn get_ancestor(&self, widget_type: GType) -> Option<Self> {
-        let tmp = unsafe { ffi::gtk_widget_get_ancestor(self.get_widget(), widget_type) };
+        let tmp = unsafe { ffi::gtk_widget_get_ancestor(self.unwrap_widget(), widget_type) };
 
         if tmp.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp))
+            Some(gtk::FFIWidget::wrap_widget(tmp))
         }
     }
 
     fn is_ancestor<T: WidgetTrait>(&self, ancestor: &T) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_is_ancestor(self.get_widget(), ancestor.get_widget())) }
+        unsafe { to_bool(ffi::gtk_widget_is_ancestor(self.unwrap_widget(), ancestor.unwrap_widget())) }
     }
 
     fn hide_on_delete(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_hide_on_delete(self.get_widget())) }
+        unsafe { to_bool(ffi::gtk_widget_hide_on_delete(self.unwrap_widget())) }
     }
 
     fn set_direction(&self, dir: gtk::TextDirection) {
-        unsafe { ffi::gtk_widget_set_direction(self.get_widget(), dir) }
+        unsafe { ffi::gtk_widget_set_direction(self.unwrap_widget(), dir) }
     }
 
     fn get_direction(&self) -> gtk::TextDirection {
-        unsafe { ffi::gtk_widget_get_direction(self.get_widget()) }
+        unsafe { ffi::gtk_widget_get_direction(self.unwrap_widget()) }
     }
 
     fn set_default_direction(dir: gtk::TextDirection) {
@@ -165,18 +165,18 @@ pub trait WidgetTrait: gtk::FFIWidget + gtk::GObjectTrait {
     }
 
     fn in_destruction(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_in_destruction(self.get_widget())) }
+        unsafe { to_bool(ffi::gtk_widget_in_destruction(self.unwrap_widget())) }
     }
 
     fn unparent(&self) {
-        unsafe { ffi::gtk_widget_unparent(self.get_widget()) }
+        unsafe { ffi::gtk_widget_unparent(self.unwrap_widget()) }
     }
 
     fn translate_coordinates<T: WidgetTrait>(&self, dest_widget: &T, src_x: i32, src_y: i32) -> Option<(i32, i32)> {
         let mut dest_x = 0i32;
         let mut dest_y = 0i32;
 
-        let r = to_bool(unsafe { ffi::gtk_widget_translate_coordinates(self.get_widget(), dest_widget.get_widget(), src_x, src_y, &mut dest_x, &mut dest_y) });
+        let r = to_bool(unsafe { ffi::gtk_widget_translate_coordinates(self.unwrap_widget(), dest_widget.unwrap_widget(), src_x, src_y, &mut dest_x, &mut dest_y) });
         if r {
             Some((dest_x, dest_y))
         }
@@ -186,99 +186,99 @@ pub trait WidgetTrait: gtk::FFIWidget + gtk::GObjectTrait {
     }
 
     fn override_background_color(&self, state: gtk::StateFlags, color: &gdk_ffi::C_GdkRGBA) {
-        unsafe { ffi::gtk_widget_override_background_color(self.get_widget(), state, color) }
+        unsafe { ffi::gtk_widget_override_background_color(self.unwrap_widget(), state, color) }
     }
 
     fn override_color(&self, state: gtk::StateFlags, color: &gdk_ffi::C_GdkRGBA) {
-        unsafe { ffi::gtk_widget_override_color(self.get_widget(), state, color) }
+        unsafe { ffi::gtk_widget_override_color(self.unwrap_widget(), state, color) }
     }
 
     fn override_symbolic_color(&self, name: &str, color: &gdk_ffi::C_GdkRGBA) {
         let c_str = CString::from_slice(name.as_bytes());
 
-        unsafe { ffi::gtk_widget_override_symbolic_color(self.get_widget(), c_str.as_ptr(), color); }
+        unsafe { ffi::gtk_widget_override_symbolic_color(self.unwrap_widget(), c_str.as_ptr(), color); }
     }
 
     fn override_cursor(&self, cursor: &gdk_ffi::C_GdkRGBA, secondary_cursor: &gdk_ffi::C_GdkRGBA) {
-        unsafe { ffi::gtk_widget_override_cursor(self.get_widget(), cursor, secondary_cursor) }
+        unsafe { ffi::gtk_widget_override_cursor(self.unwrap_widget(), cursor, secondary_cursor) }
     }
 
     fn queue_draw_area(&self, x: i32, y: i32, width: i32, height: i32) {
-        unsafe { ffi::gtk_widget_queue_draw_area(self.get_widget(), x, y, width, height) }
+        unsafe { ffi::gtk_widget_queue_draw_area(self.unwrap_widget(), x, y, width, height) }
     }
 
     fn set_app_paintable(&self, app_paintable: bool) {
-        unsafe { ffi::gtk_widget_set_app_paintable(self.get_widget(), to_gboolean(app_paintable)) }
+        unsafe { ffi::gtk_widget_set_app_paintable(self.unwrap_widget(), to_gboolean(app_paintable)) }
     }
 
     fn set_double_buffered(&self, double_buffered: bool) {
-        unsafe { ffi::gtk_widget_set_double_buffered(self.get_widget(), to_gboolean(double_buffered)) }
+        unsafe { ffi::gtk_widget_set_double_buffered(self.unwrap_widget(), to_gboolean(double_buffered)) }
     }
 
     fn set_redraw_on_allocate(&self, redraw_on_allocate: bool) {
-        unsafe { ffi::gtk_widget_set_redraw_on_allocate(self.get_widget(), to_gboolean(redraw_on_allocate)) }
+        unsafe { ffi::gtk_widget_set_redraw_on_allocate(self.unwrap_widget(), to_gboolean(redraw_on_allocate)) }
     }
 
     fn mnemonic_activate(&self, group_cycling: bool) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_mnemonic_activate(self.get_widget(), to_gboolean(group_cycling))) }
+        unsafe { to_bool(ffi::gtk_widget_mnemonic_activate(self.unwrap_widget(), to_gboolean(group_cycling))) }
     }
 
     /*fn send_expose(&self, event: &mut gdk::Event) -> i32 {
-        unsafe { ffi::gtk_widget_send_expose(self.get_widget(), event) }
+        unsafe { ffi::gtk_widget_send_expose(self.unwrap_widget(), event) }
     }
 
     fn send_focus_change(&self, event: &mut gdk::Event) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_send_expose(self.get_widget(), event)) }
+        unsafe { to_bool(ffi::gtk_widget_send_expose(self.unwrap_widget(), event)) }
     }*/
 
     fn child_focus(&self, direction: gtk::DirectionType) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_child_focus(self.get_widget(), direction)) }
+        unsafe { to_bool(ffi::gtk_widget_child_focus(self.unwrap_widget(), direction)) }
     }
 
     fn get_child_visible(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_get_child_visible(self.get_widget())) }
+        unsafe { to_bool(ffi::gtk_widget_get_child_visible(self.unwrap_widget())) }
     }
 
     fn get_parent(&self) -> Option<Self> {
-        let tmp = unsafe { ffi::gtk_widget_get_parent(self.get_widget()) };
+        let tmp = unsafe { ffi::gtk_widget_get_parent(self.unwrap_widget()) };
 
         if tmp.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp))
+            Some(gtk::FFIWidget::wrap_widget(tmp))
         }
     }
 
     fn has_screen(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_has_screen(self.get_widget())) }
+        unsafe { to_bool(ffi::gtk_widget_has_screen(self.unwrap_widget())) }
     }
 
     fn get_size_request(&self) -> (i32, i32) {
         let mut width = 0i32;
         let mut height = 0i32;
 
-        unsafe { ffi::gtk_widget_get_size_request(self.get_widget(), &mut width, &mut height) };
+        unsafe { ffi::gtk_widget_get_size_request(self.unwrap_widget(), &mut width, &mut height) };
         (width, height)
     }
 
     fn set_child_visible(&self, is_visible: bool) {
-        unsafe { ffi::gtk_widget_set_child_visible(self.get_widget(), to_gboolean(is_visible)) }
+        unsafe { ffi::gtk_widget_set_child_visible(self.unwrap_widget(), to_gboolean(is_visible)) }
     }
 
     fn set_size_request(&self, width: i32, height: i32) {
-        unsafe { ffi::gtk_widget_set_size_request(self.get_widget(), width, height) }
+        unsafe { ffi::gtk_widget_set_size_request(self.unwrap_widget(), width, height) }
     }
 
     fn set_no_show_all(&self, no_show_all: bool) {
-        unsafe { ffi::gtk_widget_set_no_show_all(self.get_widget(), to_gboolean(no_show_all)) }
+        unsafe { ffi::gtk_widget_set_no_show_all(self.unwrap_widget(), to_gboolean(no_show_all)) }
     }
 
     fn get_no_show_all(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_get_no_show_all(self.get_widget())) }
+        unsafe { to_bool(ffi::gtk_widget_get_no_show_all(self.unwrap_widget())) }
     }
 
     fn list_mnemonic_labels(&self) -> glib::List<Box<Self>> {
-        let tmp = unsafe { ffi::gtk_widget_list_mnemonic_labels(self.get_widget()) };
+        let tmp = unsafe { ffi::gtk_widget_list_mnemonic_labels(self.unwrap_widget()) };
 
         if tmp.is_null() {
             glib::List::new()
@@ -287,35 +287,35 @@ pub trait WidgetTrait: gtk::FFIWidget + gtk::GObjectTrait {
             let mut tmp_vec : glib::List<Box<Self>> = glib::List::new();
 
             for it in old_list.iter() {
-                tmp_vec.append(Box::new(gtk::FFIWidget::wrap(*it)));
+                tmp_vec.append(Box::new(gtk::FFIWidget::wrap_widget(*it)));
             }
             tmp_vec
         }
     }
 
     fn add_mnemonic_label<T: WidgetTrait>(&self, label: &T) {
-        unsafe { ffi::gtk_widget_add_mnemonic_label(self.get_widget(), label.get_widget()) }
+        unsafe { ffi::gtk_widget_add_mnemonic_label(self.unwrap_widget(), label.unwrap_widget()) }
     }
 
     fn remove_mnemonic_label<T: WidgetTrait>(&self, label: &T) {
-        unsafe { ffi::gtk_widget_remove_mnemonic_label(self.get_widget(), label.get_widget()) }
+        unsafe { ffi::gtk_widget_remove_mnemonic_label(self.unwrap_widget(), label.unwrap_widget()) }
     }
 
     fn is_composited(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_is_composited(self.get_widget())) }
+        unsafe { to_bool(ffi::gtk_widget_is_composited(self.unwrap_widget())) }
     }
 
     fn error_bell(&self) {
-        unsafe { ffi::gtk_widget_error_bell(self.get_widget()) }
+        unsafe { ffi::gtk_widget_error_bell(self.unwrap_widget()) }
     }
 
     fn keynav_failed(&self, direction: gtk::DirectionType) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_keynav_failed(self.get_widget(), direction)) }
+        unsafe { to_bool(ffi::gtk_widget_keynav_failed(self.unwrap_widget(), direction)) }
     }
 
     fn get_tooltip_markup(&self) -> Option<String> {
         unsafe {
-            let tmp = ffi::gtk_widget_get_tooltip_markup(self.get_widget());
+            let tmp = ffi::gtk_widget_get_tooltip_markup(self.unwrap_widget());
 
             if tmp.is_null() {
                 None
@@ -332,14 +332,14 @@ pub trait WidgetTrait: gtk::FFIWidget + gtk::GObjectTrait {
         unsafe {
             let c_str = CString::from_slice(markup.as_bytes());
 
-            ffi::gtk_widget_set_tooltip_markup(self.get_widget(), c_str.as_ptr() as *mut c_char);
+            ffi::gtk_widget_set_tooltip_markup(self.unwrap_widget(), c_str.as_ptr() as *mut c_char);
         }
     }
 
 
     fn get_tooltip_text(&self) -> Option<String> {
         unsafe {
-            let tmp = ffi::gtk_widget_get_tooltip_text(self.get_widget());
+            let tmp = ffi::gtk_widget_get_tooltip_text(self.unwrap_widget());
 
             if tmp.is_null() {
                 None
@@ -355,203 +355,203 @@ pub trait WidgetTrait: gtk::FFIWidget + gtk::GObjectTrait {
     fn set_tooltip_text(&self, text: &str) {
         unsafe {
             let c_str = CString::from_slice(text.as_bytes());
-            ffi::gtk_widget_set_tooltip_text(self.get_widget(), c_str.as_ptr() as *mut c_char);
+            ffi::gtk_widget_set_tooltip_text(self.unwrap_widget(), c_str.as_ptr() as *mut c_char);
         }
     }
 
     fn get_has_tooltip(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_get_has_tooltip(self.get_widget())) }
+        unsafe { to_bool(ffi::gtk_widget_get_has_tooltip(self.unwrap_widget())) }
     }
 
     fn set_has_tooltip(&self, has_tooltip: bool) {
-        unsafe { ffi::gtk_widget_set_has_tooltip(self.get_widget(), to_gboolean(has_tooltip)) }
+        unsafe { ffi::gtk_widget_set_has_tooltip(self.unwrap_widget(), to_gboolean(has_tooltip)) }
     }
 
     fn trigger_tooltip_query(&self) {
-        unsafe { ffi::gtk_widget_trigger_tooltip_query(self.get_widget()) }
+        unsafe { ffi::gtk_widget_trigger_tooltip_query(self.unwrap_widget()) }
     }
 
     fn get_allocated_baseline(&self) -> i32 {
-        unsafe { ffi::gtk_widget_get_allocated_baseline(self.get_widget()) }
+        unsafe { ffi::gtk_widget_get_allocated_baseline(self.unwrap_widget()) }
     }
 
     fn get_app_paintable(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_get_app_paintable(self.get_widget())) }
+        unsafe { to_bool(ffi::gtk_widget_get_app_paintable(self.unwrap_widget())) }
     }
 
     fn get_can_default(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_get_can_default(self.get_widget())) }
+        unsafe { to_bool(ffi::gtk_widget_get_can_default(self.unwrap_widget())) }
     }
 
     fn set_can_default(&self, can_default: bool) {
-        unsafe { ffi::gtk_widget_set_can_default(self.get_widget(), to_gboolean(can_default)) }
+        unsafe { ffi::gtk_widget_set_can_default(self.unwrap_widget(), to_gboolean(can_default)) }
     }
 
     fn get_can_focus(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_get_can_focus(self.get_widget())) }
+        unsafe { to_bool(ffi::gtk_widget_get_can_focus(self.unwrap_widget())) }
     }
 
     fn set_can_focus(&self, can_focus: bool) {
-        unsafe { ffi::gtk_widget_set_can_focus(self.get_widget(), to_gboolean(can_focus)) }
+        unsafe { ffi::gtk_widget_set_can_focus(self.unwrap_widget(), to_gboolean(can_focus)) }
     }
 
     fn get_double_buffered(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_get_double_buffered(self.get_widget())) }
+        unsafe { to_bool(ffi::gtk_widget_get_double_buffered(self.unwrap_widget())) }
     }
 
     fn get_has_window(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_get_has_window(self.get_widget())) }
+        unsafe { to_bool(ffi::gtk_widget_get_has_window(self.unwrap_widget())) }
     }
 
     fn set_has_window(&self, has_window: bool) {
-        unsafe { ffi::gtk_widget_set_has_window(self.get_widget(), to_gboolean(has_window)) }
+        unsafe { ffi::gtk_widget_set_has_window(self.unwrap_widget(), to_gboolean(has_window)) }
     }
 
     fn get_sensitive(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_get_sensitive(self.get_widget())) }
+        unsafe { to_bool(ffi::gtk_widget_get_sensitive(self.unwrap_widget())) }
     }
 
     fn is_sensitive(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_is_sensitive(self.get_widget())) }
+        unsafe { to_bool(ffi::gtk_widget_is_sensitive(self.unwrap_widget())) }
     }
 
     fn get_visible(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_get_visible(self.get_widget())) }
+        unsafe { to_bool(ffi::gtk_widget_get_visible(self.unwrap_widget())) }
     }
 
     fn is_visible(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_is_visible(self.get_widget())) }
+        unsafe { to_bool(ffi::gtk_widget_is_visible(self.unwrap_widget())) }
     }
 
     fn set_visible(&self, visible: bool) {
-        unsafe { ffi::gtk_widget_set_visible(self.get_widget(), to_gboolean(visible)) }
+        unsafe { ffi::gtk_widget_set_visible(self.unwrap_widget(), to_gboolean(visible)) }
     }
 
     fn set_state_flags(&self, flags: gtk::StateFlags, clear: bool) {
-        unsafe { ffi::gtk_widget_set_state_flags(self.get_widget(), flags, to_gboolean(clear)) }
+        unsafe { ffi::gtk_widget_set_state_flags(self.unwrap_widget(), flags, to_gboolean(clear)) }
     }
 
     fn unset_state_flags(&self, flags: gtk::StateFlags) {
-        unsafe { ffi::gtk_widget_unset_state_flags(self.get_widget(), flags) }
+        unsafe { ffi::gtk_widget_unset_state_flags(self.unwrap_widget(), flags) }
     }
 
     fn get_state_flags(&self) -> gtk::StateFlags {
-        unsafe { ffi::gtk_widget_get_state_flags(self.get_widget()) }
+        unsafe { ffi::gtk_widget_get_state_flags(self.unwrap_widget()) }
     }
 
     fn has_default(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_has_default(self.get_widget())) }
+        unsafe { to_bool(ffi::gtk_widget_has_default(self.unwrap_widget())) }
     }
 
     fn has_focus(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_has_focus(self.get_widget())) }
+        unsafe { to_bool(ffi::gtk_widget_has_focus(self.unwrap_widget())) }
     }
 
     fn has_visible_focus(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_has_visible_focus(self.get_widget())) }
+        unsafe { to_bool(ffi::gtk_widget_has_visible_focus(self.unwrap_widget())) }
     }
 
     fn has_grab(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_has_grab(self.get_widget())) }
+        unsafe { to_bool(ffi::gtk_widget_has_grab(self.unwrap_widget())) }
     }
 
     fn is_drawable(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_is_drawable(self.get_widget())) }
+        unsafe { to_bool(ffi::gtk_widget_is_drawable(self.unwrap_widget())) }
     }
 
     fn is_toplevel(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_is_toplevel(self.get_widget())) }
+        unsafe { to_bool(ffi::gtk_widget_is_toplevel(self.unwrap_widget())) }
     }
 
     fn set_receives_default(&self, receives_default: bool) {
-        unsafe { ffi::gtk_widget_set_receives_default(self.get_widget(), to_gboolean(receives_default)) }
+        unsafe { ffi::gtk_widget_set_receives_default(self.unwrap_widget(), to_gboolean(receives_default)) }
     }
 
     fn get_receives_default(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_get_receives_default(self.get_widget())) }
+        unsafe { to_bool(ffi::gtk_widget_get_receives_default(self.unwrap_widget())) }
     }
 
     fn set_support_multidevice(&self, support_multidevice: bool) {
-        unsafe { ffi::gtk_widget_set_support_multidevice(self.get_widget(), to_gboolean(support_multidevice)) }
+        unsafe { ffi::gtk_widget_set_support_multidevice(self.unwrap_widget(), to_gboolean(support_multidevice)) }
     }
 
     fn get_support_multidevice(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_get_support_multidevice(self.get_widget())) }
+        unsafe { to_bool(ffi::gtk_widget_get_support_multidevice(self.unwrap_widget())) }
     }
 
     fn set_realized(&self, realized: bool) {
-        unsafe { ffi::gtk_widget_set_realized(self.get_widget(), to_gboolean(realized)) }
+        unsafe { ffi::gtk_widget_set_realized(self.unwrap_widget(), to_gboolean(realized)) }
     }
 
     fn get_realized(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_get_realized(self.get_widget())) }
+        unsafe { to_bool(ffi::gtk_widget_get_realized(self.unwrap_widget())) }
     }
 
     fn set_mapped(&self, mapped: bool) {
-        unsafe { ffi::gtk_widget_set_mapped(self.get_widget(), to_gboolean(mapped)) }
+        unsafe { ffi::gtk_widget_set_mapped(self.unwrap_widget(), to_gboolean(mapped)) }
     }
 
     fn get_mapped(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_get_mapped(self.get_widget())) }
+        unsafe { to_bool(ffi::gtk_widget_get_mapped(self.unwrap_widget())) }
     }
 
     fn get_modifier_mask(&self, intent: gdk::ModifierIntent) -> gdk::ModifierType {
-        unsafe { ffi::gtk_widget_get_modifier_mask(self.get_widget(), intent) }
+        unsafe { ffi::gtk_widget_get_modifier_mask(self.unwrap_widget(), intent) }
     }
 
     fn set_opacity(&self, opacity: f64) {
-        unsafe { ffi::gtk_widget_set_opacity(self.get_widget(), opacity) }
+        unsafe { ffi::gtk_widget_set_opacity(self.unwrap_widget(), opacity) }
     }
 
     fn get_opacity(&self) -> f64 {
-        unsafe { ffi::gtk_widget_get_opacity(self.get_widget()) }
+        unsafe { ffi::gtk_widget_get_opacity(self.unwrap_widget()) }
     }
 
     fn set_margin_top(&mut self, margin: i32) -> () {
         unsafe {
-            ffi::gtk_widget_set_margin_top(self.get_widget(), margin as c_int)
+            ffi::gtk_widget_set_margin_top(self.unwrap_widget(), margin as c_int)
         }
     }
 
     fn set_margin_bottom(&mut self, margin: i32) -> () {
         unsafe {
-            ffi::gtk_widget_set_margin_bottom(self.get_widget(), margin as c_int)
+            ffi::gtk_widget_set_margin_bottom(self.unwrap_widget(), margin as c_int)
         }
     }
 
     fn get_margin_top(&mut self) -> i32 {
         unsafe {
-            ffi::gtk_widget_get_margin_top(self.get_widget()) as i32
+            ffi::gtk_widget_get_margin_top(self.unwrap_widget()) as i32
         }
     }
 
     fn get_margin_bottom(&mut self) -> i32 {
         unsafe {
-            ffi::gtk_widget_get_margin_bottom(self.get_widget()) as i32
+            ffi::gtk_widget_get_margin_bottom(self.unwrap_widget()) as i32
         }
     }
 
     fn get_allocated_width(&self) -> i32 {
         unsafe{
-            ffi::gtk_widget_get_allocated_width(self.get_widget()) as i32
+            ffi::gtk_widget_get_allocated_width(self.unwrap_widget()) as i32
         }
     }
 
     fn get_allocated_height(&self) -> i32 {
         unsafe{
-            ffi::gtk_widget_get_allocated_height(self.get_widget()) as i32
+            ffi::gtk_widget_get_allocated_height(self.unwrap_widget()) as i32
         }
     }
 
     fn reset_style(&self) {
-        unsafe { ffi::gtk_widget_reset_style(self.get_widget()) }
+        unsafe { ffi::gtk_widget_reset_style(self.unwrap_widget()) }
     }
 
     fn get_preferred_height(&self) -> (i32, i32) {
         let mut minimum_height = 0i32;
         let mut natural_height = 0i32;
 
-        unsafe { ffi::gtk_widget_get_preferred_height(self.get_widget(), &mut minimum_height, &mut natural_height); }
+        unsafe { ffi::gtk_widget_get_preferred_height(self.unwrap_widget(), &mut minimum_height, &mut natural_height); }
         (minimum_height, natural_height)
     }
 
@@ -559,7 +559,7 @@ pub trait WidgetTrait: gtk::FFIWidget + gtk::GObjectTrait {
         let mut minimum_width = 0i32;
         let mut natural_width = 0i32;
 
-        unsafe { ffi::gtk_widget_get_preferred_width(self.get_widget(), &mut minimum_width, &mut natural_width); }
+        unsafe { ffi::gtk_widget_get_preferred_width(self.unwrap_widget(), &mut minimum_width, &mut natural_width); }
         (minimum_width, natural_width)
     }
 
@@ -567,7 +567,7 @@ pub trait WidgetTrait: gtk::FFIWidget + gtk::GObjectTrait {
         let mut minimum_height = 0i32;
         let mut natural_height = 0i32;
 
-        unsafe { ffi::gtk_widget_get_preferred_height_for_width(self.get_widget(), width, &mut minimum_height, &mut natural_height) };
+        unsafe { ffi::gtk_widget_get_preferred_height_for_width(self.unwrap_widget(), width, &mut minimum_height, &mut natural_height) };
         (minimum_height, natural_height)
     }
 
@@ -575,7 +575,7 @@ pub trait WidgetTrait: gtk::FFIWidget + gtk::GObjectTrait {
         let mut minimum_width = 0i32;
         let mut natural_width = 0i32;
 
-        unsafe { ffi::gtk_widget_get_preferred_width_for_height(self.get_widget(), height, &mut minimum_width, &mut natural_width) };
+        unsafe { ffi::gtk_widget_get_preferred_width_for_height(self.unwrap_widget(), height, &mut minimum_width, &mut natural_width) };
         (minimum_width, natural_width)
     }
 
@@ -585,119 +585,119 @@ pub trait WidgetTrait: gtk::FFIWidget + gtk::GObjectTrait {
         let mut minimum_baseline = 0i32;
         let mut natural_baseline = 0i32;
 
-        unsafe { ffi::gtk_widget_get_preferred_height_and_baseline_for_width(self.get_widget(), width, &mut minimum_height,
+        unsafe { ffi::gtk_widget_get_preferred_height_and_baseline_for_width(self.unwrap_widget(), width, &mut minimum_height,
             &mut natural_height, &mut minimum_baseline, &mut natural_baseline) };
 
         (minimum_height, natural_height, minimum_baseline, natural_baseline)
     }
 
     fn get_request_mode(&self) -> gtk::SizeRequestMode {
-        unsafe { ffi::gtk_widget_get_request_mode(self.get_widget()) }
+        unsafe { ffi::gtk_widget_get_request_mode(self.unwrap_widget()) }
     }
 
     fn get_halign(&self) -> gtk::Align {
-        unsafe { ffi::gtk_widget_get_halign(self.get_widget()) }
+        unsafe { ffi::gtk_widget_get_halign(self.unwrap_widget()) }
     }
 
     fn set_halign(&self, align: gtk::Align) {
-        unsafe { ffi::gtk_widget_set_halign(self.get_widget(), align) }
+        unsafe { ffi::gtk_widget_set_halign(self.unwrap_widget(), align) }
     }
 
     fn get_valign(&self) -> gtk::Align {
-        unsafe { ffi::gtk_widget_get_valign(self.get_widget()) }
+        unsafe { ffi::gtk_widget_get_valign(self.unwrap_widget()) }
     }
 
     fn get_valign_with_baseline(&self) -> gtk::Align {
-        unsafe { ffi::gtk_widget_get_valign_with_baseline(self.get_widget()) }
+        unsafe { ffi::gtk_widget_get_valign_with_baseline(self.unwrap_widget()) }
     }
 
     fn set_valign(&self, align: gtk::Align) {
-        unsafe { ffi::gtk_widget_set_valign(self.get_widget(), align) }
+        unsafe { ffi::gtk_widget_set_valign(self.unwrap_widget(), align) }
     }
 
     fn get_margin_start(&self) -> i32 {
-        unsafe { ffi::gtk_widget_get_margin_start(self.get_widget()) }
+        unsafe { ffi::gtk_widget_get_margin_start(self.unwrap_widget()) }
     }
 
     fn set_margin_start(&self, margin: i32) {
-        unsafe { ffi::gtk_widget_set_margin_start(self.get_widget(), margin) }
+        unsafe { ffi::gtk_widget_set_margin_start(self.unwrap_widget(), margin) }
     }
 
     fn get_margin_end(&self) -> i32 {
-        unsafe { ffi::gtk_widget_get_margin_end(self.get_widget()) }
+        unsafe { ffi::gtk_widget_get_margin_end(self.unwrap_widget()) }
     }
 
     fn set_margin_end(&self, margin: i32) {
-        unsafe { ffi::gtk_widget_set_margin_end(self.get_widget(), margin) }
+        unsafe { ffi::gtk_widget_set_margin_end(self.unwrap_widget(), margin) }
     }
 
     fn get_hexpand(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_get_hexpand(self.get_widget())) }
+        unsafe { to_bool(ffi::gtk_widget_get_hexpand(self.unwrap_widget())) }
     }
 
     fn set_hexpand(&self, expand: bool) {
-        unsafe { ffi::gtk_widget_set_hexpand(self.get_widget(), to_gboolean(expand)) }
+        unsafe { ffi::gtk_widget_set_hexpand(self.unwrap_widget(), to_gboolean(expand)) }
     }
 
     fn get_hexpand_set(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_get_hexpand_set(self.get_widget())) }
+        unsafe { to_bool(ffi::gtk_widget_get_hexpand_set(self.unwrap_widget())) }
     }
 
     fn set_hexpand_set(&self, expand: bool) {
-        unsafe { ffi::gtk_widget_set_hexpand_set(self.get_widget(), to_gboolean(expand)) }
+        unsafe { ffi::gtk_widget_set_hexpand_set(self.unwrap_widget(), to_gboolean(expand)) }
     }
 
     fn get_vexpand(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_get_vexpand(self.get_widget())) }
+        unsafe { to_bool(ffi::gtk_widget_get_vexpand(self.unwrap_widget())) }
     }
 
     fn set_vexpand(&self, expand: bool) {
-        unsafe { ffi::gtk_widget_set_vexpand(self.get_widget(), to_gboolean(expand)) }
+        unsafe { ffi::gtk_widget_set_vexpand(self.unwrap_widget(), to_gboolean(expand)) }
     }
 
     fn get_vexpand_set(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_get_vexpand_set(self.get_widget())) }
+        unsafe { to_bool(ffi::gtk_widget_get_vexpand_set(self.unwrap_widget())) }
     }
 
     fn set_vexpand_set(&self, expand: bool) {
-        unsafe { ffi::gtk_widget_set_vexpand_set(self.get_widget(), to_gboolean(expand)) }
+        unsafe { ffi::gtk_widget_set_vexpand_set(self.unwrap_widget(), to_gboolean(expand)) }
     }
 
     fn queue_compute_expand(&self) {
-        unsafe { ffi::gtk_widget_queue_compute_expand(self.get_widget()) }
+        unsafe { ffi::gtk_widget_queue_compute_expand(self.unwrap_widget()) }
     }
 
     fn compute_expand(&self, orientation: gtk::Orientation) -> bool {
-        unsafe { to_bool(ffi::gtk_widget_compute_expand(self.get_widget(), orientation)) }
+        unsafe { to_bool(ffi::gtk_widget_compute_expand(self.unwrap_widget(), orientation)) }
     }
 
     fn init_template(&self) {
-        unsafe { ffi::gtk_widget_init_template(self.get_widget()) }
+        unsafe { ffi::gtk_widget_init_template(self.unwrap_widget()) }
     }
 
     fn thaw_child_notify(&self) {
-        unsafe { ffi::gtk_widget_thaw_child_notify(self.get_widget()) }
+        unsafe { ffi::gtk_widget_thaw_child_notify(self.unwrap_widget()) }
     }
 
     fn freeze_child_notify(&self) {
-        unsafe { ffi::gtk_widget_freeze_child_notify(self.get_widget()) }
+        unsafe { ffi::gtk_widget_freeze_child_notify(self.unwrap_widget()) }
     }
 
     fn child_notify(&self, child_property: &str) {
         unsafe {
             let c_str = CString::from_slice(child_property.as_bytes());
 
-            ffi::gtk_widget_child_notify(self.get_widget(), c_str.as_ptr())
+            ffi::gtk_widget_child_notify(self.unwrap_widget(), c_str.as_ptr())
         }
     }
 
     fn destroy(&self) {
-        unsafe { ffi::gtk_widget_destroy(self.get_widget()) }
+        unsafe { ffi::gtk_widget_destroy(self.unwrap_widget()) }
     }
 
     fn destroyed(&self, other: &Self) {
-        let mut tmp = other.get_widget();
+        let mut tmp = other.unwrap_widget();
 
-        unsafe { ffi::gtk_widget_destroyed(self.get_widget(), &mut tmp) }
+        unsafe { ffi::gtk_widget_destroyed(self.unwrap_widget(), &mut tmp) }
     }
 }

--- a/src/gtk/traits/window.rs
+++ b/src/gtk/traits/window.rs
@@ -24,19 +24,19 @@ pub trait WindowTrait : gtk::WidgetTrait {
         unsafe {
             let c_str = CString::from_slice(title.as_bytes());
 
-            ffi::gtk_window_set_title(GTK_WINDOW(self.get_widget()), c_str.as_ptr());
+            ffi::gtk_window_set_title(GTK_WINDOW(self.unwrap_widget()), c_str.as_ptr());
         }
     }
 
     fn set_decorated(&mut self, setting: bool) -> () {
         unsafe {
-            ffi::gtk_window_set_decorated(GTK_WINDOW(self.get_widget()), to_gboolean(setting));
+            ffi::gtk_window_set_decorated(GTK_WINDOW(self.unwrap_widget()), to_gboolean(setting));
         }
     }
 
     fn get_title(&self) -> Option<String> {
         unsafe {
-            let c_title = ffi::gtk_window_get_title(GTK_WINDOW(self.get_widget()));
+            let c_title = ffi::gtk_window_get_title(GTK_WINDOW(self.unwrap_widget()));
 
             if c_title.is_null() {
                 None
@@ -48,20 +48,20 @@ pub trait WindowTrait : gtk::WidgetTrait {
 
     fn set_default_size(&self, width: i32, height: i32){
         unsafe {
-            ffi::gtk_window_set_default_size(self.get_widget(), width, height)
+            ffi::gtk_window_set_default_size(self.unwrap_widget(), width, height)
         }
     }
 
     fn set_window_position(&self, window_position: WindowPosition) {
         unsafe {
-            ffi::gtk_window_set_position(GTK_WINDOW(self.get_widget()), window_position);
+            ffi::gtk_window_set_position(GTK_WINDOW(self.unwrap_widget()), window_position);
         }
     }
 
     #[cfg(any(feature = "GTK_3_10",feature = "GTK_3_12", feature = "GTK_3_14"))]
     fn set_titlebar<T: gtk::WidgetTrait>(&self, titlebar: &T) {
         unsafe {
-            ffi::gtk_window_set_titlebar(GTK_WINDOW(self.get_widget()), titlebar.get_widget());
+            ffi::gtk_window_set_titlebar(GTK_WINDOW(self.unwrap_widget()), titlebar.unwrap_widget());
         }
     }
 }

--- a/src/gtk/widgets/about_dialog.rs
+++ b/src/gtk/widgets/about_dialog.rs
@@ -28,13 +28,13 @@ impl AboutDialog {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 
     pub fn get_program_name(&self) -> Option<String> {
         unsafe {
-            let name = ffi::gtk_about_dialog_get_program_name(GTK_ABOUT_DIALOG(self.get_widget()));
+            let name = ffi::gtk_about_dialog_get_program_name(GTK_ABOUT_DIALOG(self.unwrap_widget()));
 
             if name.is_null() {
                 None
@@ -48,13 +48,13 @@ impl AboutDialog {
         unsafe {
             let c_str = CString::from_slice(name.as_bytes());
 
-            ffi::gtk_about_dialog_set_program_name(GTK_ABOUT_DIALOG(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_about_dialog_set_program_name(GTK_ABOUT_DIALOG(self.unwrap_widget()), c_str.as_ptr())
         };
     }
 
     pub fn get_version(&self) -> Option<String> {
         unsafe {
-            let version = ffi::gtk_about_dialog_get_version(GTK_ABOUT_DIALOG(self.get_widget()));
+            let version = ffi::gtk_about_dialog_get_version(GTK_ABOUT_DIALOG(self.unwrap_widget()));
 
             if version.is_null() {
                 None
@@ -68,13 +68,13 @@ impl AboutDialog {
         unsafe {
             let c_str = CString::from_slice(version.as_bytes());
 
-            ffi::gtk_about_dialog_set_version(GTK_ABOUT_DIALOG(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_about_dialog_set_version(GTK_ABOUT_DIALOG(self.unwrap_widget()), c_str.as_ptr())
         };
     }
 
     pub fn get_copyright(&self) -> Option<String> {
         unsafe {
-            let copyright = ffi::gtk_about_dialog_get_copyright(GTK_ABOUT_DIALOG(self.get_widget()));
+            let copyright = ffi::gtk_about_dialog_get_copyright(GTK_ABOUT_DIALOG(self.unwrap_widget()));
 
             if copyright.is_null() {
                 None
@@ -88,13 +88,13 @@ impl AboutDialog {
         unsafe {
             let c_str = CString::from_slice(copyright.as_bytes());
 
-            ffi::gtk_about_dialog_set_copyright(GTK_ABOUT_DIALOG(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_about_dialog_set_copyright(GTK_ABOUT_DIALOG(self.unwrap_widget()), c_str.as_ptr())
         };
     }
 
     pub fn get_comments(&self) -> Option<String> {
         unsafe {
-            let comments = ffi::gtk_about_dialog_get_comments(GTK_ABOUT_DIALOG(self.get_widget()));
+            let comments = ffi::gtk_about_dialog_get_comments(GTK_ABOUT_DIALOG(self.unwrap_widget()));
 
             if comments.is_null() {
                 None
@@ -108,13 +108,13 @@ impl AboutDialog {
         unsafe {
             let c_str = CString::from_slice(comments.as_bytes());
 
-            ffi::gtk_about_dialog_set_comments(GTK_ABOUT_DIALOG(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_about_dialog_set_comments(GTK_ABOUT_DIALOG(self.unwrap_widget()), c_str.as_ptr())
         };
     }
 
     pub fn get_license(&self) -> Option<String> {
         unsafe {
-            let license = ffi::gtk_about_dialog_get_license(GTK_ABOUT_DIALOG(self.get_widget()));
+            let license = ffi::gtk_about_dialog_get_license(GTK_ABOUT_DIALOG(self.unwrap_widget()));
 
             if license.is_null() {
                 None
@@ -128,29 +128,29 @@ impl AboutDialog {
         unsafe {
             let c_str = CString::from_slice(license.as_bytes());
 
-            ffi::gtk_about_dialog_set_license(GTK_ABOUT_DIALOG(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_about_dialog_set_license(GTK_ABOUT_DIALOG(self.unwrap_widget()), c_str.as_ptr())
         };
     }
 
     pub fn get_wrap_license(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_about_dialog_get_wrap_license(GTK_ABOUT_DIALOG(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_about_dialog_get_wrap_license(GTK_ABOUT_DIALOG(self.unwrap_widget()))) }
     }
 
     pub fn set_wrap_license(&self, wrap_license: bool) -> () {
-        unsafe { ffi::gtk_about_dialog_set_wrap_license(GTK_ABOUT_DIALOG(self.get_widget()), to_gboolean(wrap_license)) }
+        unsafe { ffi::gtk_about_dialog_set_wrap_license(GTK_ABOUT_DIALOG(self.unwrap_widget()), to_gboolean(wrap_license)) }
     }
 
     pub fn get_license_type(&self) -> gtk::License {
-        unsafe { ffi::gtk_about_dialog_get_license_type(GTK_ABOUT_DIALOG(self.get_widget())) }
+        unsafe { ffi::gtk_about_dialog_get_license_type(GTK_ABOUT_DIALOG(self.unwrap_widget())) }
     }
 
     pub fn set_license_type(&self, license_type: gtk::License) -> () {
-        unsafe { ffi::gtk_about_dialog_set_license_type(GTK_ABOUT_DIALOG(self.get_widget()), license_type) }
+        unsafe { ffi::gtk_about_dialog_set_license_type(GTK_ABOUT_DIALOG(self.unwrap_widget()), license_type) }
     }
 
     pub fn get_website(&self) -> Option<String> {
         unsafe {
-            let website = ffi::gtk_about_dialog_get_website(GTK_ABOUT_DIALOG(self.get_widget()));
+            let website = ffi::gtk_about_dialog_get_website(GTK_ABOUT_DIALOG(self.unwrap_widget()));
 
             if website.is_null() {
                 None
@@ -164,13 +164,13 @@ impl AboutDialog {
         unsafe {
             let c_str = CString::from_slice(website.as_bytes());
 
-            ffi::gtk_about_dialog_set_website(GTK_ABOUT_DIALOG(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_about_dialog_set_website(GTK_ABOUT_DIALOG(self.unwrap_widget()), c_str.as_ptr())
         };
     }
 
     pub fn get_website_label(&self) -> Option<String> {
         unsafe {
-            let website_label = ffi::gtk_about_dialog_get_website_label(GTK_ABOUT_DIALOG(self.get_widget()));
+            let website_label = ffi::gtk_about_dialog_get_website_label(GTK_ABOUT_DIALOG(self.unwrap_widget()));
 
             if website_label.is_null() {
                 None
@@ -184,12 +184,12 @@ impl AboutDialog {
         unsafe {
             let c_str = CString::from_slice(website_label.as_bytes());
 
-            ffi::gtk_about_dialog_set_website_label(GTK_ABOUT_DIALOG(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_about_dialog_set_website_label(GTK_ABOUT_DIALOG(self.unwrap_widget()), c_str.as_ptr())
         };
     }
 
     pub fn get_authors(&self) -> Vec<String> {
-        let authors = unsafe { ffi::gtk_about_dialog_get_authors(GTK_ABOUT_DIALOG(self.get_widget())) };
+        let authors = unsafe { ffi::gtk_about_dialog_get_authors(GTK_ABOUT_DIALOG(self.unwrap_widget())) };
         let mut ret = Vec::new();
 
         if !authors.is_null() {
@@ -218,11 +218,11 @@ impl AboutDialog {
 
             tmp_vec.push(c_str.as_ptr());
         }
-        unsafe { ffi::gtk_about_dialog_set_authors(GTK_ABOUT_DIALOG(self.get_widget()), tmp_vec.as_slice().as_ptr()) }
+        unsafe { ffi::gtk_about_dialog_set_authors(GTK_ABOUT_DIALOG(self.unwrap_widget()), tmp_vec.as_slice().as_ptr()) }
     }
 
     pub fn get_artists(&self) -> Vec<String> {
-        let artists = unsafe { ffi::gtk_about_dialog_get_artists(GTK_ABOUT_DIALOG(self.get_widget())) };
+        let artists = unsafe { ffi::gtk_about_dialog_get_artists(GTK_ABOUT_DIALOG(self.unwrap_widget())) };
         let mut ret = Vec::new();
 
         if !artists.is_null() {
@@ -251,11 +251,11 @@ impl AboutDialog {
 
             tmp_vec.push(c_str.as_ptr());
         }
-        unsafe { ffi::gtk_about_dialog_set_artists(GTK_ABOUT_DIALOG(self.get_widget()), tmp_vec.as_slice().as_ptr()) }
+        unsafe { ffi::gtk_about_dialog_set_artists(GTK_ABOUT_DIALOG(self.unwrap_widget()), tmp_vec.as_slice().as_ptr()) }
     }
 
     pub fn get_documenters(&self) -> Vec<String> {
-        let documenters = unsafe { ffi::gtk_about_dialog_get_documenters(GTK_ABOUT_DIALOG(self.get_widget())) };
+        let documenters = unsafe { ffi::gtk_about_dialog_get_documenters(GTK_ABOUT_DIALOG(self.unwrap_widget())) };
         let mut ret = Vec::new();
 
         if !documenters.is_null() {
@@ -284,12 +284,12 @@ impl AboutDialog {
             
             tmp_vec.push(c_str.as_ptr());
         }
-        unsafe { ffi::gtk_about_dialog_set_documenters(GTK_ABOUT_DIALOG(self.get_widget()), tmp_vec.as_slice().as_ptr()) }
+        unsafe { ffi::gtk_about_dialog_set_documenters(GTK_ABOUT_DIALOG(self.unwrap_widget()), tmp_vec.as_slice().as_ptr()) }
     }
 
     pub fn get_translator_credits(&self) -> Option<String> {
         unsafe {
-            let translator_credits = ffi::gtk_about_dialog_get_translator_credits(GTK_ABOUT_DIALOG(self.get_widget()));
+            let translator_credits = ffi::gtk_about_dialog_get_translator_credits(GTK_ABOUT_DIALOG(self.unwrap_widget()));
 
             if translator_credits.is_null() {
                 None
@@ -303,7 +303,7 @@ impl AboutDialog {
         unsafe {
             let c_str = CString::from_slice(translator_credits.as_bytes());
 
-            ffi::gtk_about_dialog_set_translator_credits(GTK_ABOUT_DIALOG(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_about_dialog_set_translator_credits(GTK_ABOUT_DIALOG(self.unwrap_widget()), c_str.as_ptr())
         };
     }
 
@@ -313,17 +313,17 @@ impl AboutDialog {
         if logo.is_null() {
             None
         } else {
-            Some(unsafe { gtk::FFIWidget::wrap(logo) })
+            Some(unsafe { gtk::FFIWidget::wrap_widget(logo) })
         }
     }
 
     pub fn set_logo(&self, logo: Pixbuf) -> () {
-        unsafe { ffi::gtk_about_dialog_set_logo(GTK_ABOUT_DIALOG(self.get_widget()), GDK_PIXBUF(logo.get_widget())) }
+        unsafe { ffi::gtk_about_dialog_set_logo(GTK_ABOUT_DIALOG(self.unwrap_widget()), GDK_PIXBUF(logo.unwrap_widget())) }
     }*/
 
     pub fn get_logo_icon_name(&self) -> Option<String> {
         unsafe {
-            let logo_icon_name = ffi::gtk_about_dialog_get_logo_icon_name(GTK_ABOUT_DIALOG(self.get_widget()));
+            let logo_icon_name = ffi::gtk_about_dialog_get_logo_icon_name(GTK_ABOUT_DIALOG(self.unwrap_widget()));
 
             if logo_icon_name.is_null() {
                 None
@@ -337,7 +337,7 @@ impl AboutDialog {
         unsafe {
             let c_str = CString::from_slice(logo_icon_name.as_bytes());
 
-            ffi::gtk_about_dialog_set_logo_icon_name(GTK_ABOUT_DIALOG(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_about_dialog_set_logo_icon_name(GTK_ABOUT_DIALOG(self.unwrap_widget()), c_str.as_ptr())
         };
     }
 
@@ -352,7 +352,7 @@ impl AboutDialog {
         unsafe {
             let c_str = CString::from_slice(section_name.as_bytes());
 
-            ffi::gtk_about_dialog_add_credit_section(GTK_ABOUT_DIALOG(self.get_widget()), c_str.as_ptr(), tmp_vec.as_slice().as_ptr())
+            ffi::gtk_about_dialog_add_credit_section(GTK_ABOUT_DIALOG(self.unwrap_widget()), c_str.as_ptr(), tmp_vec.as_slice().as_ptr())
         }
     }
 

--- a/src/gtk/widgets/action_bar.rs
+++ b/src/gtk/widgets/action_bar.rs
@@ -33,28 +33,28 @@ impl ActionBar {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 
     pub fn set_center_widget<T: gtk::WidgetTrait>(&mut self, center_widget: &T) {
         unsafe {
             ffi::gtk_action_bar_set_center_widget(GTK_ACTION_BAR(self.pointer),
-                                                  center_widget.get_widget())
+                                                  center_widget.unwrap_widget())
         }
     }
 
     pub fn pack_start<T: gtk::WidgetTrait>(&mut self, child: &T) {
         unsafe {
             ffi::gtk_action_bar_pack_start(GTK_ACTION_BAR(self.pointer),
-                                           child.get_widget())
+                                           child.unwrap_widget())
         }
     }
 
     pub fn pack_end<T: gtk::WidgetTrait>(&mut self, child: &T) {
         unsafe {
             ffi::gtk_action_bar_pack_end(GTK_ACTION_BAR(self.pointer),
-                                         child.get_widget())
+                                         child.unwrap_widget())
         }
     }
 }

--- a/src/gtk/widgets/adjustment.rs
+++ b/src/gtk/widgets/adjustment.rs
@@ -159,7 +159,7 @@ impl Adjustment {
     }
 
     #[doc(hidden)]
-    pub fn get_pointer(&self) -> *mut ffi::C_GtkAdjustment {
+    pub fn unwrap_pointer(&self) -> *mut ffi::C_GtkAdjustment {
         self.pointer
     }
 

--- a/src/gtk/widgets/app_chooser_dialog.rs
+++ b/src/gtk/widgets/app_chooser_dialog.rs
@@ -26,7 +26,7 @@ impl AppChooserDialog {
             let c_str = CString::from_slice(content_type.as_bytes());
 
             ffi::gtk_app_chooser_dialog_new_for_content_type(match parent {
-                Some(ref p) => GTK_WINDOW(p.get_widget()),
+                Some(ref p) => GTK_WINDOW(p.unwrap_widget()),
                 None => ::std::ptr::null_mut()
             }, flags, c_str.as_ptr())
         };
@@ -34,17 +34,17 @@ impl AppChooserDialog {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 
     pub fn widget<T: gtk::WidgetTrait>(&self) -> Option<T> {
-        let tmp_pointer = unsafe { ffi::gtk_app_chooser_dialog_get_widget(GTK_APP_CHOOSER_DIALOG(self.get_widget())) };
+        let tmp_pointer = unsafe { ffi::gtk_app_chooser_dialog_get_widget(GTK_APP_CHOOSER_DIALOG(self.unwrap_widget())) };
 
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 
@@ -52,13 +52,13 @@ impl AppChooserDialog {
         unsafe {
             let c_str = CString::from_slice(heading.as_bytes());
 
-            ffi::gtk_app_chooser_dialog_set_heading(GTK_APP_CHOOSER_DIALOG(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_app_chooser_dialog_set_heading(GTK_APP_CHOOSER_DIALOG(self.unwrap_widget()), c_str.as_ptr())
         }
     }
 
     pub fn get_heading(&self) -> Option<String> {
         unsafe {
-            let tmp_pointer = ffi::gtk_app_chooser_dialog_get_heading(GTK_APP_CHOOSER_DIALOG(self.get_widget()));
+            let tmp_pointer = ffi::gtk_app_chooser_dialog_get_heading(GTK_APP_CHOOSER_DIALOG(self.unwrap_widget()));
 
             if tmp_pointer.is_null() {
                 None

--- a/src/gtk/widgets/app_info.rs
+++ b/src/gtk/widgets/app_info.rs
@@ -38,16 +38,16 @@ impl AppInfo {/*
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer as *mut gtk::ffi::C_GtkWidget))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer as *mut gtk::ffi::C_GtkWidget))
         }
     }
 
     pub fn equals(&self, other: &AppInfo) -> bool {
-        unsafe { to_bool(ffi::g_app_info_equal(GTK_APP_INFO(self.get_widget()), GTK_APP_INFO(other.get_widget()))) }
+        unsafe { to_bool(ffi::g_app_info_equal(GTK_APP_INFO(self.unwrap_widget()), GTK_APP_INFO(other.unwrap_widget()))) }
     }
 
     pub fn get_id(&self) -> Option<String> {
-        let tmp_pointer = unsafe { ffi::g_app_info_get_id(GTK_APP_INFO(self.get_widget())) };
+        let tmp_pointer = unsafe { ffi::g_app_info_get_id(GTK_APP_INFO(self.unwrap_widget())) };
 
         if tmp_pointer.is_null() {
             None
@@ -57,7 +57,7 @@ impl AppInfo {/*
     }
 
     pub fn get_name(&self) -> Option<String> {
-        let tmp_pointer = unsafe { ffi::g_app_info_get_name(GTK_APP_INFO(self.get_widget())) };
+        let tmp_pointer = unsafe { ffi::g_app_info_get_name(GTK_APP_INFO(self.unwrap_widget())) };
 
         if tmp_pointer.is_null() {
             None
@@ -67,7 +67,7 @@ impl AppInfo {/*
     }
 
     pub fn get_display_name(&self) -> Option<String> {
-        let tmp_pointer = unsafe { ffi::g_app_info_get_display_name(GTK_APP_INFO(self.get_widget())) };
+        let tmp_pointer = unsafe { ffi::g_app_info_get_display_name(GTK_APP_INFO(self.unwrap_widget())) };
 
         if tmp_pointer.is_null() {
             None
@@ -77,7 +77,7 @@ impl AppInfo {/*
     }
 
     pub fn get_description(&self) -> Option<String> {
-        let tmp_pointer = unsafe { ffi::g_app_info_get_description(GTK_APP_INFO(self.get_widget())) };
+        let tmp_pointer = unsafe { ffi::g_app_info_get_description(GTK_APP_INFO(self.unwrap_widget())) };
 
         if tmp_pointer.is_null() {
             None
@@ -87,7 +87,7 @@ impl AppInfo {/*
     }
 
     pub fn get_executable(&self) -> Option<String> {
-        let tmp_pointer = unsafe { ffi::g_app_info_get_executable(GTK_APP_INFO(self.get_widget())) };
+        let tmp_pointer = unsafe { ffi::g_app_info_get_executable(GTK_APP_INFO(self.unwrap_widget())) };
 
         if tmp_pointer.is_null() {
             None
@@ -97,7 +97,7 @@ impl AppInfo {/*
     }
 
     pub fn get_commandline(&self) -> Option<String> {
-        let tmp_pointer = unsafe { ffi::g_app_info_get_commandline(GTK_APP_INFO(self.get_widget())) };
+        let tmp_pointer = unsafe { ffi::g_app_info_get_commandline(GTK_APP_INFO(self.unwrap_widget())) };
 
         if tmp_pointer.is_null() {
             None
@@ -107,37 +107,37 @@ impl AppInfo {/*
     }
 
     pub fn launch(&self, files: &mut glib::List, launch_context: &mut gtk::AppLaunchContext, error: &mut glib::Error) -> bool {
-        unsafe { to_bool({ ffi::g_app_info_launch(GTK_APP_INFO(self.get_widget()),
+        unsafe { to_bool({ ffi::g_app_info_launch(GTK_APP_INFO(self.unwrap_widget()),
             files.unwrap(),
-            GTK_APP_LAUNCH_CONTEXT(launch_context.get_widget()),
+            GTK_APP_LAUNCH_CONTEXT(launch_context.unwrap_widget()),
             &mut error.unwrap()) }) }
     }
 
     pub fn supports_files(&self) -> bool {
-        unsafe { to_bool(ffi::g_app_info_supports_files(GTK_APP_INFO(self.get_widget()))) }
+        unsafe { to_bool(ffi::g_app_info_supports_files(GTK_APP_INFO(self.unwrap_widget()))) }
     }
 
     pub fn supports_uris(&self) -> bool {
-        unsafe { to_bool(ffi::g_app_info_supports_uris(GTK_APP_INFO(self.get_widget()))) }
+        unsafe { to_bool(ffi::g_app_info_supports_uris(GTK_APP_INFO(self.unwrap_widget()))) }
     }
 
     pub fn launch_uris(&self, uris: &mut glib::List, launch_context: &mut gtk::AppLaunchContext, error: &mut glib::Error) -> bool {
-        unsafe { to_bool({ ffi::g_app_info_launch_uris(GTK_APP_INFO(self.get_widget()),
+        unsafe { to_bool({ ffi::g_app_info_launch_uris(GTK_APP_INFO(self.unwrap_widget()),
             uris.unwrap(),
-            GTK_APP_LAUNCH_CONTEXT(launch_context.get_widget()),
+            GTK_APP_LAUNCH_CONTEXT(launch_context.unwrap_widget()),
             &mut error.unwrap()) }) }
     }
 
     pub fn should_show(&self) -> bool {
-        unsafe { to_bool(ffi::g_app_info_should_show(GTK_APP_INFO(self.get_widget()))) }
+        unsafe { to_bool(ffi::g_app_info_should_show(GTK_APP_INFO(self.unwrap_widget()))) }
     }
 
     pub fn can_delete(&self) -> bool {
-        unsafe { to_bool(ffi::g_app_info_can_delete(GTK_APP_INFO(self.get_widget()))) }
+        unsafe { to_bool(ffi::g_app_info_can_delete(GTK_APP_INFO(self.unwrap_widget()))) }
     }
 
     pub fn delete(&self) -> bool {
-        unsafe { to_bool(ffi::g_app_info_delete(GTK_APP_INFO(self.get_widget()))) }
+        unsafe { to_bool(ffi::g_app_info_delete(GTK_APP_INFO(self.unwrap_widget()))) }
     }
 
     pub fn reset_type_associations(&self, content_type: &str) -> () {
@@ -151,7 +151,7 @@ impl AppInfo {/*
     pub fn set_as_default_for_type(&self, content_type: &str, error: &mut glib::Error) -> bool {
         unsafe { to_bool({
             content_type.with_c_str(|c_str| {
-                ffi::g_app_info_set_as_default_for_type(GTK_APP_INFO(self.get_widget()), c_str, &mut error.unwrap())
+                ffi::g_app_info_set_as_default_for_type(GTK_APP_INFO(self.unwrap_widget()), c_str, &mut error.unwrap())
             })
         }) }
     }
@@ -159,7 +159,7 @@ impl AppInfo {/*
     pub fn set_as_default_for_extension(&self, extension: &str, error: &mut glib::Error) -> bool {
         unsafe { to_bool({
             extension.with_c_str(|c_str| {
-                ffi::g_app_info_set_as_default_for_extension(GTK_APP_INFO(self.get_widget()), c_str, &mut error.unwrap())
+                ffi::g_app_info_set_as_default_for_extension(GTK_APP_INFO(self.unwrap_widget()), c_str, &mut error.unwrap())
             })
         }) }
     }
@@ -167,7 +167,7 @@ impl AppInfo {/*
     pub fn set_as_last_used_for_type(&self, content_type: &str, error: &mut glib::Error) -> bool {
         unsafe { to_bool({
             content_type.with_c_str(|c_str| {
-                ffi::g_app_info_set_as_last_used_for_type(GTK_APP_INFO(self.get_widget()), c_str, &mut error.unwrap())
+                ffi::g_app_info_set_as_last_used_for_type(GTK_APP_INFO(self.unwrap_widget()), c_str, &mut error.unwrap())
             })
         }) }
     }
@@ -175,25 +175,25 @@ impl AppInfo {/*
     pub fn add_supports_type(&self, content_type: &str, error: &mut glib::Error) -> bool {
         unsafe { to_bool({
             content_type.with_c_str(|c_str| {
-                ffi::g_app_info_add_supports_type(GTK_APP_INFO(self.get_widget()), c_str, &mut error.unwrap())
+                ffi::g_app_info_add_supports_type(GTK_APP_INFO(self.unwrap_widget()), c_str, &mut error.unwrap())
             })
         }) }
     }
 
     pub fn can_remove_supports_type(&self) -> bool {
-        unsafe { to_bool(ffi::g_app_info_can_remove_supports_type(GTK_APP_INFO(self.get_widget()))) }
+        unsafe { to_bool(ffi::g_app_info_can_remove_supports_type(GTK_APP_INFO(self.unwrap_widget()))) }
     }
 
     pub fn remove_supports_type(&self, content_type: &str, error: &mut glib::Error) -> bool {
         unsafe { to_bool({
             content_type.with_c_str(|c_str| {
-                ffi::g_app_info_remove_supports_type(GTK_APP_INFO(self.get_widget()), c_str, &mut error.unwrap())
+                ffi::g_app_info_remove_supports_type(GTK_APP_INFO(self.unwrap_widget()), c_str, &mut error.unwrap())
             })
         }) }
     }
 
     pub fn get_supported_types(&self) -> Vec<String> {
-        let types = unsafe { ffi::g_app_info_get_supported_types(GTK_APP_INFO(self.get_widget())) };
+        let types = unsafe { ffi::g_app_info_get_supported_types(GTK_APP_INFO(self.unwrap_widget())) };
         let mut ret = Vec::new();
 
         if types.is_not_null() {
@@ -243,7 +243,7 @@ impl AppInfo {/*
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer as *mut gtk::ffi::C_GtkWidget))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer as *mut gtk::ffi::C_GtkWidget))
         }
     }
 
@@ -257,7 +257,7 @@ impl AppInfo {/*
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer as *mut gtk::ffi::C_GtkWidget))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer as *mut gtk::ffi::C_GtkWidget))
         }
     }
 
@@ -292,16 +292,16 @@ impl AppInfo {/*
     pub fn launch_default_for_uri(uri: &str, launch_context: &gtk::AppLaunchContext, error: &glib::Error) -> bool {
         unsafe { to_bool({
             uri.with_c_str(|c_str| {
-                ffi::g_app_info_launch_default_for_uri(c_str, GTK_APP_LAUNCH_CONTEXT(launch_context.get_widget()), &mut error.unwrap())
+                ffi::g_app_info_launch_default_for_uri(c_str, GTK_APP_LAUNCH_CONTEXT(launch_context.unwrap_widget()), &mut error.unwrap())
         }) }
     }*/
 }
 
 /*impl Clone for AppInfo {
     fn clone(&self) -> AppInfo {
-        let tmp_pointer = unsafe { ffi::g_app_info_dup(GTK_APP_INFO(self.get_widget())) };
+        let tmp_pointer = unsafe { ffi::g_app_info_dup(GTK_APP_INFO(self.unwrap_widget())) };
 
-        gtk::FFIWidget::wrap(tmp_pointer as *mut gtk::ffi::C_GtkWidget)
+        gtk::FFIWidget::wrap_widget(tmp_pointer as *mut gtk::ffi::C_GtkWidget)
     }
 }
 

--- a/src/gtk/widgets/app_launch_context.rs
+++ b/src/gtk/widgets/app_launch_context.rs
@@ -29,7 +29,7 @@ impl AppLaunchContext {/*
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer as *mut gtk::ffi::C_GtkWidget))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer as *mut gtk::ffi::C_GtkWidget))
         }
     }
 
@@ -37,7 +37,7 @@ impl AppLaunchContext {/*
         unsafe {
             variable.with_c_str(|c_variable| {
                 value.with_c_str(|c_value| {
-                    ffi::g_app_launch_context_setenv(GTK_APP_LAUNCH_CONTEXT(self.get_widget()), c_variable, c_value)
+                    ffi::g_app_launch_context_setenv(GTK_APP_LAUNCH_CONTEXT(self.unwrap_widget()), c_variable, c_value)
                 })
             })
         }
@@ -46,13 +46,13 @@ impl AppLaunchContext {/*
     pub fn unsetenv(&self, variable: &str) -> () {
         unsafe {
             variable.with_c_str(|c_variable| {
-                ffi::g_app_launch_context_unsetenv(GTK_APP_LAUNCH_CONTEXT(self.get_widget()), c_variable)
+                ffi::g_app_launch_context_unsetenv(GTK_APP_LAUNCH_CONTEXT(self.unwrap_widget()), c_variable)
             })
         }
     }
 
     pub fn get_environment(&self) -> Vec<String> {
-        let env = unsafe { ffi::g_app_launch_context_get_environment(GTK_APP_LAUNCH_CONTEXT(self.get_widget())) };
+        let env = unsafe { ffi::g_app_launch_context_get_environment(GTK_APP_LAUNCH_CONTEXT(self.unwrap_widget())) };
         let mut ret = Vec::new();
 
         if env.is_not_null() {
@@ -74,7 +74,7 @@ impl AppLaunchContext {/*
     }
 
     pub fn get_display(&self, info: &gtk::AppInfo, files: &glib::List) -> Option<String> {
-        let tmp_pointer = unsafe { ffi::g_app_launch_context_get_display(GTK_APP_LAUNCH_CONTEXT(self.get_widget()), GTK_APP_INFO(info.get_widget()), files.unwrap()) };
+        let tmp_pointer = unsafe { ffi::g_app_launch_context_get_display(GTK_APP_LAUNCH_CONTEXT(self.unwrap_widget()), GTK_APP_INFO(info.unwrap_widget()), files.unwrap()) };
 
         if tmp_pointer.is_null() {
             None
@@ -84,7 +84,7 @@ impl AppLaunchContext {/*
     }
 
     pub fn get_startup_notify_id(&self, app_info: &gtk::AppInfo, files: &glib::List) -> Option<String> {
-        let tmp_pointer = unsafe { ffi::g_app_launch_context_get_startup_notify_id(GTK_APP_LAUNCH_CONTEXT(self.get_widget()), GTK_APP_INFO(app_info.get_widget()), files.unwrap()) };
+        let tmp_pointer = unsafe { ffi::g_app_launch_context_get_startup_notify_id(GTK_APP_LAUNCH_CONTEXT(self.unwrap_widget()), GTK_APP_INFO(app_info.unwrap_widget()), files.unwrap()) };
 
         if tmp_pointer.is_null() {
             None
@@ -96,7 +96,7 @@ impl AppLaunchContext {/*
     pub fn launch_failed(&self, startup_notify_id: &str) -> () {
         unsafe {
             startup_notify_id.with_c_str(|c_str|{
-                ffi::g_app_launch_context_launch_failed(GTK_APP_LAUNCH_CONTEXT(self.get_widget()), c_str)
+                ffi::g_app_launch_context_launch_failed(GTK_APP_LAUNCH_CONTEXT(self.unwrap_widget()), c_str)
             })
         }
     }*/

--- a/src/gtk/widgets/button_box.rs
+++ b/src/gtk/widgets/button_box.rs
@@ -36,11 +36,11 @@ impl ButtonBox {
     }
 
     pub fn get_child_secondary<T: gtk::WidgetTrait + gtk::ButtonTrait>(&self, child: &T) -> bool {
-        unsafe { to_bool(ffi::gtk_button_box_get_child_secondary(GTK_BUTTONBOX(self.pointer), child.get_widget())) }
+        unsafe { to_bool(ffi::gtk_button_box_get_child_secondary(GTK_BUTTONBOX(self.pointer), child.unwrap_widget())) }
     }
 
     pub fn get_child_non_homogeneous<T: gtk::WidgetTrait + gtk::ButtonTrait>(&self, child: &T) -> bool {
-        unsafe { to_bool(ffi::gtk_button_box_get_child_non_homogeneous(GTK_BUTTONBOX(self.pointer), child.get_widget())) }
+        unsafe { to_bool(ffi::gtk_button_box_get_child_non_homogeneous(GTK_BUTTONBOX(self.pointer), child.unwrap_widget())) }
     }
 
     pub fn set_layout(&mut self, layout_style: ButtonBoxStyle) -> () {
@@ -50,11 +50,11 @@ impl ButtonBox {
     }
 
     pub fn set_child_secondary<T: gtk::WidgetTrait + gtk::ButtonTrait>(&mut self, child: &T, is_secondary: bool) -> () {
-        unsafe { ffi::gtk_button_box_set_child_secondary(GTK_BUTTONBOX(self.pointer), child.get_widget(), to_gboolean(is_secondary)); }
+        unsafe { ffi::gtk_button_box_set_child_secondary(GTK_BUTTONBOX(self.pointer), child.unwrap_widget(), to_gboolean(is_secondary)); }
     }
 
     pub fn set_child_non_homogeneous<T: gtk::WidgetTrait + gtk::ButtonTrait>(&mut self, child: &T, non_homogeneous: bool) -> () {
-        unsafe { ffi::gtk_button_box_set_child_non_homogeneous(GTK_BUTTONBOX(self.pointer), child.get_widget(), to_gboolean(non_homogeneous)); }
+        unsafe { ffi::gtk_button_box_set_child_non_homogeneous(GTK_BUTTONBOX(self.pointer), child.unwrap_widget(), to_gboolean(non_homogeneous)); }
     }
 }
 

--- a/src/gtk/widgets/color_chooser_dialog.rs
+++ b/src/gtk/widgets/color_chooser_dialog.rs
@@ -27,7 +27,7 @@ impl ColorChooserDialog {
 
             ffi::gtk_color_chooser_dialog_new(c_str.as_ptr(),
                 match parent {
-                    Some(ref p) => GTK_WINDOW(p.get_widget()),
+                    Some(ref p) => GTK_WINDOW(p.unwrap_widget()),
                     None => ::std::ptr::null_mut()
                 }
             )
@@ -36,7 +36,7 @@ impl ColorChooserDialog {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 }

--- a/src/gtk/widgets/color_chooser_widget.rs
+++ b/src/gtk/widgets/color_chooser_widget.rs
@@ -27,7 +27,7 @@ impl ColorChooserWidget {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 }

--- a/src/gtk/widgets/combo_box.rs
+++ b/src/gtk/widgets/combo_box.rs
@@ -31,22 +31,22 @@ impl ComboBox {
     }
 
     pub fn new_with_model(model: &gtk::TreeModel) -> Option<ComboBox> {
-        let tmp_pointer = unsafe { ffi::gtk_combo_box_new_with_model(model.get_pointer()) };
+        let tmp_pointer = unsafe { ffi::gtk_combo_box_new_with_model(model.unwrap_pointer()) };
         check_pointer!(tmp_pointer, ComboBox)
     }
 
     pub fn new_with_model_and_entry(model: &gtk::TreeModel) -> Option<ComboBox> {
-        let tmp_pointer = unsafe { ffi::gtk_combo_box_new_with_model_and_entry(model.get_pointer()) };
+        let tmp_pointer = unsafe { ffi::gtk_combo_box_new_with_model_and_entry(model.unwrap_pointer()) };
         check_pointer!(tmp_pointer, ComboBox)
     }
 
     /*pub fn new_with_area(area: &gtk::CellArea) -> Option<ComboBox> {
-        let tmp_pointer = unsafe { ffi::gtk_combo_box_new_with_area(area.get_pointer()) };
+        let tmp_pointer = unsafe { ffi::gtk_combo_box_new_with_area(area.unwrap_pointer()) };
         check_pointer!(tmp_pointer, ComboBox)
     }
 
     pub fn new_with_area_and_entry(area: &gtk::CellArea) -> Option<ComboBox> {
-        let tmp_pointer = unsafe { ffi::gtk_combo_box_new_with_area_and_entry(area.get_pointer()) };
+        let tmp_pointer = unsafe { ffi::gtk_combo_box_new_with_area_and_entry(area.unwrap_pointer()) };
         check_pointer!(tmp_pointer, ComboBox)
     }*/
 }

--- a/src/gtk/widgets/dialog.rs
+++ b/src/gtk/widgets/dialog.rs
@@ -26,7 +26,7 @@ impl Dialog {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 
@@ -37,7 +37,7 @@ impl Dialog {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }*/
 }

--- a/src/gtk/widgets/entry.rs
+++ b/src/gtk/widgets/entry.rs
@@ -43,7 +43,7 @@ impl Entry {
     }
 
     pub fn new_with_buffer(buffer: &gtk::EntryBuffer) -> Option<Entry> {
-        let tmp_pointer = unsafe { ffi::gtk_entry_new_with_buffer(buffer.get_pointer()) };
+        let tmp_pointer = unsafe { ffi::gtk_entry_new_with_buffer(buffer.unwrap_pointer()) };
         check_pointer!(tmp_pointer, Entry)
     }
 }

--- a/src/gtk/widgets/entry_buffer.rs
+++ b/src/gtk/widgets/entry_buffer.rs
@@ -122,7 +122,7 @@ impl EntryBuffer {
     }
 
     #[doc(hidden)]
-    pub fn get_pointer(&self) -> *mut ffi::C_GtkEntryBuffer {
+    pub fn unwrap_pointer(&self) -> *mut ffi::C_GtkEntryBuffer {
         self.pointer
     }
 

--- a/src/gtk/widgets/entry_completion.rs
+++ b/src/gtk/widgets/entry_completion.rs
@@ -42,12 +42,12 @@ impl EntryCompletion {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 
     pub fn set_model(&self, model: &TreeModel) {
-        unsafe { ffi::gtk_entry_completion_set_model(GTK_ENTRY_COMPLETION(self.pointer), model.get_pointer()) }
+        unsafe { ffi::gtk_entry_completion_set_model(GTK_ENTRY_COMPLETION(self.pointer), model.unwrap_pointer()) }
     }
 
     pub fn get_model(&self) -> Option<TreeModel> {

--- a/src/gtk/widgets/expander.rs
+++ b/src/gtk/widgets/expander.rs
@@ -118,13 +118,13 @@ impl Expander {
 
     pub fn set_label_widget(&mut self, label: &gtk::Label) -> () {
         unsafe {
-            ffi::gtk_expander_set_label_widget(GTK_EXPANDER(self.pointer), label.get_widget());
+            ffi::gtk_expander_set_label_widget(GTK_EXPANDER(self.pointer), label.unwrap_widget());
         }
     }
 
     pub fn get_label_widget(&mut self) -> gtk::Label {
         unsafe {
-            gtk::FFIWidget::wrap(ffi::gtk_expander_get_label_widget(GTK_EXPANDER(self.pointer)))
+            gtk::FFIWidget::wrap_widget(ffi::gtk_expander_get_label_widget(GTK_EXPANDER(self.pointer)))
         }
     }
 }

--- a/src/gtk/widgets/file_chooser_dialog.rs
+++ b/src/gtk/widgets/file_chooser_dialog.rs
@@ -31,7 +31,7 @@ impl FileChooserDialog {
 
             ffi::gtk_file_chooser_dialog_new(c_str.as_ptr(),
                 match parent {
-                    Some(ref p) => GTK_WINDOW(p.get_widget()),
+                    Some(ref p) => GTK_WINDOW(p.unwrap_widget()),
                     None => GTK_WINDOW(::std::ptr::null_mut())
                 }, action, c_cancel.as_ptr(), gtk::ResponseType::Cancel, c_ok.as_ptr(), gtk::ResponseType::Accept, ::std::ptr::null_mut())
         };
@@ -39,7 +39,7 @@ impl FileChooserDialog {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 }

--- a/src/gtk/widgets/file_chooser_widget.rs
+++ b/src/gtk/widgets/file_chooser_widget.rs
@@ -27,7 +27,7 @@ impl FileChooserWidget {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 }

--- a/src/gtk/widgets/file_filter.rs
+++ b/src/gtk/widgets/file_filter.rs
@@ -71,7 +71,7 @@ impl FileFilter {
         unsafe { ffi::gtk_file_filter_add_pixbuf_formats(self.pointer) }
     }
 
-    pub fn get_pointer(&self) -> *mut ffi::C_GtkFileFilter {
+    pub fn unwrap_pointer(&self) -> *mut ffi::C_GtkFileFilter {
         self.pointer
     }
 

--- a/src/gtk/widgets/fixed.rs
+++ b/src/gtk/widgets/fixed.rs
@@ -34,7 +34,7 @@ impl Fixed {
                              x: i32,
                              y: i32) -> () {
         unsafe {
-            ffi::gtk_fixed_put(GTK_FIXED(self.pointer), widget.get_widget(), x as c_int, y as c_int);
+            ffi::gtk_fixed_put(GTK_FIXED(self.pointer), widget.unwrap_widget(), x as c_int, y as c_int);
         }
     }
 
@@ -44,7 +44,7 @@ impl Fixed {
                               x: i32,
                               y: i32) -> () {
         unsafe {
-            ffi::gtk_fixed_move(GTK_FIXED(self.pointer), widget.get_widget(), x as c_int, y as c_int);
+            ffi::gtk_fixed_move(GTK_FIXED(self.pointer), widget.unwrap_widget(), x as c_int, y as c_int);
         }
     }
 }

--- a/src/gtk/widgets/flow_box.rs
+++ b/src/gtk/widgets/flow_box.rs
@@ -106,7 +106,7 @@ impl FlowBox {
     pub fn insert<T: gtk::WidgetTrait>(&mut self, widget: &T, position: i32) {
         unsafe {
             ffi::gtk_flow_box_insert(GTK_FLOW_BOX(self.pointer),
-                                     widget.get_widget(),
+                                     widget.unwrap_widget(),
                                      position)
         }
     }
@@ -118,21 +118,21 @@ impl FlowBox {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer as *mut ffi::C_GtkWidget))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer as *mut ffi::C_GtkWidget))
         }
     }
 
     pub fn select_child(&mut self, child: &FlowBoxChild) {
         unsafe {
             ffi::gtk_flow_box_select_child(GTK_FLOW_BOX(self.pointer),
-                                           GTK_FLOW_BOX_CHILD(child.get_widget()))
+                                           GTK_FLOW_BOX_CHILD(child.unwrap_widget()))
         }
     }
 
     pub fn unselect_child(&mut self, child: &FlowBoxChild) {
         unsafe {
             ffi::gtk_flow_box_unselect_child(GTK_FLOW_BOX(self.pointer),
-                                             GTK_FLOW_BOX_CHILD(child.get_widget()))
+                                             GTK_FLOW_BOX_CHILD(child.unwrap_widget()))
         }
     }
 
@@ -163,14 +163,14 @@ impl FlowBox {
     pub fn set_hadjustment(&mut self, adjustment: gtk::Adjustment) {
         unsafe {
             ffi::gtk_flow_box_set_hadjustment(GTK_FLOW_BOX(self.pointer),
-                                              adjustment.get_pointer())
+                                              adjustment.unwrap_pointer())
         }
     }
 
     pub fn set_vadjustment(&mut self, adjustment: gtk::Adjustment) {
         unsafe {
             ffi::gtk_flow_box_set_vadjustment(GTK_FLOW_BOX(self.pointer),
-                                              adjustment.get_pointer())
+                                              adjustment.unwrap_pointer())
         }
     }
 }

--- a/src/gtk/widgets/font_chooser_dialog.rs
+++ b/src/gtk/widgets/font_chooser_dialog.rs
@@ -27,7 +27,7 @@ impl FontChooserDialog {
 
             ffi::gtk_font_chooser_dialog_new(c_str.as_ptr(),
                 match parent {
-                    Some(ref p) => GTK_WINDOW(p.get_widget()),
+                    Some(ref p) => GTK_WINDOW(p.unwrap_widget()),
                     None => GTK_WINDOW(::std::ptr::null_mut())
                 }
             )
@@ -36,7 +36,7 @@ impl FontChooserDialog {
         if tmp.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp))
+            Some(gtk::FFIWidget::wrap_widget(tmp))
         }
     }
 }

--- a/src/gtk/widgets/font_chooser_widget.rs
+++ b/src/gtk/widgets/font_chooser_widget.rs
@@ -27,7 +27,7 @@ impl FontChooserWidget {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 }

--- a/src/gtk/widgets/grid.rs
+++ b/src/gtk/widgets/grid.rs
@@ -41,7 +41,7 @@ impl Grid {
                                 height: i32) -> () {
         unsafe {
             ffi::gtk_grid_attach(GTK_GRID(self.pointer),
-                                 child.get_widget(),
+                                 child.unwrap_widget(),
                                  left as c_int,
                                  top as c_int,
                                  width as c_int,
@@ -57,8 +57,8 @@ impl Grid {
                                         height: i32) -> () {
         unsafe {
             ffi::gtk_grid_attach_next_to(GTK_GRID(self.pointer),
-                                         child.get_widget(),
-                                         sibling.get_widget(),
+                                         child.unwrap_widget(),
+                                         sibling.unwrap_widget(),
                                          side,
                                          width as c_int,
                                          height as c_int);
@@ -93,7 +93,7 @@ impl Grid {
 
     pub fn insert_next_to<T: gtk::WidgetTrait>(&mut self, sibling: &T, side: PositionType) -> () {
         unsafe {
-            ffi::gtk_grid_insert_next_to(GTK_GRID(self.pointer), sibling.get_widget(), side);
+            ffi::gtk_grid_insert_next_to(GTK_GRID(self.pointer), sibling.unwrap_widget(), side);
         }
     }
 

--- a/src/gtk/widgets/header_bar.rs
+++ b/src/gtk/widgets/header_bar.rs
@@ -70,7 +70,7 @@ impl HeaderBar {
     pub fn set_custom_title<T: gtk::WidgetTrait>(&mut self, title_widget: Option<&T>) {
         unsafe {
             ffi::gtk_header_bar_set_custom_title(GTK_HEADER_BAR(self.pointer),
-                                                 get_widget!(title_widget))
+                                                 unwrap_widget!(title_widget))
         }
     }
 
@@ -82,21 +82,21 @@ impl HeaderBar {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 
     pub fn pack_start<T: gtk::WidgetTrait>(&mut self, child: &T) {
         unsafe {
             ffi::gtk_header_bar_pack_start(GTK_HEADER_BAR(self.pointer),
-                                           child.get_widget())
+                                           child.unwrap_widget())
         }
     }
 
     pub fn pack_end<T: gtk::WidgetTrait>(&mut self, child: &T) {
         unsafe {
             ffi::gtk_header_bar_pack_end(GTK_HEADER_BAR(self.pointer),
-                                         child.get_widget())
+                                         child.unwrap_widget())
         }
     }
 

--- a/src/gtk/widgets/icon_view.rs
+++ b/src/gtk/widgets/icon_view.rs
@@ -32,12 +32,12 @@ impl IconView {
     }*/
 
     pub fn new_with_model(model: &TreeModel) -> Option<IconView> {
-        let tmp_pointer = unsafe { ffi::gtk_icon_view_new_with_model(model.get_pointer()) };
+        let tmp_pointer = unsafe { ffi::gtk_icon_view_new_with_model(model.unwrap_pointer()) };
         check_pointer!(tmp_pointer, IconView)
     }
 
     pub fn set_model(&self, model: &TreeModel) {
-        unsafe { ffi::gtk_icon_view_set_model(GTK_ICON_VIEW(self.pointer), model.get_pointer()) }
+        unsafe { ffi::gtk_icon_view_set_model(GTK_ICON_VIEW(self.pointer), model.unwrap_pointer()) }
     }
 
     pub fn get_model(&self) -> Option<TreeModel> {
@@ -85,8 +85,8 @@ impl IconView {
     }
 
     pub fn get_item_at_pos<T: gtk::CellRendererTrait>(&self, x: i32, y: i32, path: &TreePath, cell: &T) -> bool {
-        match unsafe { ffi::gtk_icon_view_get_item_at_pos(GTK_ICON_VIEW(self.pointer), x, y, &mut path.get_pointer(),
-            &mut GTK_CELL_RENDERER(cell.get_widget())) } {
+        match unsafe { ffi::gtk_icon_view_get_item_at_pos(GTK_ICON_VIEW(self.pointer), x, y, &mut path.unwrap_pointer(),
+            &mut GTK_CELL_RENDERER(cell.unwrap_widget())) } {
             0 => false,
             _ => true
         }
@@ -97,7 +97,7 @@ impl IconView {
     }
 
     pub fn set_cursor<T: gtk::CellRendererTrait>(&self, path: &TreePath, cell: &T, start_edition: bool) {
-        unsafe { ffi::gtk_icon_view_set_cursor(GTK_ICON_VIEW(self.pointer), path.get_pointer(), GTK_CELL_RENDERER(cell.get_widget()),
+        unsafe { ffi::gtk_icon_view_set_cursor(GTK_ICON_VIEW(self.pointer), path.unwrap_pointer(), GTK_CELL_RENDERER(cell.unwrap_widget()),
             match start_edition {
                 true => 1,
                 false => 0
@@ -105,8 +105,8 @@ impl IconView {
     }
 
     pub fn get_cursor<T: gtk::CellRendererTrait>(&self, path: &TreePath, cell: &T) -> bool {
-        match unsafe { ffi::gtk_icon_view_get_cursor(GTK_ICON_VIEW(self.pointer), &mut path.get_pointer(),
-            &mut GTK_CELL_RENDERER(cell.get_widget())) } {
+        match unsafe { ffi::gtk_icon_view_get_cursor(GTK_ICON_VIEW(self.pointer), &mut path.unwrap_pointer(),
+            &mut GTK_CELL_RENDERER(cell.unwrap_widget())) } {
             0 => false,
             _ => true
         }
@@ -196,15 +196,15 @@ impl IconView {
     }
 
     pub fn select_path(&self, path: &TreePath) {
-        unsafe { ffi::gtk_icon_view_select_path(GTK_ICON_VIEW(self.pointer), path.get_pointer()) }
+        unsafe { ffi::gtk_icon_view_select_path(GTK_ICON_VIEW(self.pointer), path.unwrap_pointer()) }
     }
 
     pub fn unselect_path(&self, path: &TreePath) {
-        unsafe { ffi::gtk_icon_view_unselect_path(GTK_ICON_VIEW(self.pointer), path.get_pointer()) }
+        unsafe { ffi::gtk_icon_view_unselect_path(GTK_ICON_VIEW(self.pointer), path.unwrap_pointer()) }
     }
 
     pub fn path_is_selected(&self, path: &TreePath) -> bool {
-        match unsafe { ffi::gtk_icon_view_path_is_selected(GTK_ICON_VIEW(self.pointer), path.get_pointer()) } {
+        match unsafe { ffi::gtk_icon_view_path_is_selected(GTK_ICON_VIEW(self.pointer), path.unwrap_pointer()) } {
             0 => false,
             _ => true
         }
@@ -218,7 +218,7 @@ impl IconView {
         } else {
             let list: glib::List<*mut ffi::C_GtkWidget> = glib::GlibContainer::wrap(tmp);
 
-            list.iter().map(|it| gtk::FFIWidget::wrap(*it)).collect()
+            list.iter().map(|it| gtk::FFIWidget::wrap_widget(*it)).collect()
         }
     }*/
 
@@ -231,17 +231,17 @@ impl IconView {
     }
 
     pub fn item_activated(&self, path: &TreePath) {
-        unsafe { ffi::gtk_icon_view_item_activated(GTK_ICON_VIEW(self.pointer), path.get_pointer()) }
+        unsafe { ffi::gtk_icon_view_item_activated(GTK_ICON_VIEW(self.pointer), path.unwrap_pointer()) }
     }
 
     pub fn scroll_to_path(&self, path: &TreePath, use_align: bool, row_align: f32, col_align: f32) {
-        unsafe { ffi::gtk_icon_view_scroll_to_path(GTK_ICON_VIEW(self.pointer), path.get_pointer(),
+        unsafe { ffi::gtk_icon_view_scroll_to_path(GTK_ICON_VIEW(self.pointer), path.unwrap_pointer(),
             if use_align {1} else {0}, row_align, col_align) }
     }
 
     pub fn get_visible_range(&self, start_path: &TreePath, end_path: &TreePath) -> bool {
-        match unsafe { ffi::gtk_icon_view_get_visible_range(GTK_ICON_VIEW(self.pointer), &mut start_path.get_pointer(),
-            &mut end_path.get_pointer()) } {
+        match unsafe { ffi::gtk_icon_view_get_visible_range(GTK_ICON_VIEW(self.pointer), &mut start_path.unwrap_pointer(),
+            &mut end_path.unwrap_pointer()) } {
             0 => false,
             _ => true
         }
@@ -256,11 +256,11 @@ impl IconView {
     }
 
     pub fn get_item_row(&self, path: &TreePath) -> i32 {
-        unsafe { ffi::gtk_icon_view_get_item_row(GTK_ICON_VIEW(self.pointer), path.get_pointer()) }
+        unsafe { ffi::gtk_icon_view_get_item_row(GTK_ICON_VIEW(self.pointer), path.unwrap_pointer()) }
     }
 
     pub fn get_item_column(&self, path: &TreePath) -> i32 {
-        unsafe { ffi::gtk_icon_view_get_item_column(GTK_ICON_VIEW(self.pointer), path.get_pointer()) }
+        unsafe { ffi::gtk_icon_view_get_item_column(GTK_ICON_VIEW(self.pointer), path.unwrap_pointer()) }
     }
 
     pub fn unset_model_drag_source(&self) {
@@ -283,15 +283,15 @@ impl IconView {
     }
 
     pub fn set_drag_dest_item(&self, path: &TreePath, pos: gtk::IconViewDropPosition) {
-        unsafe { ffi::gtk_icon_view_set_drag_dest_item(GTK_ICON_VIEW(self.pointer), path.get_pointer(), pos) }
+        unsafe { ffi::gtk_icon_view_set_drag_dest_item(GTK_ICON_VIEW(self.pointer), path.unwrap_pointer(), pos) }
     }
 
     pub fn get_drag_dest_item(&self, path: &TreePath, pos: &mut gtk::IconViewDropPosition) {
-        unsafe { ffi::gtk_icon_view_get_drag_dest_item(GTK_ICON_VIEW(self.pointer), &mut path.get_pointer(), pos) }
+        unsafe { ffi::gtk_icon_view_get_drag_dest_item(GTK_ICON_VIEW(self.pointer), &mut path.unwrap_pointer(), pos) }
     }
 
     pub fn get_dest_item_at_pos(&self, drag_x: i32, drag_y: i32, path: &TreePath, pos: &mut gtk::IconViewDropPosition) {
-        unsafe { ffi::gtk_icon_view_get_dest_item_at_pos(GTK_ICON_VIEW(self.pointer), drag_x, drag_y, &mut path.get_pointer(), pos) }
+        unsafe { ffi::gtk_icon_view_get_dest_item_at_pos(GTK_ICON_VIEW(self.pointer), drag_x, drag_y, &mut path.unwrap_pointer(), pos) }
     }
 }
 

--- a/src/gtk/widgets/image.rs
+++ b/src/gtk/widgets/image.rs
@@ -46,7 +46,7 @@ impl Image {
         let c_str = CString::from_slice(filename.as_bytes());
 
         unsafe {
-            ffi::gtk_image_set_from_file(GTK_IMAGE(self.get_widget()), c_str.as_ptr());
+            ffi::gtk_image_set_from_file(GTK_IMAGE(self.unwrap_widget()), c_str.as_ptr());
         };
     }
 
@@ -54,7 +54,7 @@ impl Image {
         let c_str = CString::from_slice(icon_name.as_bytes());
 
         unsafe {
-            ffi::gtk_image_set_from_icon_name(GTK_IMAGE(self.get_widget()), c_str.as_ptr(), size)
+            ffi::gtk_image_set_from_icon_name(GTK_IMAGE(self.unwrap_widget()), c_str.as_ptr(), size)
         };
     }
 }

--- a/src/gtk/widgets/info_bar.rs
+++ b/src/gtk/widgets/info_bar.rs
@@ -34,7 +34,7 @@ impl InfoBar {
 
     pub fn add_action_widget<T: gtk::WidgetTrait>(&mut self, child: &T, response_id: i32) -> () {
         unsafe {
-            ffi::gtk_info_bar_add_action_widget(GTK_INFOBAR(self.pointer), child.get_widget(), response_id as c_int)
+            ffi::gtk_info_bar_add_action_widget(GTK_INFOBAR(self.pointer), child.unwrap_widget(), response_id as c_int)
         }
     }
 
@@ -43,7 +43,7 @@ impl InfoBar {
             let c_str = CString::from_slice(button_text.as_bytes());
             ffi::gtk_info_bar_add_button(GTK_INFOBAR(self.pointer), c_str.as_ptr(), response_id as c_int)
         };
-        gtk::FFIWidget::wrap(button)
+        gtk::FFIWidget::wrap_widget(button)
     }
 
     pub fn set_response_sensitive(&mut self, response_id: i32, setting: bool) -> () {

--- a/src/gtk/widgets/layout.rs
+++ b/src/gtk/widgets/layout.rs
@@ -24,8 +24,8 @@ struct_Widget!(Layout);
 impl Layout {
     pub fn new(hadjustment: &gtk::Adjustment, vadjustment: &gtk::Adjustment) -> Option<Layout> {
         let tmp_pointer = unsafe {
-            ffi::gtk_layout_new(hadjustment.get_pointer(),
-                                vadjustment.get_pointer())
+            ffi::gtk_layout_new(hadjustment.unwrap_pointer(),
+                                vadjustment.unwrap_pointer())
         };
         check_pointer!(tmp_pointer, Layout)
     }
@@ -33,7 +33,7 @@ impl Layout {
     pub fn put<T: gtk::WidgetTrait>(&mut self, child: &T, x: i32, y: i32) {
         unsafe {
             ffi::gtk_layout_put(GTK_LAYOUT(self.pointer),
-                                child.get_widget(),
+                                child.unwrap_widget(),
                                 x,
                                 y)
         }
@@ -43,7 +43,7 @@ impl Layout {
     pub fn move_<T: gtk::WidgetTrait>(&mut self, child: &T, x: i32, y: i32) {
         unsafe {
             ffi::gtk_layout_move(GTK_LAYOUT(self.pointer),
-                                 child.get_widget(),
+                                 child.unwrap_widget(),
                                  x,
                                  y)
         }

--- a/src/gtk/widgets/list_box.rs
+++ b/src/gtk/widgets/list_box.rs
@@ -32,14 +32,14 @@ impl ListBox {
     pub fn prepend<T: gtk::WidgetTrait>(&mut self, child: &T) {
         unsafe {
             ffi::gtk_list_box_prepend(GTK_LIST_BOX(self.pointer),
-                                      child.get_widget())
+                                      child.unwrap_widget())
         }
     }
 
     pub fn insert<T: gtk::WidgetTrait>(&mut self, child: &T, position: i32) {
         unsafe {
             ffi::gtk_list_box_insert(GTK_LIST_BOX(self.pointer),
-                                     child.get_widget(),
+                                     child.unwrap_widget(),
                                      position)
         }
     }
@@ -51,7 +51,7 @@ impl ListBox {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer as *mut ffi::C_GtkWidget))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer as *mut ffi::C_GtkWidget))
         }
     }
 
@@ -62,7 +62,7 @@ impl ListBox {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer as *mut ffi::C_GtkWidget))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer as *mut ffi::C_GtkWidget))
         }
     }
 
@@ -73,28 +73,28 @@ impl ListBox {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer as *mut ffi::C_GtkWidget))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer as *mut ffi::C_GtkWidget))
         }
     }
 
     pub fn select_row(&mut self, row: &ListBoxRow) {
         unsafe {
             ffi::gtk_list_box_select_row(GTK_LIST_BOX(self.pointer),
-                                         GTK_LIST_BOX_ROW(row.get_widget()))
+                                         GTK_LIST_BOX_ROW(row.unwrap_widget()))
         }
     }
 
     pub fn set_placeholder<T: gtk::WidgetTrait>(&mut self, placeholder: &T) {
         unsafe {
             ffi::gtk_list_box_set_placeholder(GTK_LIST_BOX(self.pointer),
-                                              placeholder.get_widget())
+                                              placeholder.unwrap_widget())
         }
     }
 
     pub fn set_adjustment(&mut self, adjustment: &gtk::Adjustment) {
         unsafe {
             ffi::gtk_list_box_set_adjustment(GTK_LIST_BOX(self.pointer),
-                                             adjustment.get_pointer())
+                                             adjustment.unwrap_pointer())
         }
     }
 
@@ -149,7 +149,7 @@ impl ListBox {
     pub fn drag_highlight_row(&mut self, row: &ListBoxRow) {
         unsafe {
             ffi::gtk_list_box_drag_highlight_row(GTK_LIST_BOX(self.pointer),
-                                                 row.get_widget() as *mut ffi::C_GtkListBoxRow)
+                                                 row.unwrap_widget() as *mut ffi::C_GtkListBoxRow)
         }
     }
 }
@@ -185,14 +185,14 @@ impl ListBoxRow {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 
     pub fn set_header<T: gtk::WidgetTrait>(&mut self, header: &T) {
         unsafe {
             ffi::gtk_list_box_row_set_header(GTK_LIST_BOX_ROW(self.pointer),
-                                             header.get_widget())
+                                             header.unwrap_widget())
         }
     }
 

--- a/src/gtk/widgets/list_store.rs
+++ b/src/gtk/widgets/list_store.rs
@@ -38,34 +38,34 @@ impl ListStore {
         unsafe {
             let text_c = CString::from_slice(text.as_bytes());
 
-            ffi::gtk_list_store_set(self.pointer, iter.get_pointer(), column, text_c.as_ptr(), -1is)
+            ffi::gtk_list_store_set(self.pointer, iter.unwrap_pointer(), column, text_c.as_ptr(), -1is)
         }
     }
 
     pub fn remove(&self, iter: &TreeIter) -> bool {
-        unsafe { to_bool(ffi::gtk_list_store_remove(self.pointer, iter.get_pointer())) }
+        unsafe { to_bool(ffi::gtk_list_store_remove(self.pointer, iter.unwrap_pointer())) }
     }
 
     pub fn insert(&self, iter: &mut TreeIter, position: i32) {
-        unsafe { ffi::gtk_list_store_insert(self.pointer, iter.get_pointer(), position) }
+        unsafe { ffi::gtk_list_store_insert(self.pointer, iter.unwrap_pointer(), position) }
     }
 
     pub fn insert_before(&self, iter: &mut TreeIter, sibling: Option<&TreeIter>) {
-        unsafe { ffi::gtk_list_store_insert_before(self.pointer, iter.get_pointer(),
-                                                   if sibling.is_none() { ::std::ptr::null_mut()} else { sibling.unwrap().get_pointer() }) }
+        unsafe { ffi::gtk_list_store_insert_before(self.pointer, iter.unwrap_pointer(),
+                                                   if sibling.is_none() { ::std::ptr::null_mut()} else { sibling.unwrap().unwrap_pointer() }) }
     }
 
     pub fn insert_after(&self, iter: &mut TreeIter, sibling: Option<&TreeIter>) {
-        unsafe { ffi::gtk_list_store_insert_after(self.pointer, iter.get_pointer(),
-                                                  if sibling.is_none() { ::std::ptr::null_mut()} else { sibling.unwrap().get_pointer() }) }
+        unsafe { ffi::gtk_list_store_insert_after(self.pointer, iter.unwrap_pointer(),
+                                                  if sibling.is_none() { ::std::ptr::null_mut()} else { sibling.unwrap().unwrap_pointer() }) }
     }
 
     pub fn prepend(&self, iter: &mut TreeIter) {
-        unsafe { ffi::gtk_list_store_prepend(self.pointer, iter.get_pointer()) }
+        unsafe { ffi::gtk_list_store_prepend(self.pointer, iter.unwrap_pointer()) }
     }
 
     pub fn append(&self, iter: &mut TreeIter) {
-        unsafe { ffi::gtk_list_store_append(self.pointer, iter.get_pointer()) }
+        unsafe { ffi::gtk_list_store_append(self.pointer, iter.unwrap_pointer()) }
     }
 
     pub fn clear(&self) {
@@ -73,7 +73,7 @@ impl ListStore {
     }
 
     pub fn iter_is_valid(&self, iter: &TreeIter) -> bool {
-        unsafe { to_bool(ffi::gtk_list_store_iter_is_valid(self.pointer, iter.get_pointer())) }
+        unsafe { to_bool(ffi::gtk_list_store_iter_is_valid(self.pointer, iter.unwrap_pointer())) }
     }
 
     pub fn reorder(&self, new_order: *mut i32) {
@@ -81,17 +81,17 @@ impl ListStore {
     }
 
     pub fn swap(&self, a: &TreeIter, b: &TreeIter) {
-        unsafe { ffi::gtk_list_store_swap(self.pointer, a.get_pointer(), b.get_pointer()) }
+        unsafe { ffi::gtk_list_store_swap(self.pointer, a.unwrap_pointer(), b.unwrap_pointer()) }
     }
 
     pub fn move_before(&self, iter: &TreeIter, position: Option<&TreeIter>) {
-        unsafe { ffi::gtk_list_store_move_before(self.pointer, iter.get_pointer(),
-                                                 if position.is_none() { ::std::ptr::null_mut() } else { position.unwrap().get_pointer() }) }
+        unsafe { ffi::gtk_list_store_move_before(self.pointer, iter.unwrap_pointer(),
+                                                 if position.is_none() { ::std::ptr::null_mut() } else { position.unwrap().unwrap_pointer() }) }
     }
 
     pub fn move_after(&self, iter: &TreeIter, position: Option<&TreeIter>) {
-        unsafe { ffi::gtk_list_store_move_before(self.pointer, iter.get_pointer(),
-                                                 if position.is_none() { ::std::ptr::null_mut() } else { position.unwrap().get_pointer() }) }
+        unsafe { ffi::gtk_list_store_move_before(self.pointer, iter.unwrap_pointer(),
+                                                 if position.is_none() { ::std::ptr::null_mut() } else { position.unwrap().unwrap_pointer() }) }
     }
 
     pub fn get_model(&self) -> Option<gtk::TreeModel> {
@@ -103,11 +103,11 @@ impl ListStore {
     }
 
     pub fn set_value(&self, iter: &TreeIter, column: i32, value: &gtk::GValue) {
-        unsafe { ffi::gtk_list_store_set_value(self.pointer, iter.get_pointer(), column, value.unwrap_pointer()) }
+        unsafe { ffi::gtk_list_store_set_value(self.pointer, iter.unwrap_pointer(), column, value.unwrap_pointer()) }
     }
 
     #[doc(hidden)]
-    pub fn get_pointer(&self) -> *mut ffi::C_GtkListStore {
+    pub fn unwrap_pointer(&self) -> *mut ffi::C_GtkListStore {
         self.pointer
     }
 

--- a/src/gtk/widgets/menu_button.rs
+++ b/src/gtk/widgets/menu_button.rs
@@ -30,7 +30,7 @@ impl MenuButton {
 
     pub fn set_popup<T: gtk::WidgetTrait>(&mut self, popup: &T) -> () {
         unsafe {
-            ffi::gtk_menu_button_set_popup(GTK_MENUBUTTON(self.pointer), popup.get_widget());
+            ffi::gtk_menu_button_set_popup(GTK_MENUBUTTON(self.pointer), popup.unwrap_widget());
         }
     }
 
@@ -48,7 +48,7 @@ impl MenuButton {
 
     pub fn set_align_widget<T: gtk::WidgetTrait>(&mut self, align_widget: &T) -> () {
         unsafe {
-            ffi::gtk_menu_button_set_align_widget(GTK_MENUBUTTON(self.pointer), align_widget.get_widget())
+            ffi::gtk_menu_button_set_align_widget(GTK_MENUBUTTON(self.pointer), align_widget.unwrap_widget())
         }
     }
 }

--- a/src/gtk/widgets/menu_tool_button.rs
+++ b/src/gtk/widgets/menu_tool_button.rs
@@ -32,13 +32,13 @@ impl MenuToolButton {
                     let c_str = CString::from_slice(l.as_bytes());
 
                     match icon_widget {
-                        Some(i) => ffi::gtk_menu_tool_button_new(i.get_widget(), c_str.as_ptr()),
+                        Some(i) => ffi::gtk_menu_tool_button_new(i.unwrap_widget(), c_str.as_ptr()),
                         None    => ffi::gtk_menu_tool_button_new(ptr::null_mut(), c_str.as_ptr())
                     }
                 },
                 None    => {
                     match icon_widget {
-                        Some(i) => ffi::gtk_menu_tool_button_new(i.get_widget(), ptr::null()),
+                        Some(i) => ffi::gtk_menu_tool_button_new(i.unwrap_widget(), ptr::null()),
                         None    => ffi::gtk_menu_tool_button_new(ptr::null_mut(), ptr::null())
                     }
                 }

--- a/src/gtk/widgets/message_dialog.rs
+++ b/src/gtk/widgets/message_dialog.rs
@@ -23,7 +23,7 @@ struct_Widget!(MessageDialog);
 impl MessageDialog {
     pub fn new(parent: Option<gtk::Window>, flags: gtk::DialogFlags, _type: gtk::MessageType, buttons: gtk::ButtonsType) -> Option<MessageDialog> {
         let tmp_pointer = unsafe { ffi::gtk_message_dialog_new(match parent {
-                Some(ref p) => GTK_WINDOW(p.get_widget()),
+                Some(ref p) => GTK_WINDOW(p.unwrap_widget()),
                 None => ::std::ptr::null_mut()
             }, flags, _type, buttons, ::std::ptr::null())
         };
@@ -31,7 +31,7 @@ impl MessageDialog {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 
@@ -50,17 +50,17 @@ impl MessageDialog {
         unsafe {
             let c_str = CString::from_slice(markup.as_bytes());
 
-            ffi::gtk_message_dialog_set_markup(GTK_MESSAGE_DIALOG(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_message_dialog_set_markup(GTK_MESSAGE_DIALOG(self.unwrap_widget()), c_str.as_ptr())
         }
     }
 
     pub fn get_message_area<T: gtk::WidgetTrait>(&self) -> Option<T> {
-        let tmp_pointer = unsafe { ffi::gtk_message_dialog_get_message_area(GTK_MESSAGE_DIALOG(self.get_widget())) };
+        let tmp_pointer = unsafe { ffi::gtk_message_dialog_get_message_area(GTK_MESSAGE_DIALOG(self.unwrap_widget())) };
 
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 }

--- a/src/gtk/widgets/note_book.rs
+++ b/src/gtk/widgets/note_book.rs
@@ -36,8 +36,8 @@ impl NoteBook {
                                           -> i32 {
         unsafe {
             ffi::gtk_notebook_append_page(GTK_NOTEBOOK(self.pointer),
-                                          child.get_widget(),
-                                          get_widget!(tab_label))
+                                          child.unwrap_widget(),
+                                          unwrap_widget!(tab_label))
         }
     }
 
@@ -48,9 +48,9 @@ impl NoteBook {
                                                -> i32 {
         unsafe {
             ffi::gtk_notebook_append_page_menu(GTK_NOTEBOOK(self.pointer),
-                                               child.get_widget(),
-                                               get_widget!(tab_label),
-                                               get_widget!(menu_label))
+                                               child.unwrap_widget(),
+                                               unwrap_widget!(tab_label),
+                                               unwrap_widget!(menu_label))
         }
     }
 
@@ -60,8 +60,8 @@ impl NoteBook {
                                            -> i32 {
         unsafe {
             ffi::gtk_notebook_prepend_page(GTK_NOTEBOOK(self.pointer),
-                                           child.get_widget(),
-                                           get_widget!(tab_label))
+                                           child.unwrap_widget(),
+                                           unwrap_widget!(tab_label))
         }
     }
 
@@ -72,9 +72,9 @@ impl NoteBook {
                                                -> i32 {
         unsafe {
             ffi::gtk_notebook_prepend_page_menu(GTK_NOTEBOOK(self.pointer),
-                                                child.get_widget(),
-                                                get_widget!(tab_label),
-                                                get_widget!(menu_label))
+                                                child.unwrap_widget(),
+                                                unwrap_widget!(tab_label),
+                                                unwrap_widget!(menu_label))
         }
     }
 
@@ -85,8 +85,8 @@ impl NoteBook {
                                            -> i32 {
         unsafe {
             ffi::gtk_notebook_insert_page(GTK_NOTEBOOK(self.pointer),
-                                          child.get_widget(),
-                                          get_widget!(tab_label),
+                                          child.unwrap_widget(),
+                                          unwrap_widget!(tab_label),
                                           position)
         }
     }
@@ -99,9 +99,9 @@ impl NoteBook {
                                                -> i32 {
         unsafe {
             ffi::gtk_notebook_insert_page_menu(GTK_NOTEBOOK(self.pointer),
-                                               child.get_widget(),
-                                               get_widget!(tab_label),
-                                               get_widget!(menu_label),
+                                               child.unwrap_widget(),
+                                               unwrap_widget!(tab_label),
+                                               unwrap_widget!(menu_label),
                                                position)
         }
     }
@@ -144,7 +144,7 @@ impl NoteBook {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 
@@ -156,7 +156,7 @@ impl NoteBook {
 
     pub fn page_num<T: gtk::WidgetTrait>(&self, child: &T) -> i32 {
         unsafe {
-            ffi::gtk_notebook_page_num(GTK_NOTEBOOK(self.pointer), child.get_widget())
+            ffi::gtk_notebook_page_num(GTK_NOTEBOOK(self.pointer), child.unwrap_widget())
         }
     }
 
@@ -256,20 +256,20 @@ impl NoteBook {
     pub fn get_tab_label<T: gtk::WidgetTrait>(&self, child: &T) -> Option<gtk::Label> {
         let tmp_pointer = unsafe {
             ffi::gtk_notebook_get_tab_label(GTK_NOTEBOOK(self.pointer),
-                                            child.get_widget())
+                                            child.unwrap_widget())
         };
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 
     pub fn set_tab_label<T: gtk::WidgetTrait>(&mut self, child: &T, tab_label: Option<&gtk::Label>) {
         unsafe {
             ffi::gtk_notebook_set_tab_label(GTK_NOTEBOOK(self.pointer),
-                                            child.get_widget(),
-                                            get_widget!(tab_label))
+                                            child.unwrap_widget(),
+                                            unwrap_widget!(tab_label))
         }
     }
 
@@ -278,7 +278,7 @@ impl NoteBook {
 
         unsafe {
             ffi::gtk_notebook_set_tab_label_text(GTK_NOTEBOOK(self.pointer),
-                                                 child.get_widget(),
+                                                 child.unwrap_widget(),
                                                  c_str.as_ptr())
         }
     }
@@ -286,7 +286,7 @@ impl NoteBook {
     pub fn get_tab_label_text<T: gtk::WidgetTrait>(&mut self, child: &T) -> Option<String> {
         unsafe {
             let c_str = ffi::gtk_notebook_get_tab_label_text(GTK_NOTEBOOK(self.pointer),
-                                                             child.get_widget());
+                                                             child.unwrap_widget());
             
             if c_str.is_null() {
                 None
@@ -299,20 +299,20 @@ impl NoteBook {
     pub fn get_menu_label<T: gtk::WidgetTrait>(&self, child: &T) -> Option<gtk::Label> {
         let tmp_pointer = unsafe {
             ffi::gtk_notebook_get_menu_label(GTK_NOTEBOOK(self.pointer),
-                                             child.get_widget())
+                                             child.unwrap_widget())
         };
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 
     pub fn set_menu_label<T: gtk::WidgetTrait>(&mut self, child: &T, tab_label: Option<&gtk::Label>) {
         unsafe {
             ffi::gtk_notebook_set_menu_label(GTK_NOTEBOOK(self.pointer),
-                                             child.get_widget(),
-                                             get_widget!(tab_label))
+                                             child.unwrap_widget(),
+                                             unwrap_widget!(tab_label))
         }
     }
 
@@ -321,7 +321,7 @@ impl NoteBook {
 
         unsafe {
             ffi::gtk_notebook_set_menu_label_text(GTK_NOTEBOOK(self.pointer),
-                                                  child.get_widget(),
+                                                  child.unwrap_widget(),
                                                   c_str.as_ptr())
         }
     }
@@ -329,7 +329,7 @@ impl NoteBook {
     pub fn get_menu_label_text<T: gtk::WidgetTrait>(&mut self, child: &T) -> Option<String> {
         unsafe {
             let c_str = ffi::gtk_notebook_get_menu_label_text(GTK_NOTEBOOK(self.pointer),
-                                                              child.get_widget());
+                                                              child.unwrap_widget());
 
             if c_str.is_null() {
                 None
@@ -342,7 +342,7 @@ impl NoteBook {
     pub fn reorder_child<T: gtk::WidgetTrait>(&mut self, child: &T, position: i32) {
         unsafe {
             ffi::gtk_notebook_reorder_child(GTK_NOTEBOOK(self.pointer),
-                                            child.get_widget(),
+                                            child.unwrap_widget(),
                                             position)
         }
     }
@@ -350,14 +350,14 @@ impl NoteBook {
     pub fn is_tab_reorderable<T: gtk::WidgetTrait>(&self, child: &T) -> bool {
         unsafe {
             to_bool(ffi::gtk_notebook_get_tab_reorderable(GTK_NOTEBOOK(self.pointer),
-                                                               child.get_widget()))
+                                                               child.unwrap_widget()))
         }
     }
 
     pub fn set_tab_reorderable<T: gtk::WidgetTrait>(&mut self, child: &T, reorderable: bool) {
         unsafe {
             ffi::gtk_notebook_set_tab_reorderable(GTK_NOTEBOOK(self.pointer),
-                                                 child.get_widget(),
+                                                 child.unwrap_widget(),
                                                  to_gboolean(reorderable))
         }
     }
@@ -365,14 +365,14 @@ impl NoteBook {
     pub fn is_tab_detachable<T: gtk::WidgetTrait>(&self, child: &T) -> bool {
         unsafe {
             to_bool(ffi::gtk_notebook_get_tab_detachable(GTK_NOTEBOOK(self.pointer),
-                                                              child.get_widget()))
+                                                              child.unwrap_widget()))
         }
     }
 
     pub fn set_tab_detachable<T: gtk::WidgetTrait>(&mut self, child: &T, detachable: bool) {
         unsafe {
             ffi::gtk_notebook_set_tab_detachable(GTK_NOTEBOOK(self.pointer),
-                                                child.get_widget(),
+                                                child.unwrap_widget(),
                                                 to_gboolean(detachable))
         }
     }
@@ -383,14 +383,14 @@ impl NoteBook {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 
     pub fn set_action_widget<T: gtk::WidgetTrait>(&mut self, child: &T, pack_type: gtk::PackType) {
         unsafe {
             ffi::gtk_notebook_set_action_widget(GTK_NOTEBOOK(self.pointer),
-                                                child.get_widget(),
+                                                child.unwrap_widget(),
                                                 pack_type)
         }
     }

--- a/src/gtk/widgets/overlay.rs
+++ b/src/gtk/widgets/overlay.rs
@@ -29,7 +29,7 @@ impl Overlay {
 
     pub fn add_overlay<T: gtk::WidgetTrait>(&mut self, widget: &T) {
         unsafe {
-            ffi::gtk_overlay_add_overlay(GTK_OVERLAY(self.pointer), widget.get_widget())
+            ffi::gtk_overlay_add_overlay(GTK_OVERLAY(self.pointer), widget.unwrap_widget())
         }
     }
 }

--- a/src/gtk/widgets/page_setup.rs
+++ b/src/gtk/widgets/page_setup.rs
@@ -56,12 +56,12 @@ impl PageSetup {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer as *mut ffi::C_GtkWidget))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer as *mut ffi::C_GtkWidget))
         }
     }
 
     pub fn set_paper_size(&self, size: &gtk::PaperSize) {
-        unsafe { ffi::gtk_page_setup_set_paper_size(self.pointer, GTK_PAPER_SIZE(size.get_widget())) }
+        unsafe { ffi::gtk_page_setup_set_paper_size(self.pointer, GTK_PAPER_SIZE(size.unwrap_widget())) }
     }
 
     pub fn get_top_margin(&self, unit: gtk::Unit) -> f64 {
@@ -97,7 +97,7 @@ impl PageSetup {
     }
 
     pub fn set_paper_size_and_default_margins(&self, size: &gtk::PaperSize) {
-        unsafe { ffi::gtk_page_setup_set_paper_size_and_default_margins(self.pointer, GTK_PAPER_SIZE(size.get_widget())) }
+        unsafe { ffi::gtk_page_setup_set_paper_size_and_default_margins(self.pointer, GTK_PAPER_SIZE(size.unwrap_widget())) }
     }
 
     pub fn get_paper_width(&self, unit: gtk::Unit) -> f64 {

--- a/src/gtk/widgets/page_setup_unix_dialog.rs
+++ b/src/gtk/widgets/page_setup_unix_dialog.rs
@@ -25,7 +25,7 @@ impl PageSetupUnixDialog {
         let tmp_pointer = unsafe {
             title.with_c_str(|c_str|{
                 ffi::gtk_page_setup_unix_dialog_new(match parent {
-                    Some(ref p) => GTK_WINDOW(p.get_widget()),
+                    Some(ref p) => GTK_WINDOW(p.unwrap_widget()),
                     None => ::std::ptr::null_mut()
                 })
             })
@@ -34,35 +34,35 @@ impl PageSetupUnixDialog {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 
     pub fn set_page_setup(&self, page_setup: &gtk::PageSetup) {
-        unsafe { ffi::gtk_page_setup_unix_dialog_set_page_setup(GTK_PAGE_SETUP_UNIX_DIALOG(self.get_widget()), GTK_PAGE_SETUP(page_setup.get_widget())) }
+        unsafe { ffi::gtk_page_setup_unix_dialog_set_page_setup(GTK_PAGE_SETUP_UNIX_DIALOG(self.unwrap_widget()), GTK_PAGE_SETUP(page_setup.unwrap_widget())) }
     }
 
     pub fn get_page_setup(&self) -> Option<PageSetup> {
-        let tmp = unsafe { ffi::gtk_page_setup_unix_dialog_get_page_setup(GTK_PAGE_SETUP_UNIX_DIALOG(self.get_widget())) };
+        let tmp = unsafe { ffi::gtk_page_setup_unix_dialog_get_page_setup(GTK_PAGE_SETUP_UNIX_DIALOG(self.unwrap_widget())) };
 
         if tmp.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 
     pub fn set_print_settings(&self, print_settings: &gtk::PrintSettings) {
-        unsafe { ffi::gtk_page_setup_unix_dialog_set_print_settings(GTK_PAGE_SETUP_UNIX_DIALOG(self.get_widget()), GTK_PRINT_SETTINGS(print_settings.get_widget())) }
+        unsafe { ffi::gtk_page_setup_unix_dialog_set_print_settings(GTK_PAGE_SETUP_UNIX_DIALOG(self.unwrap_widget()), GTK_PRINT_SETTINGS(print_settings.unwrap_widget())) }
     }
 
     pub fn get_print_settings(&self) -> Option<PrintSettings> {
-        let tmp = unsafe { ffi::gtk_page_setup_unix_dialog_get_print_settings(GTK_PAGE_SETUP_UNIX_DIALOG(self.get_widget())) };
+        let tmp = unsafe { ffi::gtk_page_setup_unix_dialog_get_print_settings(GTK_PAGE_SETUP_UNIX_DIALOG(self.unwrap_widget())) };
 
         if tmp.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 }

--- a/src/gtk/widgets/paned.rs
+++ b/src/gtk/widgets/paned.rs
@@ -42,26 +42,26 @@ impl Paned {
 
     pub fn add1<T: gtk::WidgetTrait>(&mut self, child: &T) -> () {
         unsafe {
-            ffi::gtk_paned_add1(GTK_PANED(self.pointer), child.get_widget())
+            ffi::gtk_paned_add1(GTK_PANED(self.pointer), child.unwrap_widget())
         }
     }
 
     pub fn add2<T: gtk::WidgetTrait>(&mut self, child: &T) -> () {
         unsafe {
-            ffi::gtk_paned_add2(GTK_PANED(self.pointer), child.get_widget())
+            ffi::gtk_paned_add2(GTK_PANED(self.pointer), child.unwrap_widget())
         }
     }
 
     pub fn pack1<T: gtk::WidgetTrait>(&mut self, child: &T, resize: bool, schrink: bool) -> () {
         unsafe {
-            ffi::gtk_paned_pack1(GTK_PANED(self.pointer), child.get_widget(),
+            ffi::gtk_paned_pack1(GTK_PANED(self.pointer), child.unwrap_widget(),
                                  to_gboolean(resize), to_gboolean(schrink));
         }
     }
 
     pub fn pack2<T: gtk::WidgetTrait>(&mut self, child: &T, resize: bool, schrink: bool) -> () {
         unsafe {
-            ffi::gtk_paned_pack2(GTK_PANED(self.pointer), child.get_widget(),
+            ffi::gtk_paned_pack2(GTK_PANED(self.pointer), child.unwrap_widget(),
                                  to_gboolean(resize), to_gboolean(schrink));
         }
     }
@@ -80,7 +80,7 @@ impl Paned {
 
     pub fn get_handle_window(&self) -> gtk::Window {
         unsafe {
-            gtk::FFIWidget::wrap(ffi::gtk_paned_get_handle_window(GTK_PANED(self.pointer)))
+            gtk::FFIWidget::wrap_widget(ffi::gtk_paned_get_handle_window(GTK_PANED(self.pointer)))
         }
     }
 }

--- a/src/gtk/widgets/paper_size.rs
+++ b/src/gtk/widgets/paper_size.rs
@@ -34,7 +34,7 @@ impl PaperSize {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer as *mut ffi::C_GtkWidget))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer as *mut ffi::C_GtkWidget))
         }
     }
 
@@ -48,7 +48,7 @@ impl PaperSize {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer as *mut ffi::C_GtkWidget))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer as *mut ffi::C_GtkWidget))
         }
     }
 
@@ -62,22 +62,22 @@ impl PaperSize {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer as *mut ffi::C_GtkWidget))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer as *mut ffi::C_GtkWidget))
         }
     }
 
     pub fn copy(&self) -> Option<PaperSize> {
-        let tmp_pointer = unsafe { ffi::gtk_paper_size_copy(GTK_PAPER_SIZE(self.get_widget())) };
+        let tmp_pointer = unsafe { ffi::gtk_paper_size_copy(GTK_PAPER_SIZE(self.unwrap_widget())) };
 
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer as *mut ffi::C_GtkWidget))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer as *mut ffi::C_GtkWidget))
         }
     }
 
     pub fn is_equal(&self, other: &PaperSize) -> bool {
-        unsafe { to_bool(ffi::gtk_paper_size_is_equal(GTK_PAPER_SIZE(self.get_widget()), GTK_PAPER_SIZE(other.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_paper_size_is_equal(GTK_PAPER_SIZE(self.unwrap_widget()), GTK_PAPER_SIZE(other.unwrap_widget()))) }
     }
 
     pub fn get_paper_sizes(include_custom: bool) -> glib::List<Box<PaperSize>> {
@@ -91,14 +91,14 @@ impl PaperSize {
             let mut tmp_vec : glib::List<Box<PaperSize>> = glib::List::new();
 
             for it in old_list.iter() {
-                tmp_vec.append(Box::new(gtk::FFIWidget::wrap(*it)));
+                tmp_vec.append(Box::new(gtk::FFIWidget::wrap_widget(*it)));
             }
             tmp_vec
         }
     }
 
     pub fn get_name(&self) -> Option<String> {
-        let tmp = unsafe { ffi::gtk_paper_size_get_name(GTK_PAPER_SIZE(self.get_widget())) };
+        let tmp = unsafe { ffi::gtk_paper_size_get_name(GTK_PAPER_SIZE(self.unwrap_widget())) };
 
         if tmp.is_null() {
             None
@@ -108,7 +108,7 @@ impl PaperSize {
     }
 
     pub fn get_display_name_name(&self) -> Option<String> {
-        let tmp = unsafe { ffi::gtk_paper_size_get_display_name(GTK_PAPER_SIZE(self.get_widget())) };
+        let tmp = unsafe { ffi::gtk_paper_size_get_display_name(GTK_PAPER_SIZE(self.unwrap_widget())) };
 
         if tmp.is_null() {
             None
@@ -118,7 +118,7 @@ impl PaperSize {
     }
 
     pub fn get_ppd_name(&self) -> Option<String> {
-        let tmp = unsafe { ffi::gtk_paper_size_get_ppd_name(GTK_PAPER_SIZE(self.get_widget())) };
+        let tmp = unsafe { ffi::gtk_paper_size_get_ppd_name(GTK_PAPER_SIZE(self.unwrap_widget())) };
 
         if tmp.is_null() {
             None
@@ -128,35 +128,35 @@ impl PaperSize {
     }
 
     pub fn get_width(&self, unit: gtk::Unit) -> f64 {
-        unsafe { ffi::gtk_paper_size_get_width(GTK_PAPER_SIZE(self.get_widget()), unit) }
+        unsafe { ffi::gtk_paper_size_get_width(GTK_PAPER_SIZE(self.unwrap_widget()), unit) }
     }
 
     pub fn get_height(&self, unit: gtk::Unit) -> f64 {
-        unsafe { ffi::gtk_paper_size_get_height(GTK_PAPER_SIZE(self.get_widget()), unit) }
+        unsafe { ffi::gtk_paper_size_get_height(GTK_PAPER_SIZE(self.unwrap_widget()), unit) }
     }
 
     pub fn is_custom(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_paper_size_is_custom(GTK_PAPER_SIZE(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_paper_size_is_custom(GTK_PAPER_SIZE(self.unwrap_widget()))) }
     }
 
     pub fn set_size(&self, width: f64, height: f64, unit: gtk::Unit) {
-        unsafe { ffi::gtk_paper_size_set_size(GTK_PAPER_SIZE(self.get_widget()), width, height, unit) }
+        unsafe { ffi::gtk_paper_size_set_size(GTK_PAPER_SIZE(self.unwrap_widget()), width, height, unit) }
     }
 
     pub fn get_default_top_margin(&self, unit: gtk::Unit) -> f64 {
-        unsafe { ffi::gtk_paper_size_get_default_top_margin(GTK_PAPER_SIZE(self.get_widget()), unit) }
+        unsafe { ffi::gtk_paper_size_get_default_top_margin(GTK_PAPER_SIZE(self.unwrap_widget()), unit) }
     }
 
     pub fn get_default_bottom_margin(&self, unit: gtk::Unit) -> f64 {
-        unsafe { ffi::gtk_paper_size_get_default_bottom_margin(GTK_PAPER_SIZE(self.get_widget()), unit) }
+        unsafe { ffi::gtk_paper_size_get_default_bottom_margin(GTK_PAPER_SIZE(self.unwrap_widget()), unit) }
     }
 
     pub fn get_default_left_margin(&self, unit: gtk::Unit) -> f64 {
-        unsafe { ffi::gtk_paper_size_get_default_left_margin(GTK_PAPER_SIZE(self.get_widget()), unit) }
+        unsafe { ffi::gtk_paper_size_get_default_left_margin(GTK_PAPER_SIZE(self.unwrap_widget()), unit) }
     }
 
     pub fn get_default_right_margin(&self, unit: gtk::Unit) -> f64 {
-        unsafe { ffi::gtk_paper_size_get_default_left_margin(GTK_PAPER_SIZE(self.get_widget()), unit) }
+        unsafe { ffi::gtk_paper_size_get_default_left_margin(GTK_PAPER_SIZE(self.unwrap_widget()), unit) }
     }
 
     pub fn get_default() -> Option<String> {
@@ -173,7 +173,7 @@ impl PaperSize {
 impl Drop for PaperSize {
     fn drop(&mut self) {
         unsafe {
-            ffi::gtk_paper_size_free(GTK_PAPER_SIZE(self.get_widget()));
+            ffi::gtk_paper_size_free(GTK_PAPER_SIZE(self.unwrap_widget()));
             ::glib::ffi::g_object_unref(self.pointer as *mut ::glib::ffi::C_GObject);
         }
     }

--- a/src/gtk/widgets/places_sidebar.rs
+++ b/src/gtk/widgets/places_sidebar.rs
@@ -29,45 +29,45 @@ impl PlacesSidebar {
     }
 
     pub fn set_open_flags(&self, flags: gtk::PlacesOpenFlags) {
-        unsafe { ffi::gtk_places_sidebar_set_open_flags(GTK_PLACES_SIDEBAR(self.get_widget()), flags) }
+        unsafe { ffi::gtk_places_sidebar_set_open_flags(GTK_PLACES_SIDEBAR(self.unwrap_widget()), flags) }
     }
 
     pub fn get_open_flags(&self) -> gtk::PlacesOpenFlags {
-        unsafe { ffi::gtk_places_sidebar_get_open_flags(GTK_PLACES_SIDEBAR(self.get_widget())) }
+        unsafe { ffi::gtk_places_sidebar_get_open_flags(GTK_PLACES_SIDEBAR(self.unwrap_widget())) }
     }
 
     pub fn set_show_desktop(&self, show_desktop: bool) {
-        unsafe { ffi::gtk_places_sidebar_set_show_desktop(GTK_PLACES_SIDEBAR(self.get_widget()), to_gboolean(show_desktop)) }
+        unsafe { ffi::gtk_places_sidebar_set_show_desktop(GTK_PLACES_SIDEBAR(self.unwrap_widget()), to_gboolean(show_desktop)) }
     }
 
     pub fn get_show_desktop(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_places_sidebar_get_show_desktop(GTK_PLACES_SIDEBAR(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_places_sidebar_get_show_desktop(GTK_PLACES_SIDEBAR(self.unwrap_widget()))) }
     }
 
     pub fn set_show_connect_to_server(&self, show_connect_to_server: bool) {
-        unsafe { ffi::gtk_places_sidebar_set_show_connect_to_server(GTK_PLACES_SIDEBAR(self.get_widget()),
+        unsafe { ffi::gtk_places_sidebar_set_show_connect_to_server(GTK_PLACES_SIDEBAR(self.unwrap_widget()),
             to_gboolean(show_connect_to_server)) }
     }
 
     pub fn get_show_connect_to_server(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_places_sidebar_get_show_connect_to_server(GTK_PLACES_SIDEBAR(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_places_sidebar_get_show_connect_to_server(GTK_PLACES_SIDEBAR(self.unwrap_widget()))) }
     }
 
     pub fn set_local_only(&self, local_only: bool) {
-        unsafe { ffi::gtk_places_sidebar_set_local_only(GTK_PLACES_SIDEBAR(self.get_widget()), to_gboolean(local_only)) }
+        unsafe { ffi::gtk_places_sidebar_set_local_only(GTK_PLACES_SIDEBAR(self.unwrap_widget()), to_gboolean(local_only)) }
     }
 
     pub fn get_local_only(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_places_sidebar_get_local_only(GTK_PLACES_SIDEBAR(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_places_sidebar_get_local_only(GTK_PLACES_SIDEBAR(self.unwrap_widget()))) }
     }
 
     pub fn set_show_enter_location(&self, show_enter_location: bool) {
-        unsafe { ffi::gtk_places_sidebar_set_show_enter_location(GTK_PLACES_SIDEBAR(self.get_widget()),
+        unsafe { ffi::gtk_places_sidebar_set_show_enter_location(GTK_PLACES_SIDEBAR(self.unwrap_widget()),
             to_gboolean(show_enter_location)) }
     }
 
     pub fn get_show_enter_location(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_places_sidebar_get_show_enter_location(GTK_PLACES_SIDEBAR(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_places_sidebar_get_show_enter_location(GTK_PLACES_SIDEBAR(self.unwrap_widget()))) }
     }
 }
 

--- a/src/gtk/widgets/popover.rs
+++ b/src/gtk/widgets/popover.rs
@@ -24,12 +24,12 @@ struct_Widget!(Popover);
 
 impl Popover {
     pub fn new<T: gtk::WidgetTrait>(relative_to: &T) -> Option<Popover> {
-        let tmp_pointer = unsafe { ffi::gtk_popover_new(relative_to.get_widget()) };
+        let tmp_pointer = unsafe { ffi::gtk_popover_new(relative_to.unwrap_widget()) };
         check_pointer!(tmp_pointer, Popover)
     }
 
     pub fn set_relative_to<T: gtk::WidgetTrait>(&self, relative_to: &T) {
-        unsafe { ffi::gtk_popover_set_relative_to(GTK_POPOVER(self.pointer), relative_to.get_widget()) }
+        unsafe { ffi::gtk_popover_set_relative_to(GTK_POPOVER(self.pointer), relative_to.unwrap_widget()) }
     }
 
     pub fn get_relative_to<T: gtk::WidgetTrait>(&self) -> Option<T> {
@@ -38,7 +38,7 @@ impl Popover {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 

--- a/src/gtk/widgets/print_settings.rs
+++ b/src/gtk/widgets/print_settings.rs
@@ -28,17 +28,17 @@ impl PrintSettings {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer as *mut ffi::C_GtkWidget))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer as *mut ffi::C_GtkWidget))
         }
     }
 
     pub fn copy(&self) -> Option<PrintSettings> {
-        let tmp_pointer = unsafe { ffi::gtk_print_settings_copy(GTK_PRINT_SETTINGS(self.get_widget())) };
+        let tmp_pointer = unsafe { ffi::gtk_print_settings_copy(GTK_PRINT_SETTINGS(self.unwrap_widget())) };
 
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer as *mut ffi::C_GtkWidget))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer as *mut ffi::C_GtkWidget))
         }
     }
 
@@ -46,7 +46,7 @@ impl PrintSettings {
         let c_str = CString::from_slice(key.as_bytes());
 
         unsafe {
-            to_bool(ffi::gtk_print_settings_has_key(GTK_PRINT_SETTINGS(self.get_widget()), c_str.as_ptr()))
+            to_bool(ffi::gtk_print_settings_has_key(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr()))
         }
     }
 
@@ -54,7 +54,7 @@ impl PrintSettings {
         unsafe {
             let c_str = CString::from_slice(key.as_bytes());
 
-            let tmp = ffi::gtk_print_settings_get(GTK_PRINT_SETTINGS(self.get_widget()), c_str.as_ptr());
+            let tmp = ffi::gtk_print_settings_get(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr());
 
             if tmp.is_null() {
                 None
@@ -69,7 +69,7 @@ impl PrintSettings {
             let c_str = CString::from_slice(key.as_bytes());
             let c_str2 = CString::from_slice(value.as_bytes());
 
-            ffi::gtk_print_settings_set(GTK_PRINT_SETTINGS(self.get_widget()), c_str.as_ptr(), c_str2.as_ptr())
+            ffi::gtk_print_settings_set(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr(), c_str2.as_ptr())
         }
     }
 
@@ -77,7 +77,7 @@ impl PrintSettings {
         unsafe {
             let c_str = CString::from_slice(key.as_bytes());
 
-            ffi::gtk_print_settings_unset(GTK_PRINT_SETTINGS(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_print_settings_unset(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr())
         }
     }
 
@@ -85,7 +85,7 @@ impl PrintSettings {
         unsafe {
             let c_str = CString::from_slice(key.as_bytes());
 
-            to_bool(ffi::gtk_print_settings_get_bool(GTK_PRINT_SETTINGS(self.get_widget()), c_str.as_ptr()))
+            to_bool(ffi::gtk_print_settings_get_bool(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr()))
         }
     }
 
@@ -93,7 +93,7 @@ impl PrintSettings {
         unsafe {
             let c_str = CString::from_slice(key.as_bytes());
 
-            ffi::gtk_print_settings_set_bool(GTK_PRINT_SETTINGS(self.get_widget()), c_str.as_ptr(), to_gboolean(value))
+            ffi::gtk_print_settings_set_bool(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr(), to_gboolean(value))
         }
     }
 
@@ -101,7 +101,7 @@ impl PrintSettings {
         unsafe {
             let c_str = CString::from_slice(key.as_bytes());
 
-            ffi::gtk_print_settings_get_double(GTK_PRINT_SETTINGS(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_print_settings_get_double(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr())
         }
     }
 
@@ -109,7 +109,7 @@ impl PrintSettings {
         unsafe {
             let c_str = CString::from_slice(key.as_bytes());
 
-            ffi::gtk_print_settings_set_double(GTK_PRINT_SETTINGS(self.get_widget()), c_str.as_ptr(), value)
+            ffi::gtk_print_settings_set_double(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr(), value)
         }
     }
 
@@ -117,7 +117,7 @@ impl PrintSettings {
         unsafe {
             let c_str = CString::from_slice(key.as_bytes());
 
-            ffi::gtk_print_settings_get_double_with_default(GTK_PRINT_SETTINGS(self.get_widget()), c_str.as_ptr(), def)
+            ffi::gtk_print_settings_get_double_with_default(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr(), def)
         }
     }
 
@@ -125,7 +125,7 @@ impl PrintSettings {
         unsafe {
             let c_str = CString::from_slice(key.as_bytes());
 
-            ffi::gtk_print_settings_get_length(GTK_PRINT_SETTINGS(self.get_widget()), c_str.as_ptr(), unit)
+            ffi::gtk_print_settings_get_length(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr(), unit)
         }
     }
 
@@ -133,7 +133,7 @@ impl PrintSettings {
         unsafe {
             let c_str = CString::from_slice(key.as_bytes());
 
-            ffi::gtk_print_settings_set_length(GTK_PRINT_SETTINGS(self.get_widget()), c_str.as_ptr(), value, unit)
+            ffi::gtk_print_settings_set_length(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr(), value, unit)
         }
     }
 
@@ -141,7 +141,7 @@ impl PrintSettings {
         unsafe {
             let c_str = CString::from_slice(key.as_bytes());
 
-            ffi::gtk_print_settings_get_int(GTK_PRINT_SETTINGS(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_print_settings_get_int(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr())
         }
     }
 
@@ -149,7 +149,7 @@ impl PrintSettings {
         unsafe {
             let c_str = CString::from_slice(key.as_bytes());
 
-            ffi::gtk_print_settings_set_int(GTK_PRINT_SETTINGS(self.get_widget()), c_str.as_ptr(), value)
+            ffi::gtk_print_settings_set_int(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr(), value)
         }
     }
 
@@ -157,12 +157,12 @@ impl PrintSettings {
         unsafe {
             let c_str = CString::from_slice(key.as_bytes());
 
-            ffi::gtk_print_settings_get_int_with_default(GTK_PRINT_SETTINGS(self.get_widget()), c_str.as_ptr(), def)
+            ffi::gtk_print_settings_get_int_with_default(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr(), def)
         }
     }
 
     pub fn get_printer(&self) -> Option<String> {
-        let tmp = unsafe { ffi::gtk_print_settings_get_printer(GTK_PRINT_SETTINGS(self.get_widget())) };
+        let tmp = unsafe { ffi::gtk_print_settings_get_printer(GTK_PRINT_SETTINGS(self.unwrap_widget())) };
 
         if tmp.is_null() {
             None
@@ -175,144 +175,144 @@ impl PrintSettings {
         unsafe {
             let c_str = CString::from_slice(printer.as_bytes());
 
-            ffi::gtk_print_settings_set_printer(GTK_PRINT_SETTINGS(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_print_settings_set_printer(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr())
         }
     }
 
     pub fn get_orientation(&self) -> gtk::PageOrientation {
-        unsafe { ffi::gtk_print_settings_get_orientation(GTK_PRINT_SETTINGS(self.get_widget())) }
+        unsafe { ffi::gtk_print_settings_get_orientation(GTK_PRINT_SETTINGS(self.unwrap_widget())) }
     }
 
     pub fn set_orientation(&self, orientation: gtk::PageOrientation) {
-        unsafe { ffi::gtk_print_settings_set_orientation(GTK_PRINT_SETTINGS(self.get_widget()), orientation) }
+        unsafe { ffi::gtk_print_settings_set_orientation(GTK_PRINT_SETTINGS(self.unwrap_widget()), orientation) }
     }
 
     pub fn get_paper_size(&self) -> Option<gtk::PaperSize> {
-        let tmp = unsafe { ffi::gtk_print_settings_get_paper_size(GTK_PRINT_SETTINGS(self.get_widget())) };
+        let tmp = unsafe { ffi::gtk_print_settings_get_paper_size(GTK_PRINT_SETTINGS(self.unwrap_widget())) };
 
         if tmp.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp as *mut ffi::C_GtkWidget))
+            Some(gtk::FFIWidget::wrap_widget(tmp as *mut ffi::C_GtkWidget))
         }
     }
 
     pub fn set_paper_size(&self, paper_size: &gtk::PaperSize) {
-        unsafe { ffi::gtk_print_settings_set_paper_size(GTK_PRINT_SETTINGS(self.get_widget()), GTK_PAPER_SIZE(paper_size.get_widget())) }
+        unsafe { ffi::gtk_print_settings_set_paper_size(GTK_PRINT_SETTINGS(self.unwrap_widget()), GTK_PAPER_SIZE(paper_size.unwrap_widget())) }
     }
 
     pub fn get_paper_width(&self, unit: gtk::Unit) -> f64 {
-        unsafe { ffi::gtk_print_settings_get_paper_width(GTK_PRINT_SETTINGS(self.get_widget()), unit) }
+        unsafe { ffi::gtk_print_settings_get_paper_width(GTK_PRINT_SETTINGS(self.unwrap_widget()), unit) }
     }
 
     pub fn set_paper_width(&self, width: f64, unit: gtk::Unit) {
-        unsafe { ffi::gtk_print_settings_set_paper_width(GTK_PRINT_SETTINGS(self.get_widget()), width, unit) }
+        unsafe { ffi::gtk_print_settings_set_paper_width(GTK_PRINT_SETTINGS(self.unwrap_widget()), width, unit) }
     }
 
     pub fn get_paper_height(&self, unit: gtk::Unit) -> f64 {
-        unsafe { ffi::gtk_print_settings_get_paper_height(GTK_PRINT_SETTINGS(self.get_widget()), unit) }
+        unsafe { ffi::gtk_print_settings_get_paper_height(GTK_PRINT_SETTINGS(self.unwrap_widget()), unit) }
     }
 
     pub fn set_paper_height(&self, height: f64, unit: gtk::Unit) {
-        unsafe { ffi::gtk_print_settings_set_paper_height(GTK_PRINT_SETTINGS(self.get_widget()), height, unit) }
+        unsafe { ffi::gtk_print_settings_set_paper_height(GTK_PRINT_SETTINGS(self.unwrap_widget()), height, unit) }
     }
 
     pub fn get_use_color(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_print_settings_get_use_color(GTK_PRINT_SETTINGS(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_print_settings_get_use_color(GTK_PRINT_SETTINGS(self.unwrap_widget()))) }
     }
 
     pub fn set_use_color(&self, use_color: bool) {
-        unsafe { ffi::gtk_print_settings_set_use_color(GTK_PRINT_SETTINGS(self.get_widget()), to_gboolean(use_color)) }
+        unsafe { ffi::gtk_print_settings_set_use_color(GTK_PRINT_SETTINGS(self.unwrap_widget()), to_gboolean(use_color)) }
     }
 
     pub fn get_collate(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_print_settings_get_collate(GTK_PRINT_SETTINGS(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_print_settings_get_collate(GTK_PRINT_SETTINGS(self.unwrap_widget()))) }
     }
 
     pub fn set_collate(&self, collate: bool) {
-        unsafe { ffi::gtk_print_settings_set_collate(GTK_PRINT_SETTINGS(self.get_widget()), to_gboolean(collate)) }
+        unsafe { ffi::gtk_print_settings_set_collate(GTK_PRINT_SETTINGS(self.unwrap_widget()), to_gboolean(collate)) }
     }
 
     pub fn get_reverse(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_print_settings_get_reverse(GTK_PRINT_SETTINGS(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_print_settings_get_reverse(GTK_PRINT_SETTINGS(self.unwrap_widget()))) }
     }
 
     pub fn set_reverse(&self, reverse: bool) {
-        unsafe { ffi::gtk_print_settings_set_reverse(GTK_PRINT_SETTINGS(self.get_widget()),
+        unsafe { ffi::gtk_print_settings_set_reverse(GTK_PRINT_SETTINGS(self.unwrap_widget()),
                                                      to_gboolean(reverse))
         }
     }
 
     pub fn get_n_copies(&self) -> i32 {
-        unsafe { ffi::gtk_print_settings_get_n_copies(GTK_PRINT_SETTINGS(self.get_widget())) }
+        unsafe { ffi::gtk_print_settings_get_n_copies(GTK_PRINT_SETTINGS(self.unwrap_widget())) }
     }
 
     pub fn set_n_copies(&self, num_copies: i32) {
-        unsafe { ffi::gtk_print_settings_set_n_copies(GTK_PRINT_SETTINGS(self.get_widget()), num_copies) }
+        unsafe { ffi::gtk_print_settings_set_n_copies(GTK_PRINT_SETTINGS(self.unwrap_widget()), num_copies) }
     }
 
     pub fn get_number_up(&self) -> gtk::NumberUpLayout {
-        unsafe { ffi::gtk_print_settings_get_number_up(GTK_PRINT_SETTINGS(self.get_widget())) }
+        unsafe { ffi::gtk_print_settings_get_number_up(GTK_PRINT_SETTINGS(self.unwrap_widget())) }
     }
 
     pub fn set_number_up(&self, number_up: gtk::NumberUpLayout) {
-        unsafe { ffi::gtk_print_settings_set_number_up(GTK_PRINT_SETTINGS(self.get_widget()), number_up) }
+        unsafe { ffi::gtk_print_settings_set_number_up(GTK_PRINT_SETTINGS(self.unwrap_widget()), number_up) }
     }
 
     pub fn get_resolution(&self) -> i32 {
-        unsafe { ffi::gtk_print_settings_get_resolution(GTK_PRINT_SETTINGS(self.get_widget())) }
+        unsafe { ffi::gtk_print_settings_get_resolution(GTK_PRINT_SETTINGS(self.unwrap_widget())) }
     }
 
     pub fn set_resolution(&self, resolution: i32) {
-        unsafe { ffi::gtk_print_settings_set_resolution(GTK_PRINT_SETTINGS(self.get_widget()), resolution) }
+        unsafe { ffi::gtk_print_settings_set_resolution(GTK_PRINT_SETTINGS(self.unwrap_widget()), resolution) }
     }
 
     pub fn set_resolution_xy(&self, resolution_x: i32, resolution_y: i32) {
-        unsafe { ffi::gtk_print_settings_set_resolution_xy(GTK_PRINT_SETTINGS(self.get_widget()), resolution_x, resolution_y) }
+        unsafe { ffi::gtk_print_settings_set_resolution_xy(GTK_PRINT_SETTINGS(self.unwrap_widget()), resolution_x, resolution_y) }
     }
 
     pub fn get_resolution_x(&self) -> i32 {
-        unsafe { ffi::gtk_print_settings_get_resolution_x(GTK_PRINT_SETTINGS(self.get_widget())) }
+        unsafe { ffi::gtk_print_settings_get_resolution_x(GTK_PRINT_SETTINGS(self.unwrap_widget())) }
     }
 
     pub fn get_resolution_y(&self) -> i32 {
-        unsafe { ffi::gtk_print_settings_get_resolution_y(GTK_PRINT_SETTINGS(self.get_widget())) }
+        unsafe { ffi::gtk_print_settings_get_resolution_y(GTK_PRINT_SETTINGS(self.unwrap_widget())) }
     }
 
     pub fn get_printer_lpi(&self) -> f64 {
-        unsafe { ffi::gtk_print_settings_get_printer_lpi(GTK_PRINT_SETTINGS(self.get_widget())) }
+        unsafe { ffi::gtk_print_settings_get_printer_lpi(GTK_PRINT_SETTINGS(self.unwrap_widget())) }
     }
 
     pub fn set_printer_lpi(&self, lpi: f64) {
-        unsafe { ffi::gtk_print_settings_set_printer_lpi(GTK_PRINT_SETTINGS(self.get_widget()), lpi) }
+        unsafe { ffi::gtk_print_settings_set_printer_lpi(GTK_PRINT_SETTINGS(self.unwrap_widget()), lpi) }
     }
 
     pub fn get_scale(&self) -> f64 {
-        unsafe { ffi::gtk_print_settings_get_scale(GTK_PRINT_SETTINGS(self.get_widget())) }
+        unsafe { ffi::gtk_print_settings_get_scale(GTK_PRINT_SETTINGS(self.unwrap_widget())) }
     }
 
     pub fn set_scale(&self, scale: f64) {
-        unsafe { ffi::gtk_print_settings_set_scale(GTK_PRINT_SETTINGS(self.get_widget()), scale) }
+        unsafe { ffi::gtk_print_settings_set_scale(GTK_PRINT_SETTINGS(self.unwrap_widget()), scale) }
     }
 
     pub fn get_print_pages(&self) -> gtk::PrintPages {
-        unsafe { ffi::gtk_print_settings_get_print_pages(GTK_PRINT_SETTINGS(self.get_widget())) }
+        unsafe { ffi::gtk_print_settings_get_print_pages(GTK_PRINT_SETTINGS(self.unwrap_widget())) }
     }
 
     pub fn set_print_pages(&self, pages: gtk::PrintPages) {
-        unsafe { ffi::gtk_print_settings_set_print_pages(GTK_PRINT_SETTINGS(self.get_widget()), pages) }
+        unsafe { ffi::gtk_print_settings_set_print_pages(GTK_PRINT_SETTINGS(self.unwrap_widget()), pages) }
     }
 
     pub fn get_page_set(&self) -> gtk::PageSet {
-        unsafe { ffi::gtk_print_settings_get_page_set(GTK_PRINT_SETTINGS(self.get_widget())) }
+        unsafe { ffi::gtk_print_settings_get_page_set(GTK_PRINT_SETTINGS(self.unwrap_widget())) }
     }
 
     pub fn set_page_set(&self, page_set: gtk::PageSet) {
-        unsafe { ffi::gtk_print_settings_set_page_set(GTK_PRINT_SETTINGS(self.get_widget()), page_set) }
+        unsafe { ffi::gtk_print_settings_set_page_set(GTK_PRINT_SETTINGS(self.unwrap_widget()), page_set) }
     }
 
     pub fn get_default_source(&self) -> Option<String> {
-        let tmp = unsafe { ffi::gtk_print_settings_get_default_source(GTK_PRINT_SETTINGS(self.get_widget())) };
+        let tmp = unsafe { ffi::gtk_print_settings_get_default_source(GTK_PRINT_SETTINGS(self.unwrap_widget())) };
 
         if tmp.is_null() {
             None
@@ -325,12 +325,12 @@ impl PrintSettings {
         unsafe {
             let c_str = CString::from_slice(default_source.as_bytes());
 
-            ffi::gtk_print_settings_set_default_source(GTK_PRINT_SETTINGS(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_print_settings_set_default_source(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr())
         }
     }
 
     pub fn get_media_type(&self) -> Option<String> {
-        let tmp = unsafe { ffi::gtk_print_settings_get_media_type(GTK_PRINT_SETTINGS(self.get_widget())) };
+        let tmp = unsafe { ffi::gtk_print_settings_get_media_type(GTK_PRINT_SETTINGS(self.unwrap_widget())) };
 
         if tmp.is_null() {
             None
@@ -343,12 +343,12 @@ impl PrintSettings {
         unsafe {
             let c_str = CString::from_slice(media_type.as_bytes());
 
-            ffi::gtk_print_settings_set_media_type(GTK_PRINT_SETTINGS(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_print_settings_set_media_type(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr())
         }
     }
 
     pub fn get_dither(&self) -> Option<String> {
-        let tmp = unsafe { ffi::gtk_print_settings_get_dither(GTK_PRINT_SETTINGS(self.get_widget())) };
+        let tmp = unsafe { ffi::gtk_print_settings_get_dither(GTK_PRINT_SETTINGS(self.unwrap_widget())) };
 
         if tmp.is_null() {
             None
@@ -361,12 +361,12 @@ impl PrintSettings {
         unsafe {
             let c_str = CString::from_slice(dither.as_bytes());
 
-            ffi::gtk_print_settings_set_dither(GTK_PRINT_SETTINGS(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_print_settings_set_dither(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr())
         }
     }
 
     pub fn get_finishings(&self) -> Option<String> {
-        let tmp = unsafe { ffi::gtk_print_settings_get_finishings(GTK_PRINT_SETTINGS(self.get_widget())) };
+        let tmp = unsafe { ffi::gtk_print_settings_get_finishings(GTK_PRINT_SETTINGS(self.unwrap_widget())) };
 
         if tmp.is_null() {
             None
@@ -379,12 +379,12 @@ impl PrintSettings {
         unsafe {
             let c_str = CString::from_slice(finishings.as_bytes());
 
-            ffi::gtk_print_settings_set_finishings(GTK_PRINT_SETTINGS(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_print_settings_set_finishings(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr())
         }
     }
 
     pub fn get_output_bin(&self) -> Option<String> {
-        let tmp = unsafe { ffi::gtk_print_settings_get_output_bin(GTK_PRINT_SETTINGS(self.get_widget())) };
+        let tmp = unsafe { ffi::gtk_print_settings_get_output_bin(GTK_PRINT_SETTINGS(self.unwrap_widget())) };
 
         if tmp.is_null() {
             None
@@ -397,7 +397,7 @@ impl PrintSettings {
         unsafe {
             let c_str = CString::from_slice(output_bin.as_bytes());
 
-            ffi::gtk_print_settings_set_output_bin(GTK_PRINT_SETTINGS(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_print_settings_set_output_bin(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr())
         }
     }
 }

--- a/src/gtk/widgets/recent_chooser_dialog.rs
+++ b/src/gtk/widgets/recent_chooser_dialog.rs
@@ -28,7 +28,7 @@ impl RecentChooserDialog {
         let cancel_str = CString::from_slice("Cancel".as_bytes());
         let tmp_pointer = unsafe {
             ffi::gtk_recent_chooser_dialog_new(c_str.as_ptr(), match parent {
-                Some(ref p) => GTK_WINDOW(p.get_widget()),
+                Some(ref p) => GTK_WINDOW(p.unwrap_widget()),
                 None => ::std::ptr::null_mut()
             }, ok_str.as_ptr(), ResponseType::Ok,
                cancel_str.as_ptr(), ResponseType::Cancel,
@@ -38,7 +38,7 @@ impl RecentChooserDialog {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 
@@ -49,9 +49,9 @@ impl RecentChooserDialog {
 
         let tmp_pointer = unsafe {
             ffi::gtk_recent_chooser_dialog_new_for_manager(c_str.as_ptr(), match parent {
-                Some(ref p) => GTK_WINDOW(p.get_widget()),
+                Some(ref p) => GTK_WINDOW(p.unwrap_widget()),
                 None => ::std::ptr::null_mut()
-            }, GTK_RECENT_MANAGER(manager.get_widget()),
+            }, GTK_RECENT_MANAGER(manager.unwrap_widget()),
                ok_str.as_ptr(), ResponseType::Ok,
                cancel_str.as_ptr(), ResponseType::Cancel,
                ::std::ptr::null::<::libc::c_void>())
@@ -60,7 +60,7 @@ impl RecentChooserDialog {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 }

--- a/src/gtk/widgets/recent_chooser_widget.rs
+++ b/src/gtk/widgets/recent_chooser_widget.rs
@@ -29,7 +29,7 @@ impl RecentChooserWidget {
     }
 
     pub fn new_for_manager(manager: &RecentManager) -> Option<RecentChooserWidget> {
-        let tmp_pointer = unsafe { ffi::gtk_recent_chooser_widget_new_for_manager(GTK_RECENT_MANAGER(manager.get_widget())) };
+        let tmp_pointer = unsafe { ffi::gtk_recent_chooser_widget_new_for_manager(GTK_RECENT_MANAGER(manager.unwrap_widget())) };
         check_pointer!(tmp_pointer, RecentChooserWidget)
     }
 }

--- a/src/gtk/widgets/recent_filter.rs
+++ b/src/gtk/widgets/recent_filter.rs
@@ -69,7 +69,7 @@ impl RecentFilter {
         }
     }
 
-    pub fn get_pointer(&self) -> *mut ffi::C_GtkRecentFilter {
+    pub fn unwrap_pointer(&self) -> *mut ffi::C_GtkRecentFilter {
         self.pointer
     }
 }

--- a/src/gtk/widgets/recent_info.rs
+++ b/src/gtk/widgets/recent_info.rs
@@ -24,21 +24,21 @@ struct_Widget!(RecentInfo);
 
 impl RecentInfo {
     pub fn _ref(&self) -> Option<RecentInfo> {
-        let tmp_pointer = unsafe { ffi::gtk_recent_info_ref(GTK_RECENT_INFO(self.get_widget())) };
+        let tmp_pointer = unsafe { ffi::gtk_recent_info_ref(GTK_RECENT_INFO(self.unwrap_widget())) };
 
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer as *mut ffi::C_GtkWidget))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer as *mut ffi::C_GtkWidget))
         }
     }
 
     pub fn unref(&self) {
-        unsafe { ffi::gtk_recent_info_unref(GTK_RECENT_INFO(self.get_widget())) }
+        unsafe { ffi::gtk_recent_info_unref(GTK_RECENT_INFO(self.unwrap_widget())) }
     }
 
     pub fn get_uri(&self) -> Option<String> {
-        let uri = unsafe { ffi::gtk_recent_info_get_uri(GTK_RECENT_INFO(self.get_widget())) };
+        let uri = unsafe { ffi::gtk_recent_info_get_uri(GTK_RECENT_INFO(self.unwrap_widget())) };
 
         if uri.is_null() {
             None
@@ -48,7 +48,7 @@ impl RecentInfo {
     }
 
     pub fn get_display_name(&self) -> Option<String> {
-        let display_name = unsafe { ffi::gtk_recent_info_get_display_name(GTK_RECENT_INFO(self.get_widget())) };
+        let display_name = unsafe { ffi::gtk_recent_info_get_display_name(GTK_RECENT_INFO(self.unwrap_widget())) };
 
         if display_name.is_null() {
             None
@@ -58,7 +58,7 @@ impl RecentInfo {
     }
 
     pub fn get_description(&self) -> Option<String> {
-        let description = unsafe { ffi::gtk_recent_info_get_description(GTK_RECENT_INFO(self.get_widget())) };
+        let description = unsafe { ffi::gtk_recent_info_get_description(GTK_RECENT_INFO(self.unwrap_widget())) };
 
         if description.is_null() {
             None
@@ -68,7 +68,7 @@ impl RecentInfo {
     }
 
     pub fn get_mime_type(&self) -> Option<String> {
-        let mime_type = unsafe { ffi::gtk_recent_info_get_mime_type(GTK_RECENT_INFO(self.get_widget())) };
+        let mime_type = unsafe { ffi::gtk_recent_info_get_mime_type(GTK_RECENT_INFO(self.unwrap_widget())) };
 
         if mime_type.is_null() {
             None
@@ -78,19 +78,19 @@ impl RecentInfo {
     }
 
     pub fn get_added(&self) -> i64 {
-        unsafe { ffi::gtk_recent_info_get_added(GTK_RECENT_INFO(self.get_widget())) }
+        unsafe { ffi::gtk_recent_info_get_added(GTK_RECENT_INFO(self.unwrap_widget())) }
     }
 
     pub fn get_modified(&self) -> i64 {
-        unsafe { ffi::gtk_recent_info_get_modified(GTK_RECENT_INFO(self.get_widget())) }
+        unsafe { ffi::gtk_recent_info_get_modified(GTK_RECENT_INFO(self.unwrap_widget())) }
     }
 
     pub fn get_visited(&self) -> i64 {
-        unsafe { ffi::gtk_recent_info_get_visited(GTK_RECENT_INFO(self.get_widget())) }
+        unsafe { ffi::gtk_recent_info_get_visited(GTK_RECENT_INFO(self.unwrap_widget())) }
     }
 
     pub fn get_private_hint(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_recent_info_get_private_hint(GTK_RECENT_INFO(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_recent_info_get_private_hint(GTK_RECENT_INFO(self.unwrap_widget()))) }
     }
 
     pub fn set_name(&self, app_name: &str) -> (bool, String, u32, i64) {
@@ -100,7 +100,7 @@ impl RecentInfo {
         let c_str = CString::from_slice(app_name.as_bytes());
 
         let ret = unsafe {
-            to_bool(ffi::gtk_recent_info_get_application_info(GTK_RECENT_INFO(self.get_widget()), c_str.as_ptr(), &app_exec, &mut count, &mut time_))
+            to_bool(ffi::gtk_recent_info_get_application_info(GTK_RECENT_INFO(self.unwrap_widget()), c_str.as_ptr(), &app_exec, &mut count, &mut time_))
         };
 
         if app_exec.is_null() {
@@ -112,7 +112,7 @@ impl RecentInfo {
 
     pub fn get_applications(&self) -> Option<Vec<String>> {
         let mut length = 0;
-        let tmp = unsafe { ffi::gtk_recent_info_get_applications(GTK_RECENT_INFO(self.get_widget()), &mut length) };
+        let tmp = unsafe { ffi::gtk_recent_info_get_applications(GTK_RECENT_INFO(self.unwrap_widget()), &mut length) };
 
         if tmp.is_null() {
             None
@@ -127,7 +127,7 @@ impl RecentInfo {
     }
 
     pub fn last_application(&self) -> Option<String> {
-        let tmp = unsafe { ffi::gtk_recent_info_last_application(GTK_RECENT_INFO(self.get_widget())) as *const c_char};
+        let tmp = unsafe { ffi::gtk_recent_info_last_application(GTK_RECENT_INFO(self.unwrap_widget())) as *const c_char};
 
         if tmp.is_null() {
             None
@@ -140,13 +140,13 @@ impl RecentInfo {
         unsafe {
             let c_str = CString::from_slice(app_name.as_bytes());
 
-            to_bool(ffi::gtk_recent_info_has_application(GTK_RECENT_INFO(self.get_widget()), c_str.as_ptr()))
+            to_bool(ffi::gtk_recent_info_has_application(GTK_RECENT_INFO(self.unwrap_widget()), c_str.as_ptr()))
         }
     }
 
     pub fn get_groups(&self) -> Option<Vec<String>> {
         let mut length = 0;
-        let tmp = unsafe { ffi::gtk_recent_info_get_groups(GTK_RECENT_INFO(self.get_widget()), &mut length) };
+        let tmp = unsafe { ffi::gtk_recent_info_get_groups(GTK_RECENT_INFO(self.unwrap_widget()), &mut length) };
 
         if tmp.is_null() {
             None
@@ -164,12 +164,12 @@ impl RecentInfo {
         let c_str = CString::from_slice(group_name.as_bytes());
 
         unsafe {
-            to_bool(ffi::gtk_recent_info_has_group(GTK_RECENT_INFO(self.get_widget()), c_str.as_ptr()))
+            to_bool(ffi::gtk_recent_info_has_group(GTK_RECENT_INFO(self.unwrap_widget()), c_str.as_ptr()))
         }
     }
 
     pub fn get_short_name(&self) -> Option<String> {
-        let tmp = unsafe { ffi::gtk_recent_info_get_short_name(GTK_RECENT_INFO(self.get_widget())) as *const c_char };
+        let tmp = unsafe { ffi::gtk_recent_info_get_short_name(GTK_RECENT_INFO(self.unwrap_widget())) as *const c_char };
 
         if tmp.is_null() {
             None
@@ -179,7 +179,7 @@ impl RecentInfo {
     }
 
     pub fn get_uri_display(&self) -> Option<String> {
-        let tmp = unsafe { ffi::gtk_recent_info_get_uri_display(GTK_RECENT_INFO(self.get_widget())) as *const c_char };
+        let tmp = unsafe { ffi::gtk_recent_info_get_uri_display(GTK_RECENT_INFO(self.unwrap_widget())) as *const c_char };
 
         if tmp.is_null() {
             None
@@ -189,19 +189,19 @@ impl RecentInfo {
     }
 
     pub fn get_age(&self) -> i32 {
-        unsafe { ffi::gtk_recent_info_get_age(GTK_RECENT_INFO(self.get_widget())) }
+        unsafe { ffi::gtk_recent_info_get_age(GTK_RECENT_INFO(self.unwrap_widget())) }
     }
 
     pub fn is_local(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_recent_info_is_local(GTK_RECENT_INFO(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_recent_info_is_local(GTK_RECENT_INFO(self.unwrap_widget()))) }
     }
 
     pub fn exists(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_recent_info_exists(GTK_RECENT_INFO(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_recent_info_exists(GTK_RECENT_INFO(self.unwrap_widget()))) }
     }
 
     pub fn _match(&self, other: &RecentInfo) -> bool {
-        unsafe { to_bool(ffi::gtk_recent_info_match(GTK_RECENT_INFO(self.get_widget()), GTK_RECENT_INFO(other.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_recent_info_match(GTK_RECENT_INFO(self.unwrap_widget()), GTK_RECENT_INFO(other.unwrap_widget()))) }
     }
 }
 

--- a/src/gtk/widgets/recent_manager.rs
+++ b/src/gtk/widgets/recent_manager.rs
@@ -29,7 +29,7 @@ impl RecentManager {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer as *mut ffi::C_GtkWidget))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer as *mut ffi::C_GtkWidget))
         }
     }
 
@@ -39,7 +39,7 @@ impl RecentManager {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer as *mut ffi::C_GtkWidget))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer as *mut ffi::C_GtkWidget))
         }
     }
 
@@ -47,7 +47,7 @@ impl RecentManager {
         let c_str = CString::from_slice(uri.as_bytes());
 
         unsafe {
-            to_bool(ffi::gtk_recent_manager_add_item(GTK_RECENT_MANAGER(self.get_widget()), c_str.as_ptr()))
+            to_bool(ffi::gtk_recent_manager_add_item(GTK_RECENT_MANAGER(self.unwrap_widget()), c_str.as_ptr()))
         }
     }
 
@@ -55,7 +55,7 @@ impl RecentManager {
         unsafe {
             let c_str = CString::from_slice(uri.as_bytes());
 
-            to_bool(ffi::gtk_recent_manager_add_full(GTK_RECENT_MANAGER(self.get_widget()), c_str.as_ptr(), &recent_data.get_ffi()))
+            to_bool(ffi::gtk_recent_manager_add_full(GTK_RECENT_MANAGER(self.unwrap_widget()), c_str.as_ptr(), &recent_data.get_ffi()))
         }
     }
 
@@ -63,12 +63,12 @@ impl RecentManager {
         let c_str = CString::from_slice(uri.as_bytes());
 
         unsafe {
-            to_bool(ffi::gtk_recent_manager_has_item(GTK_RECENT_MANAGER(self.get_widget()), c_str.as_ptr()))
+            to_bool(ffi::gtk_recent_manager_has_item(GTK_RECENT_MANAGER(self.unwrap_widget()), c_str.as_ptr()))
         }
     }
 
     pub fn get_items(&self) -> glib::List<Box<gtk::RecentInfo>> {
-        let tmp = unsafe { ffi::gtk_recent_manager_get_items(GTK_RECENT_MANAGER(self.get_widget())) };
+        let tmp = unsafe { ffi::gtk_recent_manager_get_items(GTK_RECENT_MANAGER(self.unwrap_widget())) };
 
         if tmp.is_null() {
             glib::List::new()
@@ -77,7 +77,7 @@ impl RecentManager {
             let mut tmp_vec : glib::List<Box<gtk::RecentInfo>> = glib::List::new();
 
             for it in old_list.iter() {
-                tmp_vec.append(Box::new(gtk::FFIWidget::wrap(*it as *mut ffi::C_GtkWidget)));
+                tmp_vec.append(Box::new(gtk::FFIWidget::wrap_widget(*it as *mut ffi::C_GtkWidget)));
             }
             tmp_vec
         }

--- a/src/gtk/widgets/scale.rs
+++ b/src/gtk/widgets/scale.rs
@@ -33,7 +33,7 @@ struct_Widget!(Scale);
 impl Scale {
     pub fn new(orientation: Orientation,
                adjustment: &gtk::Adjustment) -> Option<Scale> {
-        let tmp_pointer = unsafe { ffi::gtk_scale_new(orientation, adjustment.get_pointer()) };
+        let tmp_pointer = unsafe { ffi::gtk_scale_new(orientation, adjustment.unwrap_pointer()) };
         check_pointer!(tmp_pointer, Scale)
     }
 

--- a/src/gtk/widgets/scrollbar.rs
+++ b/src/gtk/widgets/scrollbar.rs
@@ -22,7 +22,7 @@ struct_Widget!(ScrollBar);
 
 impl ScrollBar {
     pub fn new(orientation: gtk::Orientation, adjustment: &gtk::Adjustment) -> Option<ScrollBar> {
-        let tmp_pointer = unsafe { ffi::gtk_scrollbar_new(orientation, adjustment.get_pointer()) };
+        let tmp_pointer = unsafe { ffi::gtk_scrollbar_new(orientation, adjustment.unwrap_pointer()) };
         check_pointer!(tmp_pointer, ScrollBar)
     }
 }

--- a/src/gtk/widgets/scrolled_window.rs
+++ b/src/gtk/widgets/scrolled_window.rs
@@ -25,8 +25,8 @@ impl ScrolledWindow {
 
         let tmp_pointer = unsafe {
             ffi::gtk_scrolled_window_new(
-                h_adjustment.map_or(ptr::null_mut(), |p| { p.get_pointer() }),
-                v_adjustment.map_or(ptr::null_mut(), |p| { p.get_pointer() })
+                h_adjustment.map_or(ptr::null_mut(), |p| { p.unwrap_pointer() }),
+                v_adjustment.map_or(ptr::null_mut(), |p| { p.unwrap_pointer() })
             )
         };
 

--- a/src/gtk/widgets/search_bar.rs
+++ b/src/gtk/widgets/search_bar.rs
@@ -31,7 +31,7 @@ impl SearchBar {
 
     pub fn connect_entry(&mut self, entry: &gtk::Entry) -> () {
         unsafe {
-            ffi::gtk_search_bar_connect_entry(GTK_SEARCHBAR(self.pointer), GTK_ENTRY(entry.get_widget()));
+            ffi::gtk_search_bar_connect_entry(GTK_SEARCHBAR(self.pointer), GTK_ENTRY(entry.unwrap_widget()));
         }
     }
 

--- a/src/gtk/widgets/size_group.rs
+++ b/src/gtk/widgets/size_group.rs
@@ -53,11 +53,11 @@ impl SizeGroup {
     }
 
     pub fn add_widget<T: gtk::WidgetTrait>(&self, widget: &T) {
-        unsafe { ffi::gtk_size_group_add_widget(self.pointer, widget.get_widget()) }
+        unsafe { ffi::gtk_size_group_add_widget(self.pointer, widget.unwrap_widget()) }
     }
 
     pub fn remove_widget<T: gtk::WidgetTrait>(&self, widget: &T) {
-        unsafe { ffi::gtk_size_group_remove_widget(self.pointer, widget.get_widget()) }
+        unsafe { ffi::gtk_size_group_remove_widget(self.pointer, widget.unwrap_widget()) }
     }
 }
 

--- a/src/gtk/widgets/socket.rs
+++ b/src/gtk/widgets/socket.rs
@@ -29,15 +29,15 @@ impl Socket {
     }
 
     /*pub fn add_id(&self, window: Window) {
-        unsafe { ffi::gtk_socket_add_id(GTK_SOCKET(self.get_widget()), window) };
+        unsafe { ffi::gtk_socket_add_id(GTK_SOCKET(self.unwrap_widget()), window) };
     }
 
     pub fn get_id(&self) -> Window {
-        unsafe { ffi::gtk_socket_get_id(GTK_SOCKET(self.get_widget())) };
+        unsafe { ffi::gtk_socket_get_id(GTK_SOCKET(self.unwrap_widget())) };
     }
 
     pub fn get_plug_window(&self) -> GdkWindow {
-        let tmp_pointer = unsafe { ffi::gtk_socket_get_plug_window(GTK_SOCKET(self.get_widget())) };
+        let tmp_pointer = unsafe { ffi::gtk_socket_get_plug_window(GTK_SOCKET(self.unwrap_widget())) };
 
         // add end of code
     }*/

--- a/src/gtk/widgets/spin_button.rs
+++ b/src/gtk/widgets/spin_button.rs
@@ -38,7 +38,7 @@ impl SpinButton {
     pub fn new(adjustment: &gtk::Adjustment,
                climb_rate: f64,
                digits: u32) -> Option<SpinButton> {
-        let tmp_pointer = unsafe { ffi::gtk_spin_button_new(adjustment.get_pointer(), climb_rate as c_double, digits as c_uint) };
+        let tmp_pointer = unsafe { ffi::gtk_spin_button_new(adjustment.unwrap_pointer(), climb_rate as c_double, digits as c_uint) };
         check_pointer!(tmp_pointer, SpinButton)
     }
 
@@ -49,13 +49,13 @@ impl SpinButton {
 
     pub fn configure(&mut self, adjustment: &gtk::Adjustment, climb_rate: f64, digits: u32) -> () {
         unsafe {
-            ffi::gtk_spin_button_configure(GTK_SPINBUTTON(self.pointer), adjustment.get_pointer(), climb_rate as c_double, digits as c_uint);
+            ffi::gtk_spin_button_configure(GTK_SPINBUTTON(self.pointer), adjustment.unwrap_pointer(), climb_rate as c_double, digits as c_uint);
         }
     }
 
     pub fn set_adjustment(&mut self, adjustment: &gtk::Adjustment) -> () {
         unsafe {
-            ffi:: gtk_spin_button_set_adjustment(GTK_SPINBUTTON(self.pointer), adjustment.get_pointer());
+            ffi:: gtk_spin_button_set_adjustment(GTK_SPINBUTTON(self.pointer), adjustment.unwrap_pointer());
         }
     }
 

--- a/src/gtk/widgets/stack.rs
+++ b/src/gtk/widgets/stack.rs
@@ -36,7 +36,7 @@ impl Stack {
 
         unsafe {
             ffi::gtk_stack_add_named(GTK_STACK(self.pointer),
-                                     child.get_widget(),
+                                     child.unwrap_widget(),
                                      c_str.as_ptr())
         }
     }
@@ -47,7 +47,7 @@ impl Stack {
 
         unsafe {
             ffi::gtk_stack_add_titled(GTK_STACK(self.pointer),
-                                      child.get_widget(),
+                                      child.unwrap_widget(),
                                       c_name.as_ptr(),
                                       c_title.as_ptr())
         }
@@ -56,7 +56,7 @@ impl Stack {
     pub fn set_visible_child<T: gtk::WidgetTrait>(&mut self, child: &T) {
         unsafe {
             ffi::gtk_stack_set_visible_child(GTK_STACK(self.pointer),
-                                             child.get_widget())
+                                             child.unwrap_widget())
         }
     }
 
@@ -65,7 +65,7 @@ impl Stack {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 

--- a/src/gtk/widgets/stack_switcher.rs
+++ b/src/gtk/widgets/stack_switcher.rs
@@ -31,7 +31,7 @@ impl StackSwitcher {
     pub fn set_stack(&mut self, stack: gtk::Stack) {
         unsafe {
             ffi::gtk_stack_switcher_set_stack(GTK_STACK_SWITCHER(self.pointer),
-                                              GTK_STACK(stack.get_widget()))
+                                              GTK_STACK(stack.unwrap_widget()))
         }
     }
 
@@ -40,7 +40,7 @@ impl StackSwitcher {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 }

--- a/src/gtk/widgets/status_bar.rs
+++ b/src/gtk/widgets/status_bar.rs
@@ -59,7 +59,7 @@ impl StatusBar {
 
     pub fn get_message_area<T: gtk::WidgetTrait + gtk::BoxTrait>(&self) -> T {
         unsafe {
-            gtk::FFIWidget::wrap(ffi::gtk_statusbar_get_message_area(GTK_STATUSBAR(self.pointer)))
+            gtk::FFIWidget::wrap_widget(ffi::gtk_statusbar_get_message_area(GTK_STATUSBAR(self.pointer)))
         }
     }
 }

--- a/src/gtk/widgets/text_buffer.rs
+++ b/src/gtk/widgets/text_buffer.rs
@@ -26,7 +26,7 @@ impl TextBuffer {
     pub fn new(text_tag_table: Option<gtk::TextTagTable>) -> Option<TextBuffer> {
         let tmp_pointer = unsafe {
             match text_tag_table {
-                Some(ttl) => ffi::gtk_text_buffer_new(ttl.get_pointer()),
+                Some(ttl) => ffi::gtk_text_buffer_new(ttl.unwrap_pointer()),
                 None      => ffi::gtk_text_buffer_new(ptr::null_mut())
             }
         };

--- a/src/gtk/widgets/text_iter.rs
+++ b/src/gtk/widgets/text_iter.rs
@@ -38,7 +38,7 @@ impl TextIter {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer as *mut ffi::C_GtkWidget))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer as *mut ffi::C_GtkWidget))
         }
     }
 
@@ -141,19 +141,19 @@ impl TextIter {
     }
 
     pub fn begins_tag(&self, tag: &gtk::TextTag) -> bool {
-        unsafe { to_bool(ffi::gtk_text_iter_begins_tag(self.pointer as *const ffi::C_GtkTextIter, tag.get_pointer())) }
+        unsafe { to_bool(ffi::gtk_text_iter_begins_tag(self.pointer as *const ffi::C_GtkTextIter, tag.unwrap_pointer())) }
     }
 
     pub fn ends_tag(&self, tag: &gtk::TextTag) -> bool {
-        unsafe { to_bool(ffi::gtk_text_iter_ends_tag(self.pointer as *const ffi::C_GtkTextIter, tag.get_pointer())) }
+        unsafe { to_bool(ffi::gtk_text_iter_ends_tag(self.pointer as *const ffi::C_GtkTextIter, tag.unwrap_pointer())) }
     }
 
     pub fn toggles_tag(&self, tag: &gtk::TextTag) -> bool {
-        unsafe { to_bool(ffi::gtk_text_iter_ends_tag(self.pointer as *const ffi::C_GtkTextIter, tag.get_pointer())) }
+        unsafe { to_bool(ffi::gtk_text_iter_ends_tag(self.pointer as *const ffi::C_GtkTextIter, tag.unwrap_pointer())) }
     }
 
     pub fn has_tag(&self, tag: &gtk::TextTag) -> bool {
-        unsafe { to_bool(ffi::gtk_text_iter_ends_tag(self.pointer as *const ffi::C_GtkTextIter, tag.get_pointer())) }
+        unsafe { to_bool(ffi::gtk_text_iter_ends_tag(self.pointer as *const ffi::C_GtkTextIter, tag.unwrap_pointer())) }
     }
 
     pub fn editable(&self, default_setting: bool) -> bool {
@@ -209,7 +209,7 @@ impl TextIter {
     }
 
     pub fn get_attributes(&self, values: &gtk::TextAttributes) -> bool {
-        unsafe { to_bool(ffi::gtk_text_iter_get_attributes(self.pointer as *const ffi::C_GtkTextIter, values.get_pointer())) }
+        unsafe { to_bool(ffi::gtk_text_iter_get_attributes(self.pointer as *const ffi::C_GtkTextIter, values.unwrap_pointer())) }
     }
 
     pub fn is_end(&self) -> bool {
@@ -381,11 +381,11 @@ impl TextIter {
     }
 
     pub fn forward_to_tag_toggle(&self, tag: &gtk::TextTag) -> bool {
-        unsafe { to_bool(ffi::gtk_text_iter_forward_to_tag_toggle(self.pointer, tag.get_pointer())) }
+        unsafe { to_bool(ffi::gtk_text_iter_forward_to_tag_toggle(self.pointer, tag.unwrap_pointer())) }
     }
 
     pub fn backward_to_tag_toggle(&self, tag: &gtk::TextTag) -> bool {
-        unsafe { to_bool(ffi::gtk_text_iter_backward_to_tag_toggle(self.pointer, tag.get_pointer())) }
+        unsafe { to_bool(ffi::gtk_text_iter_backward_to_tag_toggle(self.pointer, tag.unwrap_pointer())) }
     }
 
     pub fn is_equal_to(&self, other: &TextIter) -> bool {

--- a/src/gtk/widgets/text_mark.rs
+++ b/src/gtk/widgets/text_mark.rs
@@ -68,7 +68,7 @@ impl TextMark {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer as *mut ffi::C_GtkWidget))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer as *mut ffi::C_GtkWidget))
         }
     }
 

--- a/src/gtk/widgets/text_tag_table.rs
+++ b/src/gtk/widgets/text_tag_table.rs
@@ -31,7 +31,7 @@ impl TextTagTable {
         }
     }
 
-    pub fn get_pointer(&self) -> *mut ffi::C_GtkTextTagTable {
+    pub fn unwrap_pointer(&self) -> *mut ffi::C_GtkTextTagTable {
         self.pointer
     }
 }

--- a/src/gtk/widgets/text_view.rs
+++ b/src/gtk/widgets/text_view.rs
@@ -31,216 +31,216 @@ impl TextView {
 
     pub fn new_with_buffer(buffer: gtk::TextBuffer) -> Option<TextView> {
         let tmp_pointer = unsafe {
-            ffi::gtk_text_view_new_with_buffer(GTK_TEXT_BUFFER(buffer.get_widget()))
+            ffi::gtk_text_view_new_with_buffer(GTK_TEXT_BUFFER(buffer.unwrap_widget()))
         };
         check_pointer!(tmp_pointer, TextView)
     }
 
     pub fn set_buffer(&mut self, buffer: gtk::TextBuffer) -> () {
         unsafe {
-            ffi::gtk_text_view_set_buffer(GTK_TEXT_VIEW(self.get_widget()), GTK_TEXT_BUFFER(buffer.get_widget()));
+            ffi::gtk_text_view_set_buffer(GTK_TEXT_VIEW(self.unwrap_widget()), GTK_TEXT_BUFFER(buffer.unwrap_widget()));
         }
     }
 
     pub fn get_buffer(&self) -> Option<gtk::TextBuffer> {
         let tmp_pointer = unsafe {
-            ffi::gtk_text_view_get_buffer(GTK_TEXT_VIEW(self.get_widget()))
+            ffi::gtk_text_view_get_buffer(GTK_TEXT_VIEW(self.unwrap_widget()))
         };
 
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer as *mut ffi::C_GtkWidget))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer as *mut ffi::C_GtkWidget))
         }
     }
 
     pub fn scroll_to_mark(&self, mark: &gtk::TextMark, within_margin: f64, use_align: bool, xalign: f64, yalign: f64) {
-        unsafe { ffi::gtk_text_view_scroll_to_mark(GTK_TEXT_VIEW(self.get_widget()), mark.get_pointer(), within_margin,
+        unsafe { ffi::gtk_text_view_scroll_to_mark(GTK_TEXT_VIEW(self.unwrap_widget()), mark.unwrap_pointer(), within_margin,
             to_gboolean(use_align), xalign, yalign) }
     }
 
     pub fn scroll_to_iter(&self, iter: &gtk::TextIter, within_margin: f64, use_align: bool, xalign: f64, yalign: f64) -> bool {
-        unsafe { to_bool(ffi::gtk_text_view_scroll_to_iter(GTK_TEXT_VIEW(self.get_widget()), iter.get_pointer(), within_margin,
+        unsafe { to_bool(ffi::gtk_text_view_scroll_to_iter(GTK_TEXT_VIEW(self.unwrap_widget()), iter.unwrap_pointer(), within_margin,
             to_gboolean(use_align), xalign, yalign)) }
     }
 
     pub fn scroll_mark_onscreen(&self, mark: &gtk::TextMark) {
-        unsafe { ffi::gtk_text_view_scroll_mark_onscreen(GTK_TEXT_VIEW(self.get_widget()), mark.get_pointer()) }
+        unsafe { ffi::gtk_text_view_scroll_mark_onscreen(GTK_TEXT_VIEW(self.unwrap_widget()), mark.unwrap_pointer()) }
     }
 
     pub fn move_mark_onscreen(&self, mark: &gtk::TextMark) -> bool {
-        unsafe { to_bool(ffi::gtk_text_view_move_mark_onscreen(GTK_TEXT_VIEW(self.get_widget()), mark.get_pointer())) }
+        unsafe { to_bool(ffi::gtk_text_view_move_mark_onscreen(GTK_TEXT_VIEW(self.unwrap_widget()), mark.unwrap_pointer())) }
     }
 
     pub fn place_cursor_onscreen(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_text_view_place_cursor_onscreen(GTK_TEXT_VIEW(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_text_view_place_cursor_onscreen(GTK_TEXT_VIEW(self.unwrap_widget()))) }
     }
 
     pub fn get_line_at_y(&self, target_iter: &gtk::TextIter, y: i32, line_top: &mut i32) {
-        unsafe { ffi::gtk_text_view_get_line_at_y(GTK_TEXT_VIEW(self.get_widget()), target_iter.get_pointer(), y as ::libc::c_int,
+        unsafe { ffi::gtk_text_view_get_line_at_y(GTK_TEXT_VIEW(self.unwrap_widget()), target_iter.unwrap_pointer(), y as ::libc::c_int,
             line_top) }
     }
 
     pub fn get_iter_at_location(&self, target_iter: &gtk::TextIter, x: i32, y: i32) {
-        unsafe { ffi::gtk_text_view_get_iter_at_location(GTK_TEXT_VIEW(self.get_widget()), target_iter.get_pointer(), x, y) }
+        unsafe { ffi::gtk_text_view_get_iter_at_location(GTK_TEXT_VIEW(self.unwrap_widget()), target_iter.unwrap_pointer(), x, y) }
     }
 
     pub fn buffer_to_window_coords(&self, win: gtk::TextWindowType, buffer_x: i32, buffer_y: i32, window_x: *mut i32, window_y: &mut i32) {
-        unsafe { ffi::gtk_text_view_buffer_to_window_coords(GTK_TEXT_VIEW(self.get_widget()), win, buffer_x as ::libc::c_int,
+        unsafe { ffi::gtk_text_view_buffer_to_window_coords(GTK_TEXT_VIEW(self.unwrap_widget()), win, buffer_x as ::libc::c_int,
             buffer_y as ::libc::c_int, window_x, window_y) }
     }
 
     pub fn window_to_buffer_coords(&self, win: gtk::TextWindowType, window_x: i32, window_y: i32, buffer_x: *mut i32, buffer_y: &mut i32) {
-        unsafe { ffi::gtk_text_view_window_to_buffer_coords(GTK_TEXT_VIEW(self.get_widget()), win, window_x as ::libc::c_int,
+        unsafe { ffi::gtk_text_view_window_to_buffer_coords(GTK_TEXT_VIEW(self.unwrap_widget()), win, window_x as ::libc::c_int,
             window_y as ::libc::c_int, buffer_x, buffer_y) }
     }
 
     pub fn set_border_window_size(&self, _type: gtk::TextWindowType, size: i32) {
-        unsafe { ffi::gtk_text_view_set_border_window_size(GTK_TEXT_VIEW(self.get_widget()), _type, size as ::libc::c_int) }
+        unsafe { ffi::gtk_text_view_set_border_window_size(GTK_TEXT_VIEW(self.unwrap_widget()), _type, size as ::libc::c_int) }
     }
 
     pub fn get_border_window_size(&self, _type: gtk::TextWindowType) -> i32 {
-        unsafe { ffi::gtk_text_view_get_border_window_size(GTK_TEXT_VIEW(self.get_widget()), _type) }
+        unsafe { ffi::gtk_text_view_get_border_window_size(GTK_TEXT_VIEW(self.unwrap_widget()), _type) }
     }
 
     pub fn forward_display_line(&self, iter: &gtk::TextIter) -> bool {
-        unsafe { to_bool(ffi::gtk_text_view_forward_display_line(GTK_TEXT_VIEW(self.get_widget()), iter.get_pointer())) }
+        unsafe { to_bool(ffi::gtk_text_view_forward_display_line(GTK_TEXT_VIEW(self.unwrap_widget()), iter.unwrap_pointer())) }
     }
 
     pub fn backward_display_line(&self, iter: &gtk::TextIter) -> bool {
-        unsafe { to_bool(ffi::gtk_text_view_forward_display_line(GTK_TEXT_VIEW(self.get_widget()), iter.get_pointer())) }
+        unsafe { to_bool(ffi::gtk_text_view_forward_display_line(GTK_TEXT_VIEW(self.unwrap_widget()), iter.unwrap_pointer())) }
     }
 
     pub fn forward_display_line_end(&self, iter: &gtk::TextIter) -> bool {
-        unsafe { to_bool(ffi::gtk_text_view_forward_display_line_end(GTK_TEXT_VIEW(self.get_widget()), iter.get_pointer())) }
+        unsafe { to_bool(ffi::gtk_text_view_forward_display_line_end(GTK_TEXT_VIEW(self.unwrap_widget()), iter.unwrap_pointer())) }
     }
 
     pub fn backward_display_line_start(&self, iter: &gtk::TextIter) -> bool {
-        unsafe { to_bool(ffi::gtk_text_view_backward_display_line_start(GTK_TEXT_VIEW(self.get_widget()), iter.get_pointer())) }
+        unsafe { to_bool(ffi::gtk_text_view_backward_display_line_start(GTK_TEXT_VIEW(self.unwrap_widget()), iter.unwrap_pointer())) }
     }
 
     pub fn starts_display_line(&self, iter: &gtk::TextIter) -> bool {
-        unsafe { to_bool(ffi::gtk_text_view_starts_display_line(GTK_TEXT_VIEW(self.get_widget()),
-            iter.get_pointer())) }
+        unsafe { to_bool(ffi::gtk_text_view_starts_display_line(GTK_TEXT_VIEW(self.unwrap_widget()),
+            iter.unwrap_pointer())) }
     }
 
     pub fn move_visually(&self, iter: &gtk::TextIter, count: i32) -> bool {
-        unsafe { to_bool(ffi::gtk_text_view_move_visually(GTK_TEXT_VIEW(self.get_widget()), iter.get_pointer(),
+        unsafe { to_bool(ffi::gtk_text_view_move_visually(GTK_TEXT_VIEW(self.unwrap_widget()), iter.unwrap_pointer(),
             count as ::libc::c_int)) }
     }
 
     pub fn add_child_at_anchor<T: gtk::WidgetTrait>(&self, child: &T, anchor: &gtk::TextChildAnchor) {
-        unsafe { ffi::gtk_text_view_add_child_at_anchor(GTK_TEXT_VIEW(self.get_widget()), child.get_widget(), anchor.get_pointer()) }
+        unsafe { ffi::gtk_text_view_add_child_at_anchor(GTK_TEXT_VIEW(self.unwrap_widget()), child.unwrap_widget(), anchor.unwrap_pointer()) }
     }
 
     pub fn add_child_in_window<T: gtk::WidgetTrait>(&self, child: &T, which_window: gtk::TextWindowType, xpos: i32, ypos: i32) {
-        unsafe { ffi::gtk_text_view_add_child_in_window(GTK_TEXT_VIEW(self.get_widget()), child.get_widget(), which_window,
+        unsafe { ffi::gtk_text_view_add_child_in_window(GTK_TEXT_VIEW(self.unwrap_widget()), child.unwrap_widget(), which_window,
             xpos as ::libc::c_int, ypos as ::libc::c_int) }
     }
 
     pub fn move_child<T: gtk::WidgetTrait>(&self, child: &T, xpos: i32, ypos: i32) {
-        unsafe { ffi::gtk_text_view_move_child(GTK_TEXT_VIEW(self.get_widget()), child.get_widget(), xpos as ::libc::c_int,
+        unsafe { ffi::gtk_text_view_move_child(GTK_TEXT_VIEW(self.unwrap_widget()), child.unwrap_widget(), xpos as ::libc::c_int,
             ypos as ::libc::c_int) }
     }
 
     pub fn set_wrap_mode(&self, wrap_mode: gtk::WrapMode) {
-        unsafe { ffi::gtk_text_view_set_wrap_mode(GTK_TEXT_VIEW(self.get_widget()), wrap_mode) }
+        unsafe { ffi::gtk_text_view_set_wrap_mode(GTK_TEXT_VIEW(self.unwrap_widget()), wrap_mode) }
     }
 
     pub fn get_wrap_mode(&self) -> gtk::WrapMode {
-        unsafe { ffi::gtk_text_view_get_wrap_mode(GTK_TEXT_VIEW(self.get_widget())) }
+        unsafe { ffi::gtk_text_view_get_wrap_mode(GTK_TEXT_VIEW(self.unwrap_widget())) }
     }
 
     pub fn set_editable(&self, setting: bool) {
-        unsafe { ffi::gtk_text_view_set_editable(GTK_TEXT_VIEW(self.get_widget()), to_gboolean(setting)) }
+        unsafe { ffi::gtk_text_view_set_editable(GTK_TEXT_VIEW(self.unwrap_widget()), to_gboolean(setting)) }
     }
 
     pub fn get_editable(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_text_view_get_editable(GTK_TEXT_VIEW(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_text_view_get_editable(GTK_TEXT_VIEW(self.unwrap_widget()))) }
     }
 
     pub fn set_cursor_visible(&self, setting: bool) {
-        unsafe { ffi::gtk_text_view_set_cursor_visible(GTK_TEXT_VIEW(self.get_widget()), to_gboolean(setting)) }
+        unsafe { ffi::gtk_text_view_set_cursor_visible(GTK_TEXT_VIEW(self.unwrap_widget()), to_gboolean(setting)) }
     }
 
     pub fn get_cursor_visible(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_text_view_get_cursor_visible(GTK_TEXT_VIEW(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_text_view_get_cursor_visible(GTK_TEXT_VIEW(self.unwrap_widget()))) }
     }
 
     pub fn set_overwrite(&self, overwrite: bool) {
-        unsafe { ffi::gtk_text_view_set_overwrite(GTK_TEXT_VIEW(self.get_widget()), to_gboolean(overwrite)) }
+        unsafe { ffi::gtk_text_view_set_overwrite(GTK_TEXT_VIEW(self.unwrap_widget()), to_gboolean(overwrite)) }
     }
 
     pub fn get_overwrite(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_text_view_get_overwrite(GTK_TEXT_VIEW(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_text_view_get_overwrite(GTK_TEXT_VIEW(self.unwrap_widget()))) }
     }
 
     pub fn set_pixels_above_lines(&self, pixels_above_lines: i32) {
-        unsafe { ffi::gtk_text_view_set_pixels_above_lines(GTK_TEXT_VIEW(self.get_widget()), pixels_above_lines as ::libc::c_int) }
+        unsafe { ffi::gtk_text_view_set_pixels_above_lines(GTK_TEXT_VIEW(self.unwrap_widget()), pixels_above_lines as ::libc::c_int) }
     }
 
     pub fn get_pixels_above_lines(&self) -> i32 {
-        unsafe { ffi::gtk_text_view_get_pixels_above_lines(GTK_TEXT_VIEW(self.get_widget())) }
+        unsafe { ffi::gtk_text_view_get_pixels_above_lines(GTK_TEXT_VIEW(self.unwrap_widget())) }
     }
 
     pub fn set_pixels_below_lines(&self, pixels_below_lines: i32) {
-        unsafe { ffi::gtk_text_view_set_pixels_below_lines(GTK_TEXT_VIEW(self.get_widget()), pixels_below_lines as ::libc::c_int) }
+        unsafe { ffi::gtk_text_view_set_pixels_below_lines(GTK_TEXT_VIEW(self.unwrap_widget()), pixels_below_lines as ::libc::c_int) }
     }
 
     pub fn get_pixels_below_lines(&self) -> i32 {
-        unsafe { ffi::gtk_text_view_get_pixels_below_lines(GTK_TEXT_VIEW(self.get_widget())) }
+        unsafe { ffi::gtk_text_view_get_pixels_below_lines(GTK_TEXT_VIEW(self.unwrap_widget())) }
     }
 
     pub fn set_pixels_inside_wrap(&self, pixels_inside_wrap: i32) {
-        unsafe { ffi::gtk_text_view_set_pixels_inside_wrap(GTK_TEXT_VIEW(self.get_widget()), pixels_inside_wrap as ::libc::c_int) }
+        unsafe { ffi::gtk_text_view_set_pixels_inside_wrap(GTK_TEXT_VIEW(self.unwrap_widget()), pixels_inside_wrap as ::libc::c_int) }
     }
 
     pub fn get_pixels_inside_wrap(&self) -> i32 {
-        unsafe { ffi::gtk_text_view_get_pixels_inside_wrap(GTK_TEXT_VIEW(self.get_widget())) }
+        unsafe { ffi::gtk_text_view_get_pixels_inside_wrap(GTK_TEXT_VIEW(self.unwrap_widget())) }
     }
 
     pub fn set_justification(&self, justification: gtk::Justification) {
-        unsafe { ffi::gtk_text_view_set_justification(GTK_TEXT_VIEW(self.get_widget()), justification) }
+        unsafe { ffi::gtk_text_view_set_justification(GTK_TEXT_VIEW(self.unwrap_widget()), justification) }
     }
 
     pub fn get_justification(&self) -> gtk::Justification {
-        unsafe { ffi::gtk_text_view_get_justification(GTK_TEXT_VIEW(self.get_widget())) }
+        unsafe { ffi::gtk_text_view_get_justification(GTK_TEXT_VIEW(self.unwrap_widget())) }
     }
 
     pub fn set_left_margin(&self, left_margin: i32) {
-        unsafe { ffi::gtk_text_view_set_left_margin(GTK_TEXT_VIEW(self.get_widget()), left_margin as ::libc::c_int) }
+        unsafe { ffi::gtk_text_view_set_left_margin(GTK_TEXT_VIEW(self.unwrap_widget()), left_margin as ::libc::c_int) }
     }
 
     pub fn get_left_margin(&self) -> i32 {
-        unsafe { ffi::gtk_text_view_get_left_margin(GTK_TEXT_VIEW(self.get_widget())) }
+        unsafe { ffi::gtk_text_view_get_left_margin(GTK_TEXT_VIEW(self.unwrap_widget())) }
     }
 
     pub fn set_right_margin(&self, right_margin: i32) {
-        unsafe { ffi::gtk_text_view_set_right_margin(GTK_TEXT_VIEW(self.get_widget()), right_margin as ::libc::c_int) }
+        unsafe { ffi::gtk_text_view_set_right_margin(GTK_TEXT_VIEW(self.unwrap_widget()), right_margin as ::libc::c_int) }
     }
 
     pub fn get_right_margin(&self) -> i32 {
-        unsafe { ffi::gtk_text_view_get_right_margin(GTK_TEXT_VIEW(self.get_widget())) }
+        unsafe { ffi::gtk_text_view_get_right_margin(GTK_TEXT_VIEW(self.unwrap_widget())) }
     }
 
     pub fn set_indent(&self, indent: i32) {
-        unsafe { ffi::gtk_text_view_set_indent(GTK_TEXT_VIEW(self.get_widget()), indent as ::libc::c_int) }
+        unsafe { ffi::gtk_text_view_set_indent(GTK_TEXT_VIEW(self.unwrap_widget()), indent as ::libc::c_int) }
     }
 
     pub fn get_indent(&self) -> i32 {
-        unsafe { ffi::gtk_text_view_get_indent(GTK_TEXT_VIEW(self.get_widget())) }
+        unsafe { ffi::gtk_text_view_get_indent(GTK_TEXT_VIEW(self.unwrap_widget())) }
     }
 
     pub fn set_accepts_tab(&self, accepts_tab: bool) {
-        unsafe { ffi::gtk_text_view_set_accepts_tab(GTK_TEXT_VIEW(self.get_widget()), to_gboolean(accepts_tab)) }
+        unsafe { ffi::gtk_text_view_set_accepts_tab(GTK_TEXT_VIEW(self.unwrap_widget()), to_gboolean(accepts_tab)) }
     }
 
     pub fn get_accepts_tab(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_text_view_get_accepts_tab(GTK_TEXT_VIEW(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_text_view_get_accepts_tab(GTK_TEXT_VIEW(self.unwrap_widget()))) }
     }
 
     pub fn get_default_attributes(&self) -> Option<gtk::TextAttributes> {
-        let tmp_pointer = unsafe { ffi::gtk_text_view_get_default_attributes(GTK_TEXT_VIEW(self.get_widget())) };
+        let tmp_pointer = unsafe { ffi::gtk_text_view_get_default_attributes(GTK_TEXT_VIEW(self.unwrap_widget())) };
 
         if tmp_pointer.is_null() {
             None
@@ -250,23 +250,23 @@ impl TextView {
     }
 
     pub fn reset_im_context(&self) {
-        unsafe { ffi::gtk_text_view_reset_im_context(GTK_TEXT_VIEW(self.get_widget())) }
+        unsafe { ffi::gtk_text_view_reset_im_context(GTK_TEXT_VIEW(self.unwrap_widget())) }
     }
 
     pub fn set_input_purpose(&self, purpose: gtk::InputPurpose) {
-        unsafe { ffi::gtk_text_view_set_input_purpose(GTK_TEXT_VIEW(self.get_widget()), purpose) }
+        unsafe { ffi::gtk_text_view_set_input_purpose(GTK_TEXT_VIEW(self.unwrap_widget()), purpose) }
     }
 
     pub fn get_input_purpose(&self) -> gtk::InputPurpose {
-        unsafe { ffi::gtk_text_view_get_input_purpose(GTK_TEXT_VIEW(self.get_widget())) }
+        unsafe { ffi::gtk_text_view_get_input_purpose(GTK_TEXT_VIEW(self.unwrap_widget())) }
     }
 
     pub fn set_input_hints(&self, hints: gtk::InputHints) {
-        unsafe { ffi::gtk_text_view_set_input_hints(GTK_TEXT_VIEW(self.get_widget()), hints) }
+        unsafe { ffi::gtk_text_view_set_input_hints(GTK_TEXT_VIEW(self.unwrap_widget()), hints) }
     }
 
     pub fn get_input_hints(&self) -> gtk::InputHints {
-        unsafe { ffi::gtk_text_view_get_input_hints(GTK_TEXT_VIEW(self.get_widget())) }
+        unsafe { ffi::gtk_text_view_get_input_hints(GTK_TEXT_VIEW(self.unwrap_widget())) }
     }
 }
 

--- a/src/gtk/widgets/tool_bar.rs
+++ b/src/gtk/widgets/tool_bar.rs
@@ -42,13 +42,13 @@ impl Toolbar {
                                   item: &T,
                                   pos: i32) -> () {
         unsafe {
-            ffi::gtk_toolbar_insert(GTK_TOOLBAR(self.pointer), GTK_TOOLITEM(item.get_widget()), pos as c_int)
+            ffi::gtk_toolbar_insert(GTK_TOOLBAR(self.pointer), GTK_TOOLITEM(item.unwrap_widget()), pos as c_int)
         }
     }
 
     pub fn item_index<T: gtk::ToolItemTrait>(&mut self, item: &T) -> i32 {
         unsafe {
-            ffi::gtk_toolbar_get_item_index(GTK_TOOLBAR(self.pointer), GTK_TOOLITEM(item.get_widget())) as i32
+            ffi::gtk_toolbar_get_item_index(GTK_TOOLBAR(self.pointer), GTK_TOOLITEM(item.unwrap_widget())) as i32
         }
     }
 
@@ -64,7 +64,7 @@ impl Toolbar {
             if tmp_pointer.is_null() {
                 None
             } else {
-                Some(gtk::FFIWidget::wrap(tmp_pointer))
+                Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
             }
         }
     }
@@ -77,7 +77,7 @@ impl Toolbar {
 
     pub fn set_drop_highlight_item<T: gtk::ToolItemTrait>(&mut self, item: &T, index: i32) -> () {
         unsafe {
-            ffi::gtk_toolbar_set_drop_highlight_item(GTK_TOOLBAR(self.pointer), GTK_TOOLITEM(item.get_widget()), index as c_int);
+            ffi::gtk_toolbar_set_drop_highlight_item(GTK_TOOLBAR(self.pointer), GTK_TOOLITEM(item.unwrap_widget()), index as c_int);
         }
     }
 

--- a/src/gtk/widgets/tool_button.rs
+++ b/src/gtk/widgets/tool_button.rs
@@ -31,13 +31,13 @@ impl ToolButton {
                     let c_str = CString::from_slice(l.as_bytes());
 
                     match icon_widget {
-                        Some(i) => ffi::gtk_tool_button_new(i.get_widget(), c_str.as_ptr()),
+                        Some(i) => ffi::gtk_tool_button_new(i.unwrap_widget(), c_str.as_ptr()),
                         None    => ffi::gtk_tool_button_new(ptr::null_mut(), c_str.as_ptr())
                     }
                 }
                 None => {
                     match icon_widget {
-                        Some(i) => ffi::gtk_tool_button_new(i.get_widget(), ptr::null()),
+                        Some(i) => ffi::gtk_tool_button_new(i.unwrap_widget(), ptr::null()),
                         None    => ffi::gtk_tool_button_new(ptr::null_mut(), ptr::null())
                     }
                 }

--- a/src/gtk/widgets/tool_item_group.rs
+++ b/src/gtk/widgets/tool_item_group.rs
@@ -34,39 +34,39 @@ impl ToolItemGroup {
     }
 
     pub fn get_collapsed(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_tool_item_group_get_collapsed(GTK_TOOL_ITEM_GROUP(self.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_tool_item_group_get_collapsed(GTK_TOOL_ITEM_GROUP(self.unwrap_widget()))) }
     }
 
     pub fn set_collapsed(&self, collapsed: bool) {
-        unsafe { ffi::gtk_tool_item_group_set_collapsed(GTK_TOOL_ITEM_GROUP(self.get_widget()), to_gboolean(collapsed)) }
+        unsafe { ffi::gtk_tool_item_group_set_collapsed(GTK_TOOL_ITEM_GROUP(self.unwrap_widget()), to_gboolean(collapsed)) }
     }
 
     pub fn get_drop_item(&self, x: i32, y: i32) -> Option<ToolItem> {
-        let tmp_pointer = unsafe { ffi::gtk_tool_item_group_get_drop_item(GTK_TOOL_ITEM_GROUP(self.get_widget()),
+        let tmp_pointer = unsafe { ffi::gtk_tool_item_group_get_drop_item(GTK_TOOL_ITEM_GROUP(self.unwrap_widget()),
             x as ::libc::c_int, y as ::libc::c_int) } as *mut ffi::C_GtkWidget;
 
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(FFIWidget::wrap(tmp_pointer))
+            Some(FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 
     pub fn get_item_position(&self, item: &ToolItem) -> i32 {
-        unsafe { ffi::gtk_tool_item_group_get_item_position(GTK_TOOL_ITEM_GROUP(self.get_widget()), GTK_TOOL_ITEM(item.get_widget())) }
+        unsafe { ffi::gtk_tool_item_group_get_item_position(GTK_TOOL_ITEM_GROUP(self.unwrap_widget()), GTK_TOOL_ITEM(item.unwrap_widget())) }
     }
 
     pub fn set_item_position(&self, item: &ToolItem, position: i32) {
-        unsafe { ffi::gtk_tool_item_group_set_item_position(GTK_TOOL_ITEM_GROUP(self.get_widget()), GTK_TOOL_ITEM(item.get_widget()),
+        unsafe { ffi::gtk_tool_item_group_set_item_position(GTK_TOOL_ITEM_GROUP(self.unwrap_widget()), GTK_TOOL_ITEM(item.unwrap_widget()),
             position as ::libc::c_int) }
     }
 
     pub fn get_n_items(&self) -> u32 {
-        unsafe { ffi::gtk_tool_item_group_get_n_items(GTK_TOOL_ITEM_GROUP(self.get_widget())) }
+        unsafe { ffi::gtk_tool_item_group_get_n_items(GTK_TOOL_ITEM_GROUP(self.unwrap_widget())) }
     }
 
     pub fn get_label(&self) -> Option<String> {
-        let tmp_pointer = unsafe { ffi::gtk_tool_item_group_get_label(GTK_TOOL_ITEM_GROUP(self.get_widget())) };
+        let tmp_pointer = unsafe { ffi::gtk_tool_item_group_get_label(GTK_TOOL_ITEM_GROUP(self.unwrap_widget())) };
 
         if tmp_pointer.is_null() {
             None
@@ -79,45 +79,45 @@ impl ToolItemGroup {
         unsafe {
             let c_str = CString::from_slice(label.as_bytes());
 
-            ffi::gtk_tool_item_group_set_label(GTK_TOOL_ITEM_GROUP(self.get_widget()), c_str.as_ptr())
+            ffi::gtk_tool_item_group_set_label(GTK_TOOL_ITEM_GROUP(self.unwrap_widget()), c_str.as_ptr())
         }
     }
 
     pub fn get_label_widget<T: gtk::WidgetTrait>(&self) -> Option<T> {
-        let tmp_pointer = unsafe { ffi::gtk_tool_item_group_get_label_widget(GTK_TOOL_ITEM_GROUP(self.get_widget())) };
+        let tmp_pointer = unsafe { ffi::gtk_tool_item_group_get_label_widget(GTK_TOOL_ITEM_GROUP(self.unwrap_widget())) };
 
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 
     pub fn get_nth_item(&self, index: u32) -> Option<ToolItem> {
-        let tmp_pointer = unsafe { ffi::gtk_tool_item_group_get_nth_item(GTK_TOOL_ITEM_GROUP(self.get_widget()), index) } as *mut ffi::C_GtkWidget;
+        let tmp_pointer = unsafe { ffi::gtk_tool_item_group_get_nth_item(GTK_TOOL_ITEM_GROUP(self.unwrap_widget()), index) } as *mut ffi::C_GtkWidget;
 
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(FFIWidget::wrap(tmp_pointer))
+            Some(FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 
     pub fn get_header_relief(&self) -> gtk::ReliefStyle {
-        unsafe { ffi::gtk_tool_item_group_get_header_relief(GTK_TOOL_ITEM_GROUP(self.get_widget())) }
+        unsafe { ffi::gtk_tool_item_group_get_header_relief(GTK_TOOL_ITEM_GROUP(self.unwrap_widget())) }
     }
 
     pub fn set_header_relief(&self, style: gtk::ReliefStyle) {
-        unsafe { ffi::gtk_tool_item_group_set_header_relief(GTK_TOOL_ITEM_GROUP(self.get_widget()), style) }
+        unsafe { ffi::gtk_tool_item_group_set_header_relief(GTK_TOOL_ITEM_GROUP(self.unwrap_widget()), style) }
     }
 
     pub fn insert(&self, item: &ToolItem, position: i32) {
-        unsafe { ffi::gtk_tool_item_group_insert(GTK_TOOL_ITEM_GROUP(self.get_widget()), GTK_TOOL_ITEM(item.get_widget()),
+        unsafe { ffi::gtk_tool_item_group_insert(GTK_TOOL_ITEM_GROUP(self.unwrap_widget()), GTK_TOOL_ITEM(item.unwrap_widget()),
             position as ::libc::c_int) }
     }
 
     pub fn set_label_widget<T: gtk::WidgetTrait>(&self, label_widget: &T) {
-        unsafe { ffi::gtk_tool_item_group_set_label_widget(GTK_TOOL_ITEM_GROUP(self.get_widget()), label_widget.get_widget()) }
+        unsafe { ffi::gtk_tool_item_group_set_label_widget(GTK_TOOL_ITEM_GROUP(self.unwrap_widget()), label_widget.unwrap_widget()) }
     }
 }
 

--- a/src/gtk/widgets/tool_palette.rs
+++ b/src/gtk/widgets/tool_palette.rs
@@ -29,82 +29,82 @@ impl ToolPalette {
     }
 
     pub fn get_icon_size(&self) -> gtk::IconSize {
-        unsafe { ffi::gtk_tool_palette_get_icon_size(GTK_TOOL_PALETTE(self.get_widget())) }
+        unsafe { ffi::gtk_tool_palette_get_icon_size(GTK_TOOL_PALETTE(self.unwrap_widget())) }
     }
 
     pub fn set_icon_size(&self, icon_size: gtk::IconSize) {
-        unsafe { ffi::gtk_tool_palette_set_icon_size(GTK_TOOL_PALETTE(self.get_widget()), icon_size) }
+        unsafe { ffi::gtk_tool_palette_set_icon_size(GTK_TOOL_PALETTE(self.unwrap_widget()), icon_size) }
     }
 
     pub fn unset_icon_size(&self) {
-        unsafe { ffi::gtk_tool_palette_unset_icon_size(GTK_TOOL_PALETTE(self.get_widget())) }
+        unsafe { ffi::gtk_tool_palette_unset_icon_size(GTK_TOOL_PALETTE(self.unwrap_widget())) }
     }
 
     pub fn get_style(&self) -> gtk::ToolbarStyle {
-        unsafe { ffi::gtk_tool_palette_get_style(GTK_TOOL_PALETTE(self.get_widget())) }
+        unsafe { ffi::gtk_tool_palette_get_style(GTK_TOOL_PALETTE(self.unwrap_widget())) }
     }
 
     pub fn set_style(&self, style: gtk::ToolbarStyle) {
-        unsafe { ffi::gtk_tool_palette_set_style(GTK_TOOL_PALETTE(self.get_widget()), style) }
+        unsafe { ffi::gtk_tool_palette_set_style(GTK_TOOL_PALETTE(self.unwrap_widget()), style) }
     }
 
     pub fn unset_style(&self) {
-        unsafe { ffi::gtk_tool_palette_unset_style(GTK_TOOL_PALETTE(self.get_widget())) }
+        unsafe { ffi::gtk_tool_palette_unset_style(GTK_TOOL_PALETTE(self.unwrap_widget())) }
     }
 
     pub fn get_drop_item(&self, x: i32, y: i32) -> Option<ToolItem> {
-        let tmp_pointer = unsafe { ffi::gtk_tool_palette_get_drop_item(GTK_TOOL_PALETTE(self.get_widget()),
+        let tmp_pointer = unsafe { ffi::gtk_tool_palette_get_drop_item(GTK_TOOL_PALETTE(self.unwrap_widget()),
             x as ::libc::c_int, y as ::libc::c_int) };
 
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer as *mut ffi::C_GtkWidget))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer as *mut ffi::C_GtkWidget))
         }
     }
 
     pub fn set_drag_source(&self, targets: gtk::ToolPaletteDragTargets) {
-        unsafe { ffi::gtk_tool_palette_set_drag_source(GTK_TOOL_PALETTE(self.get_widget()), targets) }
+        unsafe { ffi::gtk_tool_palette_set_drag_source(GTK_TOOL_PALETTE(self.unwrap_widget()), targets) }
     }
 
     pub fn get_exclusive(&self, group: &gtk::ToolItemGroup) -> bool {
-        unsafe { to_bool(ffi::gtk_tool_palette_get_exclusive(GTK_TOOL_PALETTE(self.get_widget()),
-            GTK_TOOL_ITEM_GROUP(group.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_tool_palette_get_exclusive(GTK_TOOL_PALETTE(self.unwrap_widget()),
+            GTK_TOOL_ITEM_GROUP(group.unwrap_widget()))) }
     }
 
     pub fn set_exclusive(&self, group: &gtk::ToolItemGroup, exclusive: bool) {
-        unsafe { ffi::gtk_tool_palette_set_exclusive(GTK_TOOL_PALETTE(self.get_widget()),
-            GTK_TOOL_ITEM_GROUP(group.get_widget()), to_gboolean(exclusive)) }
+        unsafe { ffi::gtk_tool_palette_set_exclusive(GTK_TOOL_PALETTE(self.unwrap_widget()),
+            GTK_TOOL_ITEM_GROUP(group.unwrap_widget()), to_gboolean(exclusive)) }
     }
 
     pub fn get_expand(&self, group: &gtk::ToolItemGroup) -> bool {
-        unsafe { to_bool(ffi::gtk_tool_palette_get_expand(GTK_TOOL_PALETTE(self.get_widget()),
-            GTK_TOOL_ITEM_GROUP(group.get_widget()))) }
+        unsafe { to_bool(ffi::gtk_tool_palette_get_expand(GTK_TOOL_PALETTE(self.unwrap_widget()),
+            GTK_TOOL_ITEM_GROUP(group.unwrap_widget()))) }
     }
 
     pub fn set_expand(&self, group: &gtk::ToolItemGroup, expand: bool) {
-        unsafe { ffi::gtk_tool_palette_set_expand(GTK_TOOL_PALETTE(self.get_widget()),
-            GTK_TOOL_ITEM_GROUP(group.get_widget()), to_gboolean(expand)) }
+        unsafe { ffi::gtk_tool_palette_set_expand(GTK_TOOL_PALETTE(self.unwrap_widget()),
+            GTK_TOOL_ITEM_GROUP(group.unwrap_widget()), to_gboolean(expand)) }
     }
 
     pub fn get_group_position(&self, group: &gtk::ToolItemGroup) -> i32 {
-        unsafe { ffi::gtk_tool_palette_get_group_position(GTK_TOOL_PALETTE(self.get_widget()),
-            GTK_TOOL_ITEM_GROUP(group.get_widget())) }
+        unsafe { ffi::gtk_tool_palette_get_group_position(GTK_TOOL_PALETTE(self.unwrap_widget()),
+            GTK_TOOL_ITEM_GROUP(group.unwrap_widget())) }
     }
 
     pub fn set_group_position(&self, group: &gtk::ToolItemGroup, expand: i32) {
-        unsafe { ffi::gtk_tool_palette_set_group_position(GTK_TOOL_PALETTE(self.get_widget()),
-            GTK_TOOL_ITEM_GROUP(group.get_widget()), expand as ::libc::c_int) }
+        unsafe { ffi::gtk_tool_palette_set_group_position(GTK_TOOL_PALETTE(self.unwrap_widget()),
+            GTK_TOOL_ITEM_GROUP(group.unwrap_widget()), expand as ::libc::c_int) }
     }
 
     pub fn get_drop_group(&self, x: i32, y: i32) -> Option<gtk::ToolItemGroup> {
-        let tmp_pointer = unsafe { ffi::gtk_tool_palette_get_drop_group(GTK_TOOL_PALETTE(self.get_widget()),
+        let tmp_pointer = unsafe { ffi::gtk_tool_palette_get_drop_group(GTK_TOOL_PALETTE(self.unwrap_widget()),
             x as ::libc::c_int, y as ::libc::c_int) };
 
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer as *mut ffi::C_GtkWidget))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer as *mut ffi::C_GtkWidget))
         }
     }
 }

--- a/src/gtk/widgets/tree_iter.rs
+++ b/src/gtk/widgets/tree_iter.rs
@@ -48,7 +48,7 @@ impl TreeIter {
     }
 
     #[doc(hidden)]
-    pub fn get_pointer(&self) -> *mut ffi::C_GtkTreeIter {
+    pub fn unwrap_pointer(&self) -> *mut ffi::C_GtkTreeIter {
         self.pointer
     }
 

--- a/src/gtk/widgets/tree_model.rs
+++ b/src/gtk/widgets/tree_model.rs
@@ -36,7 +36,7 @@ impl TreeModel {
     }
 
     pub fn get_iter(&self, iter: &mut TreeIter, path: &TreePath) -> bool {
-        match unsafe { ffi::gtk_tree_model_get_iter(self.pointer, iter.get_pointer(), path.get_pointer()) } {
+        match unsafe { ffi::gtk_tree_model_get_iter(self.pointer, iter.unwrap_pointer(), path.unwrap_pointer()) } {
             0 => false,
             _ => true
         }
@@ -45,21 +45,21 @@ impl TreeModel {
     pub fn get_iter_from_string(&self, iter: &mut TreeIter, path_string: &str) -> bool {
         let c_str = CString::from_slice(path_string.as_bytes());
 
-        match unsafe { ffi::gtk_tree_model_get_iter_from_string(self.pointer, iter.get_pointer(), c_str.as_ptr()) } {
+        match unsafe { ffi::gtk_tree_model_get_iter_from_string(self.pointer, iter.unwrap_pointer(), c_str.as_ptr()) } {
                 0 => false,
                 _ => true
             }
     }
 
     pub fn get_iter_first(&self, iter: &mut TreeIter) -> bool {
-        match unsafe { ffi::gtk_tree_model_get_iter_first(self.pointer, iter.get_pointer()) } {
+        match unsafe { ffi::gtk_tree_model_get_iter_first(self.pointer, iter.unwrap_pointer()) } {
             0 => false,
             _ => true
         }
     }
 
     pub fn get_path(&self, iter: &TreeIter) -> Option<TreePath> {
-        let tmp_pointer = unsafe { ffi::gtk_tree_model_get_path(self.pointer, iter.get_pointer()) };
+        let tmp_pointer = unsafe { ffi::gtk_tree_model_get_path(self.pointer, iter.unwrap_pointer()) };
 
         if tmp_pointer.is_null() {
             None
@@ -71,19 +71,19 @@ impl TreeModel {
     pub fn get_value(&self, iter: &TreeIter, column: i32) -> GValue {
         let value = GValue::new().unwrap();
 
-        unsafe { ffi::gtk_tree_model_get_value(self.pointer, iter.get_pointer(), column, value.unwrap_pointer()) };
+        unsafe { ffi::gtk_tree_model_get_value(self.pointer, iter.unwrap_pointer(), column, value.unwrap_pointer()) };
         value
     }
 
     pub fn iter_next(&self, iter: &mut TreeIter) -> bool {
-        match unsafe { ffi::gtk_tree_model_iter_next(self.pointer, iter.get_pointer()) } {
+        match unsafe { ffi::gtk_tree_model_iter_next(self.pointer, iter.unwrap_pointer()) } {
             0 => false,
             _ => true
         }
     }
 
     pub fn iter_previous(&self, iter: &mut TreeIter) -> bool {
-        match unsafe { ffi::gtk_tree_model_iter_previous(self.pointer, iter.get_pointer()) } {
+        match unsafe { ffi::gtk_tree_model_iter_previous(self.pointer, iter.unwrap_pointer()) } {
             0 => false,
             _ => true
         }
@@ -92,8 +92,8 @@ impl TreeModel {
     pub fn iter_children(&self, iter: &mut TreeIter, parent: Option<&TreeIter>) -> bool {
         match unsafe {
             ffi::gtk_tree_model_iter_children(self.pointer,
-                                              iter.get_pointer(),
-                                              if parent.is_none() { ::std::ptr::null_mut() } else { parent.unwrap().get_pointer() })
+                                              iter.unwrap_pointer(),
+                                              if parent.is_none() { ::std::ptr::null_mut() } else { parent.unwrap().unwrap_pointer() })
         } {
             0 => false,
             _ => true
@@ -101,21 +101,21 @@ impl TreeModel {
     }
 
     pub fn iter_has_child(&self, iter: &TreeIter) -> bool {
-        match unsafe { ffi::gtk_tree_model_iter_has_child(self.pointer, iter.get_pointer()) } {
+        match unsafe { ffi::gtk_tree_model_iter_has_child(self.pointer, iter.unwrap_pointer()) } {
             0 => false,
             _ => true
         }
     }
 
     pub fn iter_n_children(&self, iter: &TreeIter) -> i32 {
-        unsafe { ffi::gtk_tree_model_iter_n_children(self.pointer, iter.get_pointer()) }
+        unsafe { ffi::gtk_tree_model_iter_n_children(self.pointer, iter.unwrap_pointer()) }
     }
 
     pub fn iter_nth_child(&self, iter: &mut TreeIter, parent: Option<&TreeIter>, n: i32) -> bool {
         match unsafe {
             ffi::gtk_tree_model_iter_nth_child(self.pointer,
-                                               iter.get_pointer(),
-                                               if parent.is_none() { ::std::ptr::null_mut() } else { parent.unwrap().get_pointer() },
+                                               iter.unwrap_pointer(),
+                                               if parent.is_none() { ::std::ptr::null_mut() } else { parent.unwrap().unwrap_pointer() },
                                                n)
         } {
             0 => false,
@@ -124,7 +124,7 @@ impl TreeModel {
     }
 
     pub fn iter_parent(&self, iter: &mut TreeIter, child: &TreeIter) -> bool {
-        match unsafe { ffi::gtk_tree_model_iter_parent(self.pointer, iter.get_pointer(), child.get_pointer()) } {
+        match unsafe { ffi::gtk_tree_model_iter_parent(self.pointer, iter.unwrap_pointer(), child.unwrap_pointer()) } {
             0 => false,
             _ => true
         }
@@ -132,7 +132,7 @@ impl TreeModel {
 
     #[allow(unused_variables)]
     pub fn get_string_from_iter(&self, iter: &TreeIter) -> Option<String> {
-        let string = unsafe { ffi::gtk_tree_model_get_string_from_iter(self.pointer, iter.get_pointer()) as *const c_char };
+        let string = unsafe { ffi::gtk_tree_model_get_string_from_iter(self.pointer, iter.unwrap_pointer()) as *const c_char };
 
         if string.is_null() {
             None
@@ -147,40 +147,40 @@ impl TreeModel {
     }
 
     pub fn row_changed(&self, path: &TreePath, iter: &TreeIter) {
-        unsafe { ffi::gtk_tree_model_row_changed(self.pointer, path.get_pointer(), iter.get_pointer()) }
+        unsafe { ffi::gtk_tree_model_row_changed(self.pointer, path.unwrap_pointer(), iter.unwrap_pointer()) }
     }
 
     pub fn row_inserted(&self, path: &TreePath, iter: &TreeIter) {
-        unsafe { ffi::gtk_tree_model_row_inserted(self.pointer, path.get_pointer(), iter.get_pointer()) }
+        unsafe { ffi::gtk_tree_model_row_inserted(self.pointer, path.unwrap_pointer(), iter.unwrap_pointer()) }
     }
 
     pub fn row_has_child_toggled(&self, path: &TreePath, iter: &TreeIter) {
-        unsafe { ffi::gtk_tree_model_row_has_child_toggled(self.pointer, path.get_pointer(), iter.get_pointer()) }
+        unsafe { ffi::gtk_tree_model_row_has_child_toggled(self.pointer, path.unwrap_pointer(), iter.unwrap_pointer()) }
     }
 
     pub fn row_deleted(&self, path: &TreePath) {
-        unsafe { ffi::gtk_tree_model_row_deleted(self.pointer, path.get_pointer()) }
+        unsafe { ffi::gtk_tree_model_row_deleted(self.pointer, path.unwrap_pointer()) }
     }
 
     pub fn rows_reordered(&self, path: &TreePath, iter: Option<&TreeIter>, new_order: &mut [i32]) {
         unsafe {
             ffi::gtk_tree_model_rows_reordered(self.pointer,
-                                               path.get_pointer(),
-                                               if iter.is_none() { ::std::ptr::null_mut() } else { iter.unwrap().get_pointer() },
+                                               path.unwrap_pointer(),
+                                               if iter.is_none() { ::std::ptr::null_mut() } else { iter.unwrap().unwrap_pointer() },
                                                new_order.as_mut_ptr())
         }
     }
 
     pub fn ref_node(&self, iter: &TreeIter) {
-        unsafe { ffi::gtk_tree_model_ref_node(self.pointer, iter.get_pointer()) }
+        unsafe { ffi::gtk_tree_model_ref_node(self.pointer, iter.unwrap_pointer()) }
     }
 
     pub fn unref_node(&self, iter: &TreeIter) {
-        unsafe { ffi::gtk_tree_model_unref_node(self.pointer, iter.get_pointer()) }
+        unsafe { ffi::gtk_tree_model_unref_node(self.pointer, iter.unwrap_pointer()) }
     }
 
     #[doc(hidden)]
-    pub fn get_pointer(&self) -> *mut ffi::C_GtkTreeModel {
+    pub fn unwrap_pointer(&self) -> *mut ffi::C_GtkTreeModel {
         self.pointer
     }
 

--- a/src/gtk/widgets/tree_path.rs
+++ b/src/gtk/widgets/tree_path.rs
@@ -169,7 +169,7 @@ impl TreePath {
     }
 
     #[doc(hidden)]
-    pub fn get_pointer(&self) -> *mut ffi::C_GtkTreePath {
+    pub fn unwrap_pointer(&self) -> *mut ffi::C_GtkTreePath {
         self.pointer
     }
 

--- a/src/gtk/widgets/tree_selection.rs
+++ b/src/gtk/widgets/tree_selection.rs
@@ -42,13 +42,13 @@ impl TreeSelection {
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(gtk::FFIWidget::wrap(tmp_pointer))
+            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
         }
     }
 
     pub fn get_selected(&self, model: &gtk::TreeModel, iter: &mut gtk::TreeIter) -> bool {
-        match unsafe { ffi::gtk_tree_selection_get_selected(self.pointer, &mut model.get_pointer(),
-            iter.get_pointer()) } {
+        match unsafe { ffi::gtk_tree_selection_get_selected(self.pointer, &mut model.unwrap_pointer(),
+            iter.unwrap_pointer()) } {
             0 => false,
             _ => true
         }
@@ -59,30 +59,30 @@ impl TreeSelection {
     }
 
     pub fn select_path(&self, path: &TreePath) {
-        unsafe { ffi::gtk_tree_selection_select_path(self.pointer, path.get_pointer()) }
+        unsafe { ffi::gtk_tree_selection_select_path(self.pointer, path.unwrap_pointer()) }
     }
 
     pub fn unselect_path(&self, path: &TreePath) {
-        unsafe { ffi::gtk_tree_selection_unselect_path(self.pointer, path.get_pointer()) }
+        unsafe { ffi::gtk_tree_selection_unselect_path(self.pointer, path.unwrap_pointer()) }
     }
 
     pub fn path_is_selected(&self, path: &TreePath) -> bool {
-        match unsafe { ffi::gtk_tree_selection_path_is_selected(self.pointer, path.get_pointer()) } {
+        match unsafe { ffi::gtk_tree_selection_path_is_selected(self.pointer, path.unwrap_pointer()) } {
             0 => false,
             _ => true
         }
     }
 
     pub fn select_iter(&self, iter: &TreeIter) {
-        unsafe { ffi::gtk_tree_selection_select_iter(self.pointer, iter.get_pointer()) }
+        unsafe { ffi::gtk_tree_selection_select_iter(self.pointer, iter.unwrap_pointer()) }
     }
 
     pub fn unselect_iter(&self, iter: &TreeIter) {
-        unsafe { ffi::gtk_tree_selection_unselect_iter(self.pointer, iter.get_pointer()) }
+        unsafe { ffi::gtk_tree_selection_unselect_iter(self.pointer, iter.unwrap_pointer()) }
     }
 
     pub fn iter_is_selected(&self, iter: &TreeIter) -> bool {
-        match unsafe { ffi::gtk_tree_selection_iter_is_selected(self.pointer, iter.get_pointer()) } {
+        match unsafe { ffi::gtk_tree_selection_iter_is_selected(self.pointer, iter.unwrap_pointer()) } {
             0 => false,
             _ => true
         }
@@ -97,13 +97,13 @@ impl TreeSelection {
     }
 
     pub fn select_range(&self, start_path: &TreePath, end_path: &TreePath) {
-        unsafe { ffi::gtk_tree_selection_select_range(self.pointer, start_path.get_pointer(),
-            end_path.get_pointer()) }
+        unsafe { ffi::gtk_tree_selection_select_range(self.pointer, start_path.unwrap_pointer(),
+            end_path.unwrap_pointer()) }
     }
 
     pub fn unselect_range(&self, start_path: &TreePath, end_path: &TreePath) {
-        unsafe { ffi::gtk_tree_selection_unselect_range(self.pointer, start_path.get_pointer(),
-            end_path.get_pointer()) }
+        unsafe { ffi::gtk_tree_selection_unselect_range(self.pointer, start_path.unwrap_pointer(),
+            end_path.unwrap_pointer()) }
     }
 
     pub fn wrap(pointer: *mut ffi::C_GtkTreeSelection) -> Option<TreeSelection> {
@@ -116,7 +116,7 @@ impl TreeSelection {
 }
 
 impl glib::traits::FFIGObject for TreeSelection {
-    fn get_gobject(&self) -> *mut glib::ffi::C_GObject {
+    fn unwrap_gobject(&self) -> *mut glib::ffi::C_GObject {
         gtk::cast::G_OBJECT_FROM_TREE_SELECTION(self.pointer)
     }
 

--- a/src/gtk/widgets/tree_store.rs
+++ b/src/gtk/widgets/tree_store.rs
@@ -37,50 +37,50 @@ impl TreeStore {
     pub fn set_string(&self, iter: &TreeIter, column: i32, text: &str) {
         let text_c = CString::from_slice(text.as_bytes());
 
-        unsafe { ffi::gtk_tree_store_set(self.pointer, iter.get_pointer(), column, text_c.as_ptr(), -1is) }
+        unsafe { ffi::gtk_tree_store_set(self.pointer, iter.unwrap_pointer(), column, text_c.as_ptr(), -1is) }
     }
 
     pub fn remove(&self, iter: &TreeIter) -> bool {
-        unsafe { to_bool(ffi::gtk_tree_store_remove(self.pointer, iter.get_pointer())) }
+        unsafe { to_bool(ffi::gtk_tree_store_remove(self.pointer, iter.unwrap_pointer())) }
     }
 
     pub fn insert(&self, iter: &mut TreeIter, parent: Option<&TreeIter>, position: i32) {
         unsafe { ffi::gtk_tree_store_insert(self.pointer,
-                                            iter.get_pointer(),
-                                            if parent.is_none() { ::std::ptr::null_mut() } else { parent.unwrap().get_pointer() },
+                                            iter.unwrap_pointer(),
+                                            if parent.is_none() { ::std::ptr::null_mut() } else { parent.unwrap().unwrap_pointer() },
                                             position) }
     }
 
     pub fn insert_before(&self, iter: &mut TreeIter, parent: Option<&TreeIter>, sibling: Option<&TreeIter>) {
         unsafe { ffi::gtk_tree_store_insert_before(self.pointer,
-                                                   iter.get_pointer(),
-                                                   if parent.is_none() { ::std::ptr::null_mut() } else { parent.unwrap().get_pointer() },
-                                                   if sibling.is_none() { ::std::ptr::null_mut() } else { sibling.unwrap().get_pointer() }) }
+                                                   iter.unwrap_pointer(),
+                                                   if parent.is_none() { ::std::ptr::null_mut() } else { parent.unwrap().unwrap_pointer() },
+                                                   if sibling.is_none() { ::std::ptr::null_mut() } else { sibling.unwrap().unwrap_pointer() }) }
     }
 
     pub fn insert_after(&self, iter: &mut TreeIter, parent: Option<&TreeIter>, sibling: Option<&TreeIter>) {
         unsafe { ffi::gtk_tree_store_insert_after(self.pointer,
-                                                  iter.get_pointer(),
-                                                  if parent.is_none() { ::std::ptr::null_mut() } else { parent.unwrap().get_pointer() },
-                                                  if sibling.is_none() { ::std::ptr::null_mut() } else { sibling.unwrap().get_pointer() }) }
+                                                  iter.unwrap_pointer(),
+                                                  if parent.is_none() { ::std::ptr::null_mut() } else { parent.unwrap().unwrap_pointer() },
+                                                  if sibling.is_none() { ::std::ptr::null_mut() } else { sibling.unwrap().unwrap_pointer() }) }
     }
 
     pub fn prepend(&self, iter: &mut TreeIter, parent: Option<&TreeIter>) {
-        unsafe { ffi::gtk_tree_store_prepend(self.pointer, iter.get_pointer(),
-                                             if parent.is_none() { ::std::ptr::null_mut() } else { parent.unwrap().get_pointer() }) }
+        unsafe { ffi::gtk_tree_store_prepend(self.pointer, iter.unwrap_pointer(),
+                                             if parent.is_none() { ::std::ptr::null_mut() } else { parent.unwrap().unwrap_pointer() }) }
     }
 
     pub fn append(&self, iter: &mut TreeIter, parent: Option<&TreeIter>) {
-        unsafe { ffi::gtk_tree_store_append(self.pointer, iter.get_pointer(),
-                                            if parent.is_none() { ::std::ptr::null_mut() } else { parent.unwrap().get_pointer() }) }
+        unsafe { ffi::gtk_tree_store_append(self.pointer, iter.unwrap_pointer(),
+                                            if parent.is_none() { ::std::ptr::null_mut() } else { parent.unwrap().unwrap_pointer() }) }
     }
 
     pub fn is_ancestor(&self, iter: &TreeIter, descendent: &TreeIter) -> bool {
-        unsafe { to_bool(ffi::gtk_tree_store_is_ancestor(self.pointer, iter.get_pointer(), descendent.get_pointer())) }
+        unsafe { to_bool(ffi::gtk_tree_store_is_ancestor(self.pointer, iter.unwrap_pointer(), descendent.unwrap_pointer())) }
     }
 
     pub fn iter_depth(&self, iter: &TreeIter) -> i32 {
-        unsafe { ffi::gtk_tree_store_iter_depth(self.pointer, iter.get_pointer()) }
+        unsafe { ffi::gtk_tree_store_iter_depth(self.pointer, iter.unwrap_pointer()) }
     }
 
     pub fn clear(&self) {
@@ -88,25 +88,25 @@ impl TreeStore {
     }
 
     pub fn iter_is_valid(&self, iter: &TreeIter) -> bool {
-        unsafe { to_bool(ffi::gtk_tree_store_iter_is_valid(self.pointer, iter.get_pointer())) }
+        unsafe { to_bool(ffi::gtk_tree_store_iter_is_valid(self.pointer, iter.unwrap_pointer())) }
     }
 
     pub fn reorder(&self, parent: &TreeIter, new_order: *mut i32) {
-        unsafe { ffi::gtk_tree_store_reorder(self.pointer, parent.get_pointer(), new_order) }
+        unsafe { ffi::gtk_tree_store_reorder(self.pointer, parent.unwrap_pointer(), new_order) }
     }
 
     pub fn swap(&self, a: &TreeIter, b: &TreeIter) {
-        unsafe { ffi::gtk_tree_store_swap(self.pointer, a.get_pointer(), b.get_pointer()) }
+        unsafe { ffi::gtk_tree_store_swap(self.pointer, a.unwrap_pointer(), b.unwrap_pointer()) }
     }
 
     pub fn move_before(&self, iter: &TreeIter, position: Option<&TreeIter>) {
-        unsafe { ffi::gtk_tree_store_move_before(self.pointer, iter.get_pointer(),
-                                                 if position.is_none() { ::std::ptr::null_mut() } else { position.unwrap().get_pointer() }) }
+        unsafe { ffi::gtk_tree_store_move_before(self.pointer, iter.unwrap_pointer(),
+                                                 if position.is_none() { ::std::ptr::null_mut() } else { position.unwrap().unwrap_pointer() }) }
     }
 
     pub fn move_after(&self, iter: &TreeIter, position: Option<&TreeIter>) {
-        unsafe { ffi::gtk_tree_store_move_before(self.pointer, iter.get_pointer(),
-                                                 if position.is_none() { ::std::ptr::null_mut() } else { position.unwrap().get_pointer() }) }
+        unsafe { ffi::gtk_tree_store_move_before(self.pointer, iter.unwrap_pointer(),
+                                                 if position.is_none() { ::std::ptr::null_mut() } else { position.unwrap().unwrap_pointer() }) }
     }
 
     pub fn get_model(&self) -> Option<gtk::TreeModel> {
@@ -118,7 +118,7 @@ impl TreeStore {
     }
 
     pub fn set_value(&self, iter: &TreeIter, column: i32, value: &gtk::GValue) {
-        unsafe { ffi::gtk_tree_store_set_value(self.pointer, iter.get_pointer(), column, value.unwrap_pointer()) }
+        unsafe { ffi::gtk_tree_store_set_value(self.pointer, iter.unwrap_pointer(), column, value.unwrap_pointer()) }
     }
 
     /*pub fn set_valuesv<T: gtk::traits::GValuePrivate>(&self, iter: &gtk::TreeIter, columns: &[i32], values: &[T]) {
@@ -127,12 +127,12 @@ impl TreeStore {
         for value in values {
             tmp_values.push(value.get_gvalue());
         }
-        unsafe { ffi::gtk_tree_store_set_valuesv(gtk::cast::GTK_TREE_MODEL_FROM_TREE_STORE(self.pointer), iter.get_pointer(),
+        unsafe { ffi::gtk_tree_store_set_valuesv(gtk::cast::GTK_TREE_MODEL_FROM_TREE_STORE(self.pointer), iter.unwrap_pointer(),
             columns.as_ptr(), tmp_values.as_slice().as_ptr()) }
     }*/
 
     #[doc(hidden)]
-    pub fn get_pointer(&self) -> *mut ffi::C_GtkTreeStore {
+    pub fn unwrap_pointer(&self) -> *mut ffi::C_GtkTreeStore {
         self.pointer
     }
 

--- a/src/gtk/widgets/tree_view.rs
+++ b/src/gtk/widgets/tree_view.rs
@@ -31,7 +31,7 @@ impl TreeView {
     }
 
     pub fn new_with_model(model: &gtk::TreeModel) -> Option<TreeView> {
-        let tmp_pointer = unsafe { ffi::gtk_tree_view_new_with_model(model.get_pointer()) };
+        let tmp_pointer = unsafe { ffi::gtk_tree_view_new_with_model(model.unwrap_pointer()) };
         check_pointer!(tmp_pointer, TreeView)
     }
 
@@ -172,7 +172,7 @@ impl TreeView {
 
     pub fn get_search_entry(&self) -> gtk::Entry {
         unsafe {
-            gtk::FFIWidget::wrap(ffi::gtk_tree_view_get_search_entry(GTK_TREE_VIEW(self.pointer))
+            gtk::FFIWidget::wrap_widget(ffi::gtk_tree_view_get_search_entry(GTK_TREE_VIEW(self.pointer))
                                  as *mut ffi::C_GtkWidget)
         }
     }
@@ -180,7 +180,7 @@ impl TreeView {
     pub fn set_search_entry(&mut self, entry: &mut gtk::Entry) {
         unsafe {
             ffi::gtk_tree_view_set_search_entry(GTK_TREE_VIEW(self.pointer),
-                                                entry.get_widget() as *mut ffi::C_GtkEntry)
+                                                entry.unwrap_widget() as *mut ffi::C_GtkEntry)
         }
     }
 
@@ -379,7 +379,7 @@ impl TreeView {
     pub fn set_model(&mut self, model: &gtk::TreeModel) {
         unsafe {
             ffi::gtk_tree_view_set_model(GTK_TREE_VIEW(self.pointer),
-                                         model.get_pointer())
+                                         model.unwrap_pointer())
         }
     }
 
@@ -392,27 +392,27 @@ impl TreeView {
     pub fn set_cursor(&mut self, path: &TreePath, focus_column: Option<&TreeViewColumn>, start_editing: bool) {
         unsafe {
             ffi::gtk_tree_view_set_cursor(GTK_TREE_VIEW(self.pointer),
-                                          path.get_pointer(),
-                                          if focus_column.is_none() { ::std::ptr::null_mut() } else { focus_column.unwrap().get_pointer() },
+                                          path.unwrap_pointer(),
+                                          if focus_column.is_none() { ::std::ptr::null_mut() } else { focus_column.unwrap().unwrap_pointer() },
                                           to_gboolean(start_editing))
         };
     }
 
     pub fn expand_row(&mut self, path: &TreePath, open_all: bool) -> bool {
         unsafe {
-            to_bool(ffi::gtk_tree_view_expand_row(GTK_TREE_VIEW(self.pointer), path.get_pointer(), to_gboolean(open_all)))
+            to_bool(ffi::gtk_tree_view_expand_row(GTK_TREE_VIEW(self.pointer), path.unwrap_pointer(), to_gboolean(open_all)))
         }
     }
 
     pub fn collapse_row(&mut self, path: &TreePath) -> bool {
         unsafe {
-            to_bool(ffi::gtk_tree_view_collapse_row(GTK_TREE_VIEW(self.pointer), path.get_pointer()))
+            to_bool(ffi::gtk_tree_view_collapse_row(GTK_TREE_VIEW(self.pointer), path.unwrap_pointer()))
         }
     }
 
     pub fn append_column(&mut self, column: &gtk::TreeViewColumn) -> i32 {
         unsafe { ffi::gtk_tree_view_append_column(GTK_TREE_VIEW(self.pointer),
-                                                  column.get_pointer()) }
+                                                  column.unwrap_pointer()) }
     }
 }
 

--- a/src/gtk/widgets/tree_view_column.rs
+++ b/src/gtk/widgets/tree_view_column.rs
@@ -184,13 +184,13 @@ impl TreeViewColumn {
 
     pub fn set_widget<T: gtk::WidgetTrait>(&mut self, widget: &T) {
         unsafe {
-            ffi::gtk_tree_view_column_set_widget(self.pointer, widget.get_widget())
+            ffi::gtk_tree_view_column_set_widget(self.pointer, widget.unwrap_widget())
         }
     }
 
     pub fn get_widget<T: gtk::WidgetTrait>(&self) -> T {
         unsafe {
-            gtk::FFIWidget::wrap(ffi::gtk_tree_view_column_get_widget(self.pointer))
+            gtk::FFIWidget::wrap_widget(ffi::gtk_tree_view_column_get_widget(self.pointer))
         }
     }
 
@@ -268,13 +268,13 @@ impl TreeViewColumn {
 
     pub fn get_tree_view(&self) -> gtk::TreeView {
         unsafe {
-            gtk::FFIWidget::wrap(ffi::gtk_tree_view_column_get_tree_view(self.pointer))
+            gtk::FFIWidget::wrap_widget(ffi::gtk_tree_view_column_get_tree_view(self.pointer))
         }
     }
 
     pub fn get_button<T: gtk::WidgetTrait + gtk::ButtonTrait>(&self) -> T {
         unsafe {
-            gtk::FFIWidget::wrap(ffi::gtk_tree_view_column_get_button(self.pointer))
+            gtk::FFIWidget::wrap_widget(ffi::gtk_tree_view_column_get_button(self.pointer))
         }
     }
 
@@ -282,30 +282,30 @@ impl TreeViewColumn {
         let attribute_c = CString::from_slice(attribute.as_bytes());
 
         unsafe { ffi::gtk_tree_view_column_add_attribute(self.pointer,
-                                                         cast::GTK_CELL_RENDERER(cell.get_widget()),
+                                                         cast::GTK_CELL_RENDERER(cell.unwrap_widget()),
                                                          attribute_c.as_ptr(),
                                                          column) }
     }
 
     pub fn clear_attributes<T: gtk::FFIWidget + gtk::CellRendererTrait>(&self, cell: &T) {
         unsafe { ffi::gtk_tree_view_column_clear_attributes(self.pointer,
-                                                            cast::GTK_CELL_RENDERER(cell.get_widget())) }
+                                                            cast::GTK_CELL_RENDERER(cell.unwrap_widget())) }
     }
 
     pub fn pack_start<T: gtk::FFIWidget + gtk::CellRendererTrait>(&self, cell: &T, expand: bool) {
         unsafe { ffi::gtk_tree_view_column_pack_start(self.pointer,
-                                                      cast::GTK_CELL_RENDERER(cell.get_widget()),
+                                                      cast::GTK_CELL_RENDERER(cell.unwrap_widget()),
                                                       to_gboolean(expand)) }
     }
 
     pub fn pack_end<T: gtk::FFIWidget + gtk::CellRendererTrait>(&self, cell: &T, expand: bool) {
         unsafe { ffi::gtk_tree_view_column_pack_end(self.pointer,
-                                                    cast::GTK_CELL_RENDERER(cell.get_widget()),
+                                                    cast::GTK_CELL_RENDERER(cell.unwrap_widget()),
                                                     to_gboolean(expand)) }
     }
 
     #[doc(hidden)]
-    pub fn get_pointer(&self) -> *mut ffi::C_GtkTreeViewColumn {
+    pub fn unwrap_pointer(&self) -> *mut ffi::C_GtkTreeViewColumn {
         self.pointer
     }
 
@@ -322,7 +322,7 @@ impl TreeViewColumn {
 }
 
 impl glib::traits::FFIGObject for TreeViewColumn {
-    fn get_gobject(&self) -> *mut glib::ffi::C_GObject {
+    fn unwrap_gobject(&self) -> *mut glib::ffi::C_GObject {
         gtk::cast::G_OBJECT_FROM_TREE_VIEW_COLUMN(self.pointer)
     }
 

--- a/src/gtk/widgets/viewport.rs
+++ b/src/gtk/widgets/viewport.rs
@@ -24,7 +24,7 @@ struct_Widget!(Viewport);
 
 impl Viewport {
     pub fn new(hadjustment: &gtk::Adjustment, vadjustment: &gtk::Adjustment) -> Option<Viewport> {
-        let tmp_pointer = unsafe { ffi::gtk_viewport_new(hadjustment.get_pointer(), vadjustment.get_pointer()) };
+        let tmp_pointer = unsafe { ffi::gtk_viewport_new(hadjustment.unwrap_pointer(), vadjustment.unwrap_pointer()) };
         check_pointer!(tmp_pointer, Viewport)
     }
 


### PR DESCRIPTION
This is a quick bulk rename I did to improve consistency. It renames some `get_*` functions to `unwrap_*` when they have an equivalent `wrap_*`, to show that they do the opposite. Specifically, it does the following:

1. Renames `get_pointer` to `unwrap_pointer` in many places (note that `src/gtk/widgets/value.rs` already does this, since `get_pointer` conflicted with its own function of the same name).
2. Renames `FFIGObject::get_gobject` to `FFIGObject::unwrap_gobject`.
3. Renames `FFIWidget::get_widget` to `FFIWidget::unwrap_widget` and `FFIWidget::wrap` to `FFIWidget::wrap_widget`.

What do you think? It's mainly just scratching an itch, but I thought it cleaned things up. Another thing we can do in the future is replace all the explicit unwrap_pointer/wrap_pointer definitions with the `impl_GObjectFunctions` macro.