### PR TITLE
Fix the gtktest and treeview examples

### DIFF
--- a/examples/gtktest/src/gtktest.rs
+++ b/examples/gtktest/src/gtktest.rs
@@ -65,30 +65,30 @@ fn main() {
     window.set_window_position(gtk::WindowPosition::Center);
     window.add(&frame);
 
-    Connect::connect(&button, Clicked::new(&mut |&:|{
+    Connect::connect(&button, Clicked::new(&mut ||{
         //entry.set_text("Clicked!".to_string());
         let dialog = gtk::MessageDialog::new_with_markup(None, gtk::DialogFlags::Modal, gtk::MessageType::Info,
             gtk::ButtonsType::OkCancel, "This is a trap !").unwrap();
 
         dialog.run();
     }));
-    Connect::connect(&button_font, Clicked::new(&mut |&:|{
+    Connect::connect(&button_font, Clicked::new(&mut ||{
         let dialog = gtk::FontChooserDialog::new("Font chooser test", None).unwrap();
 
         dialog.run();
     }));
-    Connect::connect(&button_recent, Clicked::new(&mut |&:|{
+    Connect::connect(&button_recent, Clicked::new(&mut ||{
         let dialog = gtk::RecentChooserDialog::new("Recent chooser test", None).unwrap();
 
         dialog.run();
     }));
-    Connect::connect(&file_button, Clicked::new(&mut |&:|{
+    Connect::connect(&file_button, Clicked::new(&mut ||{
         //entry.set_text("Clicked!".to_string());
         let dialog2 = gtk::FileChooserDialog::new("Choose a file", None, gtk::FileChooserAction::Open).unwrap();
 
         dialog2.run();
     }));
-    Connect::connect(&app_button, Clicked::new(&mut |&:|{
+    Connect::connect(&app_button, Clicked::new(&mut ||{
         //entry.set_text("Clicked!".to_string());
         let dialog = gtk::AppChooserDialog::new_for_content_type(None, gtk::DialogFlags::Modal, "sh").unwrap();
 
@@ -108,7 +108,7 @@ fn main() {
         false
     }));
 
-    Connect::connect(&window, DeleteEvent::new(&mut |&mut: _|{
+    Connect::connect(&window, DeleteEvent::new(&mut |_|{
         gtk::main_quit();
         true
     }));

--- a/examples/treeview/src/treeview.rs
+++ b/examples/treeview/src/treeview.rs
@@ -29,7 +29,7 @@ fn main() {
     window.set_title("TreeView Sample");
     window.set_window_position(gtk::WindowPosition::Center);
 
-    Connect::connect(&window, DeleteEvent::new(&mut |&: _| {
+    Connect::connect(&window, DeleteEvent::new(&mut |_| {
         gtk::main_quit();
         true
     }));
@@ -39,14 +39,14 @@ fn main() {
     let hello = String::from_str("Hello world !");
     let value = gtk::GValue::new().unwrap();
 
-    value.init(gtk::GType::String);
+    value.init(ffi::glib::g_type_string);
     value.set(&hello);
     println!("gvalue.get example : {}", value.get::<String>());
 
     // left pane
 
     let mut left_tree = gtk::TreeView::new().unwrap();
-    let column_types = [glib::ffi::g_type_string];
+    let column_types = [ffi::glib::g_type_string];
     let left_store = gtk::ListStore::new(&column_types).unwrap();
     let left_model = left_store.get_model().unwrap();
 
@@ -63,7 +63,7 @@ fn main() {
     // right pane
 
     let mut right_tree = gtk::TreeView::new().unwrap();
-    let column_types = [glib::ffi::g_type_string];
+    let column_types = [ffi::glib::g_type_string];
     let right_store = gtk::TreeStore::new(&column_types).unwrap();
     let right_model = right_store.get_model().unwrap();
 

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -289,7 +289,7 @@ pub use gtk_ffi::enums::CellRendererState;
 pub use gtk_ffi::enums::TreeModelFlags;
 pub use gtk_ffi::enums::IconViewDropPosition;
 pub use gtk_ffi::enums::SensitivityType;
-pub use gtk_ffi::GType;
+pub use gtk_ffi::enums::GType;
 pub use gtk_ffi::enums::TextSearchFlags;
 pub use gtk_ffi::enums::PlacesOpenFlags;
 pub use gtk_ffi::enums::ToolPaletteDragTargets;

--- a/src/gtk/widgets/gtype.rs
+++ b/src/gtk/widgets/gtype.rs
@@ -17,10 +17,11 @@
 
 // https://developer.gnome.org/gobject/unstable/gobject-Type-Information.html#GType
 pub mod g_type {
-    use gtk::{self, ffi};
+    use gtk::ffi;
     use std::ffi::CString;
+    use glib_ffi::{self};
 
-    pub fn name(_type: gtk::GType) -> Option<String> {
+    pub fn name(_type: glib_ffi::GType) -> Option<String> {
         let tmp_pointer = unsafe { ffi::g_type_name(_type) };
 
         if tmp_pointer.is_null() {
@@ -30,7 +31,7 @@ pub mod g_type {
         }
     }
 
-    pub fn from_name(name: &str) -> gtk::GType {
+    pub fn from_name(name: &str) -> glib_ffi::GType {
         unsafe {
             let c_str = CString::from_slice(name.as_bytes());
 
@@ -38,68 +39,68 @@ pub mod g_type {
         }
     }
 
-    pub fn parent(_type: gtk::GType) -> gtk::GType {
+    pub fn parent(_type: glib_ffi::GType) -> glib_ffi::GType {
         unsafe { ffi::g_type_parent(_type) }
     }
 
-    pub fn depth(_type: gtk::GType) -> u32 {
+    pub fn depth(_type: glib_ffi::GType) -> u32 {
         unsafe { ffi::g_type_depth(_type) }
     }
 
-    pub fn next_base(leaf_type: gtk::GType, root_type: gtk::GType) -> gtk::GType {
+    pub fn next_base(leaf_type: glib_ffi::GType, root_type: glib_ffi::GType) -> glib_ffi::GType {
         unsafe { ffi::g_type_next_base(leaf_type, root_type) }
     }
 
-    pub fn is_a(_type: gtk::GType, is_a_type: gtk::GType) -> bool {
+    pub fn is_a(_type: glib_ffi::GType, is_a_type: glib_ffi::GType) -> bool {
         unsafe { to_bool(ffi::g_type_is_a(_type, is_a_type)) }
     }
 
-    pub fn children(_type: gtk::GType) -> Vec<gtk::GType> {
+    pub fn children(_type: glib_ffi::GType) -> Vec<glib_ffi::GType> {
         let mut n_children = 0u32;
         let tmp_vec = unsafe { ffi::g_type_children(_type, &mut n_children) };
 
         if n_children == 0u32 || tmp_vec.is_null() {
             Vec::new()
         } else {
-            unsafe { Vec::from_raw_buf(tmp_vec as *const gtk::GType, n_children as usize) }
+            unsafe { Vec::from_raw_buf(tmp_vec as *const glib_ffi::GType, n_children as usize) }
         }
     }
 
-    pub fn interfaces(_type: gtk::GType) -> Vec<gtk::GType> {
+    pub fn interfaces(_type: glib_ffi::GType) -> Vec<glib_ffi::GType> {
         let mut n_interfaces = 0u32;
         let tmp_vec = unsafe { ffi::g_type_interfaces(_type, &mut n_interfaces) };
 
         if n_interfaces == 0u32 || tmp_vec.is_null() {
             Vec::new()
         } else {
-            unsafe { Vec::from_raw_buf(tmp_vec as *const gtk::GType, n_interfaces as usize) }
+            unsafe { Vec::from_raw_buf(tmp_vec as *const glib_ffi::GType, n_interfaces as usize) }
         }
     }
 
-    pub fn interface_prerequisites(interface_type: gtk::GType) -> Vec<gtk::GType> {
+    pub fn interface_prerequisites(interface_type: glib_ffi::GType) -> Vec<glib_ffi::GType> {
         let mut n_prerequisites = 0u32;
         let tmp_vec = unsafe { ffi::g_type_interface_prerequisites(interface_type, &mut n_prerequisites) };
 
         if n_prerequisites == 0u32 || tmp_vec.is_null() {
             Vec::new()
         } else {
-            unsafe { Vec::from_raw_buf(tmp_vec as *const gtk::GType, n_prerequisites as usize) }
+            unsafe { Vec::from_raw_buf(tmp_vec as *const glib_ffi::GType, n_prerequisites as usize) }
         }
     }
 
-    pub fn interface_add_prerequisite(interface_type: gtk::GType, prerequisite_type: gtk::GType) {
+    pub fn interface_add_prerequisite(interface_type: glib_ffi::GType, prerequisite_type: glib_ffi::GType) {
         unsafe { ffi::g_type_interface_add_prerequisite(interface_type, prerequisite_type) }
     }
 
-    pub fn fundamental_next() -> gtk::GType {
+    pub fn fundamental_next() -> glib_ffi::GType {
         unsafe { ffi::g_type_fundamental_next() }
     }
 
-    pub fn fundamental(type_id: gtk::GType) -> gtk::GType {
+    pub fn fundamental(type_id: glib_ffi::GType) -> glib_ffi::GType {
         unsafe { ffi::g_type_fundamental(type_id) }
     }
 
-    pub fn ensure(_type: gtk::GType) {
+    pub fn ensure(_type: glib_ffi::GType) {
         unsafe { ffi::g_type_ensure(_type) }
     }
 

--- a/src/gtk/widgets/value.rs
+++ b/src/gtk/widgets/value.rs
@@ -19,6 +19,7 @@ use gtk::{self, ffi};
 use std::ffi::CString;
 use libc::{self, c_char, c_void};
 use glib::{to_bool, to_gboolean};
+use glib_ffi::{self};
 
 trait GValuePrivate {
     fn get(gvalue: &GValue) -> Self;
@@ -45,8 +46,8 @@ impl GValue {
         }
     }
 
-    pub fn init(&self, _type: gtk::GType) {
-        unsafe { ffi::g_value_init(self.pointer, ffi::get_gtype(_type)) }
+    pub fn init(&self, _type: glib_ffi::GType) {
+        unsafe { ffi::g_value_init(self.pointer, _type) }
     }
 
     pub fn reset(&self) {
@@ -157,22 +158,22 @@ impl GValue {
     }
 
     // FIXME shouldn't be like that
-    pub fn set_enum(&self, v_enum: gtk::GType) {
+    pub fn set_enum(&self, v_enum: glib_ffi::GType) {
         unsafe { ffi::g_value_set_enum(self.pointer, v_enum) }
     }
 
     // FIXME shouldn't be like that
-    pub fn get_enum(&self) -> gtk::GType {
+    pub fn get_enum(&self) -> glib_ffi::GType {
         unsafe { ffi::g_value_get_enum(self.pointer) }
     }
 
     // FIXME shouldn't be like that
-    pub fn set_flags(&self, v_flags: gtk::GType) {
+    pub fn set_flags(&self, v_flags: glib_ffi::GType) {
         unsafe { ffi::g_value_set_flags(self.pointer, v_flags) }
     }
 
     // FIXME shouldn't be like that
-    pub fn get_flags(&self) -> gtk::GType {
+    pub fn get_flags(&self) -> glib_ffi::GType {
         unsafe { ffi::g_value_get_flags(self.pointer) }
     }
 
@@ -275,12 +276,12 @@ impl GValue {
     }*/
 
     // FIXME shouldn't be like that
-    fn set_gtype(&self, v_gtype: gtk::GType) {
+    fn set_gtype(&self, v_gtype: glib_ffi::GType) {
         unsafe { ffi::g_value_set_gtype(self.pointer, v_gtype) }
     }
 
     // FIXME shouldn't be like that
-    fn get_gtype(&self) -> gtk::GType {
+    fn get_gtype(&self) -> glib_ffi::GType {
         unsafe { ffi::g_value_get_gtype(self.pointer) }
     }
 
@@ -292,11 +293,11 @@ impl GValue {
         GValuePrivate::get(self)
     }
 
-    pub fn compatible(src_type: gtk::GType, dest_type: gtk::GType) -> bool {
+    pub fn compatible(src_type: glib_ffi::GType, dest_type: glib_ffi::GType) -> bool {
         unsafe { to_bool(ffi::g_value_type_compatible(src_type, dest_type)) }
     }
 
-    pub fn transformable(src_type: gtk::GType, dest_type: gtk::GType) -> bool {
+    pub fn transformable(src_type: glib_ffi::GType, dest_type: glib_ffi::GType) -> bool {
         unsafe { to_bool(ffi::g_value_type_transformable(src_type, dest_type)) }
     }
 
@@ -414,8 +415,8 @@ impl GValuePrivate for f64 {
     }
 }
 
-impl GValuePrivate for gtk::GType {
-    fn get(gvalue: &GValue) -> gtk::GType {
+impl GValuePrivate for glib_ffi::GType {
+    fn get(gvalue: &GValue) -> glib_ffi::GType {
         gvalue.get_gtype()
     }
 
@@ -443,7 +444,7 @@ impl GValuePublic for i64 {}
 //impl GValuePublic for u64 {}
 impl GValuePublic for i8 {}
 impl GValuePublic for u8 {}
-impl GValuePublic for gtk::GType {}
+impl GValuePublic for glib_ffi::GType {}
 impl GValuePublic for String {}
 impl GValuePublic for f32 {}
 impl GValuePublic for f64 {}

--- a/src/rgtk.rs
+++ b/src/rgtk.rs
@@ -102,3 +102,9 @@ pub use gtk::WindowTrait as GtkWindowTrait;
 pub mod gtk;
 pub mod cairo;
 pub mod gdk;
+
+pub mod ffi {
+    pub mod glib {
+        pub use glib_ffi::*;
+    }
+}


### PR DESCRIPTION
This fixes two example projects that are currently broken. I also removed the `get_gtype` call from value.rs, as it seemed to break it. Lastly, I changed value.rs and gtype.rs to pull `GType` from `glib_ffi` rather than `gtk`, as that is where it originally comes from.