### PR TITLE
Transition most of the string conversions to the glib::translate API 

### DIFF
--- a/cairo-sys/src/enums.rs
+++ b/cairo-sys/src/enums.rs
@@ -14,6 +14,7 @@
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::fmt::{Error, Debug};
+use std::ffi::CStr;
 
 #[repr(C)]
 #[derive(Clone, PartialEq, PartialOrd, Copy)]
@@ -65,7 +66,7 @@ impl Debug for Status {
     fn fmt(&self, formatter: &mut ::std::fmt::Formatter) -> Result<(), Error> {
         unsafe {
             let char_ptr = super::cairo_status_to_string(*self);
-            let tmp = String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&char_ptr)).to_string();
+            let tmp = String::from_utf8_lossy(CStr::from_ptr(char_ptr).to_bytes()).into_owned();
 
             tmp.fmt(formatter)
         }

--- a/glib/src/error.rs
+++ b/glib/src/error.rs
@@ -25,7 +25,7 @@ impl Error {
     pub fn new_literal(domain: GQuark, code: i32, message: &str) -> Option<Error> {
         let tmp_pointer = unsafe {
             let mut tmp_message = message.to_tmp_for_borrow();
-            ffi::g_error_new_literal(domain, code, tmp_message.to_glib())
+            ffi::g_error_new_literal(domain, code, tmp_message.to_glib_ptr())
         };
 
         if tmp_pointer.is_null() {
@@ -52,7 +52,7 @@ impl Error {
     pub fn set(&mut self, domain: GQuark, code: i32, message: &str) -> () {
         unsafe {
             let mut tmp_message = message.to_tmp_for_borrow();
-            ffi::g_set_error_literal(&mut self.pointer, domain, code, tmp_message.to_glib())
+            ffi::g_set_error_literal(&mut self.pointer, domain, code, tmp_message.to_glib_ptr())
         }
     }
 

--- a/glib/src/error.rs
+++ b/glib/src/error.rs
@@ -15,7 +15,7 @@
 
 use ffi::{self, GQuark};
 use glib_container::GlibContainer;
-use std::ffi::CString;
+use translate::{ToGlibPtr, ToTmp};
 
 pub struct Error {
     pointer: *mut ffi::C_GError
@@ -24,9 +24,8 @@ pub struct Error {
 impl Error {
     pub fn new_literal(domain: GQuark, code: i32, message: &str) -> Option<Error> {
         let tmp_pointer = unsafe {
-            let c_str = CString::from_slice(message.as_bytes());
-
-            ffi::g_error_new_literal(domain, code, c_str.as_ptr())
+            let mut tmp_message = message.to_tmp_for_borrow();
+            ffi::g_error_new_literal(domain, code, tmp_message.to_glib())
         };
 
         if tmp_pointer.is_null() {
@@ -52,9 +51,8 @@ impl Error {
 
     pub fn set(&mut self, domain: GQuark, code: i32, message: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(message.as_bytes());
-
-            ffi::g_set_error_literal(&mut self.pointer, domain, code, c_str.as_ptr())
+            let mut tmp_message = message.to_tmp_for_borrow();
+            ffi::g_set_error_literal(&mut self.pointer, domain, code, tmp_message.to_glib())
         }
     }
 

--- a/glib/src/traits.rs
+++ b/glib/src/traits.rs
@@ -69,7 +69,7 @@ pub trait Connect<'a, T: Signal<'a>>: FFIGObject + PhantomFn<&'a T> {
             
             ffi::glue_signal_connect(
                 self.unwrap_gobject(),
-                tmp_signal_name.to_glib(),
+                tmp_signal_name.to_glib_ptr(),
                 Some(trampoline),
                 user_data_ptr
             );

--- a/glib/src/translate.rs
+++ b/glib/src/translate.rs
@@ -36,7 +36,7 @@
 //!     pub fn set_icon_name(&self, name: &str) {
 //!         unsafe {
 //!             let mut tmp_name = name.to_tmp_for_borrow();
-//!             ffi::gdk_window_set_icon_name(self.pointer, tmp_name.to_glib())
+//!             ffi::gdk_window_set_icon_name(self.pointer, tmp_name.to_glib_ptr())
 //!         }
 //!     }
 //! ```
@@ -76,7 +76,7 @@ pub trait ToGlib {
 pub trait ToGlibPtr {
     type GlibType;
 
-    fn to_glib(&mut self) -> Self::GlibType;
+    fn to_glib_ptr(&mut self) -> Self::GlibType;
 }
 
 impl ToGlib for bool {
@@ -90,7 +90,7 @@ impl ToGlib for bool {
 impl ToGlibPtr for CString {
     type GlibType = *const c_char;
 
-    fn to_glib(&mut self) -> *const c_char {
+    fn to_glib_ptr(&mut self) -> *const c_char {
         self.as_ptr()
     }
 }
@@ -98,7 +98,7 @@ impl ToGlibPtr for CString {
 impl ToGlibPtr for Option<CString> {
     type GlibType = *const c_char;
 
-    fn to_glib(&mut self) -> *const c_char {
+    fn to_glib_ptr(&mut self) -> *const c_char {
         match self {
             &mut Some(ref s) => s.as_ptr(),
             &mut None => ptr::null(),
@@ -109,7 +109,7 @@ impl ToGlibPtr for Option<CString> {
 impl <T, T2> ToGlibPtr for StackBox<T, T2> {
     type GlibType = *mut T;
 
-    fn to_glib(&mut self) -> *mut T {
+    fn to_glib_ptr(&mut self) -> *mut T {
         &mut (*self).0 as  *mut _
     }
 }

--- a/glib/src/translate.rs
+++ b/glib/src/translate.rs
@@ -129,6 +129,17 @@ impl <'a> ToTmp for &'a str {
     }
 }
 
+impl <'a> ToTmp for &'a Option<&'a str> {
+    type Tmp = Option<CString>;
+
+    fn to_tmp_for_borrow(self) -> Option<CString> {
+        match self {
+            &Some(ref s) => Some(CString::new(&s[..]).unwrap()),
+            &None => None,
+        }
+    }
+}
+
 impl <'a> ToTmp for &'a Option<String> {
     type Tmp = Option<CString>;
 

--- a/glib/src/translate.rs
+++ b/glib/src/translate.rs
@@ -30,13 +30,13 @@
 //!
 //! Letting the foreign library borrow pointers from the Rust side often
 //! requires having a temporary variable of an intermediate type (e.g. `CString`).
-//! In such cases `ToTemp` is used. See also `StackBox`.
+//! In such cases `ToTmp` is used. See also `StackBox`.
 //!
 //! ```ignore
 //!     pub fn set_icon_name(&self, name: &str) {
 //!         unsafe {
-//!             let mut name = name.to_temp_for_borrow();
-//!             ffi::gdk_window_set_icon_name(self.pointer, name.to_glib())
+//!             let mut tmp_name = name.to_tmp_for_borrow();
+//!             ffi::gdk_window_set_icon_name(self.pointer, tmp_name.to_glib())
 //!         }
 //!     }
 //! ```
@@ -61,7 +61,7 @@ use ffi;
 /// type WindowAttrBox = StackBox<ffi::C_GdkWindowAttr, Option<CString>>;
 /// ```
 ///
-/// The `ToTemp` implementation can then use `WindowAttrBox` as its output type
+/// The `ToTmp` implementation can then use `WindowAttrBox` as its output type
 /// and `impl ToGlibPtr for WindowAttrBox` is provided by this module.
 pub struct StackBox<T: Sized, T2: Sized = ()> (pub T, pub T2);
 
@@ -115,24 +115,24 @@ impl <T, T2> ToGlibPtr for StackBox<T, T2> {
 }
 
 /// Translate to a temporary intermediate variable
-pub trait ToTemp {
-    type Temp;
+pub trait ToTmp {
+    type Tmp;
 
-    fn to_temp_for_borrow(self) -> Self::Temp;
+    fn to_tmp_for_borrow(self) -> Self::Tmp;
 }
 
-impl <'a> ToTemp for &'a str {
-    type Temp = CString;
+impl <'a> ToTmp for &'a str {
+    type Tmp = CString;
 
-    fn to_temp_for_borrow(self) -> CString {
+    fn to_tmp_for_borrow(self) -> CString {
         CString::new(self).unwrap()
     }
 }
 
-impl <'a> ToTemp for &'a Option<String> {
-    type Temp = Option<CString>;
+impl <'a> ToTmp for &'a Option<String> {
+    type Tmp = Option<CString>;
 
-    fn to_temp_for_borrow(self) -> Option<CString> {
+    fn to_tmp_for_borrow(self) -> Option<CString> {
         match self {
             &Some(ref s) => Some(CString::new(&s[..]).unwrap()),
             &None => None,

--- a/glib/src/value.rs
+++ b/glib/src/value.rs
@@ -58,12 +58,9 @@ impl Value {
 
     // to free !
     pub fn strdup_value_contents(&self) -> Option<String> {
-        let tmp_pointer = unsafe { ffi::g_strdup_value_contents(self.pointer) as *const c_char };
-
-        if tmp_pointer.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp_pointer)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::g_strdup_value_contents(self.pointer) as *const c_char)
         }
     }
 
@@ -200,12 +197,9 @@ impl Value {
     }*/
 
     pub fn get_string(&self) -> Option<String> {
-        let tmp_pointer = unsafe { ffi::g_value_get_string(self.pointer) };
-
-        if tmp_pointer.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp_pointer)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::g_value_get_string(self.pointer))
         }
     }
 

--- a/glib/src/value.rs
+++ b/glib/src/value.rs
@@ -56,10 +56,9 @@ impl Value {
         unsafe { ffi::g_value_unset(self.pointer) }
     }
 
-    // to free !
     pub fn strdup_value_contents(&self) -> Option<String> {
         unsafe {
-            FromGlibPtr::borrow(
+            FromGlibPtr::take(
                 ffi::g_strdup_value_contents(self.pointer) as *const c_char)
         }
     }
@@ -179,10 +178,6 @@ impl Value {
         }
     }
 
-    pub fn set_static_string(&self, _: &str) {
-        panic!("Not possible");
-    }
-
     /*pub fn take_string(&self, v_string: &str) {
         unsafe {
             v_string.with_c_str(|c_str| {
@@ -197,18 +192,8 @@ impl Value {
         }
     }
 
-    pub fn dup_string(&self) -> Option<String> {
-        self.get_string()
-    }
-
     pub fn set_boxed<T>(&self, v_box: &T) {
         unsafe { ffi::g_value_set_boxed(self.pointer, ::std::mem::transmute(v_box)) }
-    }
-
-    /// Set the contents of a G_TYPE_BOXED derived Value to v_boxed . The boxed value is assumed to be static, and is thus not duplicated
-    /// when setting the Value.
-    pub fn set_static_boxed<T>(&self, v_box: &T) {
-        unsafe { ffi::g_value_set_static_boxed(self.pointer, ::std::mem::transmute(v_box)) }
     }
 
     /*pub fn take_boxed<T>(&self, v_box: &T) {

--- a/glib/src/value.rs
+++ b/glib/src/value.rs
@@ -15,11 +15,11 @@
 
 //! Generic values — A polymorphic type that can hold values of any other type
 
+use libc::c_char;
 use ffi;
-use libc::{self, c_char, c_void};
-use std::ffi::CString;
-use super::{to_bool, to_gboolean, Type};
-use translate::{ToGlib, ToGlibPtr, ToTmp, from_glib};
+use super::{to_bool, to_gboolean};
+use type_::Type;
+use translate::{FromGlibPtr, ToGlib, ToGlibPtr, ToTmp, from_glib};
 
 pub trait ValuePublic {
     fn get(gvalue: &Value) -> Self;
@@ -173,20 +173,14 @@ impl Value {
     }
 
     fn set_string(&self, v_string: &str) {
-        let c_str = CString::from_slice(v_string.as_bytes());
-
         unsafe {
-            ffi::g_value_set_string(self.pointer, c_str.as_ptr())
+            let mut tmp_v_string = v_string.to_tmp_for_borrow();
+            ffi::g_value_set_string(self.pointer, tmp_v_string.to_glib_ptr());
         }
     }
 
-    /// Set the contents of a G_TYPE_STRING Value to v_string . The string is assumed to be static, and is thus not duplicated
-    /// when setting the Value.
-    pub fn set_static_string(&self, v_string: &str) {
-        unsafe {
-            let mut tmp_v_string = v_string.to_tmp_for_borrow();
-            ffi::g_value_set_static_string(self.pointer, tmp_v_string.to_glib_ptr())
-        }
+    pub fn set_static_string(&self, _: &str) {
+        panic!("Not possible");
     }
 
     /*pub fn take_string(&self, v_string: &str) {
@@ -204,18 +198,7 @@ impl Value {
     }
 
     pub fn dup_string(&self) -> Option<String> {
-        let tmp_pointer = unsafe { ffi::g_value_dup_string(self.pointer) };
-
-        if tmp_pointer.is_null() {
-            None
-        } else {
-            unsafe {
-                let ret = Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&(tmp_pointer as *const c_char))).to_string());
-
-                libc::funcs::c95::stdlib::free(tmp_pointer as *mut c_void);
-                ret
-            }
-        }
+        self.get_string()
     }
 
     pub fn set_boxed<T>(&self, v_box: &T) {

--- a/glib/src/value.rs
+++ b/glib/src/value.rs
@@ -15,11 +15,11 @@
 
 //! Generic values — A polymorphic type that can hold values of any other type
 
-use ffi::{self};
+use ffi;
 use libc::{self, c_char, c_void};
 use std::ffi::CString;
 use super::{to_bool, to_gboolean, Type};
-use super::translate::{ToGlib, from_glib};
+use translate::{ToGlib, ToGlibPtr, ToTmp, from_glib};
 
 pub trait ValuePublic {
     fn get(gvalue: &Value) -> Self;
@@ -187,9 +187,8 @@ impl Value {
     /// when setting the Value.
     pub fn set_static_string(&self, v_string: &str) {
         unsafe {
-            let c_str = CString::from_slice(v_string.as_bytes());
-
-            ffi::g_value_set_static_string(self.pointer, c_str.as_ptr())
+            let mut tmp_v_string = v_string.to_tmp_for_borrow();
+            ffi::g_value_set_static_string(self.pointer, tmp_v_string.to_glib_ptr())
         }
     }
 

--- a/gtk3-sys/src/lib.rs
+++ b/gtk3-sys/src/lib.rs
@@ -1584,8 +1584,11 @@ extern "C" {
     pub fn gtk_recent_info_get_modified        (info: *mut C_GtkRecentInfo) -> time_t;
     pub fn gtk_recent_info_get_visited         (info: *mut C_GtkRecentInfo) -> time_t;
     pub fn gtk_recent_info_get_private_hint    (info: *mut C_GtkRecentInfo) -> Gboolean;
-    pub fn gtk_recent_info_get_application_info(info: *mut C_GtkRecentInfo, app_name: *const c_char, app_exec: *const *mut c_char,
-        count: *mut c_uint, time_: *mut time_t) -> Gboolean;
+    pub fn gtk_recent_info_get_application_info(info: *mut C_GtkRecentInfo,
+                                                app_name: *const c_char,
+                                                app_exec: *mut *const c_char,
+                                                count: *mut c_uint,
+                                                time_: *mut time_t) -> Gboolean;
     pub fn gtk_recent_info_get_applications    (info: *mut C_GtkRecentInfo, length: *mut c_long) -> *mut *mut c_char;
     pub fn gtk_recent_info_last_application    (info: *mut C_GtkRecentInfo) -> *mut c_char;
     pub fn gtk_recent_info_has_application     (info: *mut C_GtkRecentInfo, app_name: *const c_char) -> Gboolean;

--- a/gtk3-sys/src/lib.rs
+++ b/gtk3-sys/src/lib.rs
@@ -2232,7 +2232,7 @@ extern "C" {
     pub fn gtk_level_bar_get_inverted          (bar: *mut C_GtkLevelBar) -> Gboolean;
     pub fn gtk_level_bar_add_offset_value      (bar: *mut C_GtkLevelBar, name: *const c_char, value: c_double) -> ();
     pub fn gtk_level_bar_remove_offset_value   (bar: *mut C_GtkLevelBar, name: *const c_char) -> ();
-    pub fn gtk_level_bar_get_offset_value      (bar: *mut C_GtkLevelBar, name: *const c_char, value: *const c_double) -> Gboolean;
+    pub fn gtk_level_bar_get_offset_value      (bar: *mut C_GtkLevelBar, name: *const c_char, value: *mut c_double) -> Gboolean;
 
     //=========================================================================
     // GtkSearchBar
@@ -2776,7 +2776,7 @@ extern "C" {
     //=========================================================================
     pub fn gtk_editable_select_region        (editable: *mut C_GtkEditable, start_pos: c_int, end_pos: c_int);
     pub fn gtk_editable_get_selection_bounds (editable: *mut C_GtkEditable, start_pos: *mut c_int, end_pos: *mut c_int) -> Gboolean;
-    pub fn gtk_editable_insert_text          (editable: *mut C_GtkEditable, new_text: *const c_char, new_text_length: c_int, position: c_int);
+    pub fn gtk_editable_insert_text          (editable: *mut C_GtkEditable, new_text: *const c_char, new_text_length: c_int, position: *mut c_int);
     pub fn gtk_editable_delete_text          (editable: *mut C_GtkEditable, start_pos: c_int, end_pos: c_int);
     pub fn gtk_editable_get_chars            (editable: *mut C_GtkEditable, start_pos: c_int, end_pos: c_int) -> *const c_char;
     pub fn gtk_editable_cut_clipboard        (editable: *mut C_GtkEditable);

--- a/src/cairo/context.rs
+++ b/src/cairo/context.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 use c_vec::CVec;
 use std::ptr::Unique;
 use std::mem::transmute;
@@ -539,9 +539,8 @@ impl Context {
 
     pub fn select_font_face(&self, family: &str, slant: FontSlant, weight: FontWeight){
         unsafe {
-            let c_str = CString::from_slice(family.as_bytes());
-
-            ffi::cairo_select_font_face(self.get_ptr(), c_str.as_ptr(), slant, weight)
+            let mut tmp_family = family.to_tmp_for_borrow();
+            ffi::cairo_select_font_face(self.get_ptr(), tmp_family.to_glib_ptr(), slant, weight)
         }
     }
 
@@ -606,9 +605,8 @@ impl Context {
 
     pub fn show_text(&self, text: &str){
         unsafe {
-            let c_str = CString::from_slice(text.as_bytes());
-
-            ffi::cairo_show_text(self.get_ptr(), c_str.as_ptr())
+            let mut tmp_text = text.to_tmp_for_borrow();
+            ffi::cairo_show_text(self.get_ptr(), tmp_text.to_glib_ptr())
         }
     }
 
@@ -627,10 +625,10 @@ impl Context {
         unsafe {
             let glyphs: &[Glyph] = glyph_vec.as_slice();
             let clusters: &[TextCluster] = cluster_vec.as_slice();
-            let c_str = CString::from_slice(text.as_bytes());
+            let mut tmp_text = text.to_tmp_for_borrow();
 
                 ffi::cairo_show_text_glyphs(self.get_ptr(),
-                                            c_str.as_ptr(),
+                                            tmp_text.to_glib_ptr(),
                                             -1 as c_int, //NUL terminated
                                             glyphs.as_ptr(),
                                             glyphs.len() as c_int,
@@ -667,9 +665,8 @@ impl Context {
         };
 
         unsafe {
-            let c_str = CString::from_slice(text.as_bytes());
-
-            ffi::cairo_text_extents(self.get_ptr(), c_str.as_ptr(), &mut extents);
+            let mut tmp_text = text.to_tmp_for_borrow();
+            ffi::cairo_text_extents(self.get_ptr(), tmp_text.to_glib_ptr(), &mut extents);
         }
         extents
     }
@@ -784,9 +781,8 @@ impl Context {
 
     pub fn text_path(&self, str_: &str){
         unsafe {
-            let c_str = CString::from_slice(str_.as_bytes());
-
-            ffi::cairo_text_path(self.get_ptr(), c_str.as_ptr())
+            let mut tmp_str_ = str_.to_tmp_for_borrow();
+            ffi::cairo_text_path(self.get_ptr(), tmp_str_.to_glib_ptr())
         }
     }
 

--- a/src/cairo/fonts.rs
+++ b/src/cairo/fonts.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 use std::clone::Clone;
 use std::cmp::PartialEq;
 use std::ops::Drop;
@@ -202,13 +202,8 @@ impl FontFace {
 
     pub fn toy_get_family(&self) -> Option<String> {
         unsafe {
-            let ptr = ffi::cairo_toy_font_face_get_family(self.get_ptr());
-
-            if ptr.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&ptr)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::cairo_toy_font_face_get_family(self.get_ptr()))
         }
     }
 

--- a/src/cairo/fonts.rs
+++ b/src/cairo/fonts.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 use std::clone::Clone;
 use std::cmp::PartialEq;
 use std::ops::Drop;
@@ -192,9 +192,8 @@ impl FontFace {
     pub fn toy_create(family: &str, slant: FontSlant, weight: FontWeight) -> FontFace {
         let font_face = FontFace(
             unsafe {
-                let c_str = CString::from_slice(family.as_bytes());
-
-                ffi::cairo_toy_font_face_create(c_str.as_ptr(), slant, weight)
+                let mut tmp_family = family.to_tmp_for_borrow();
+                ffi::cairo_toy_font_face_create(tmp_family.to_glib_ptr(), slant, weight)
             }
         );
         font_face.ensure_status();

--- a/src/gdk/keys.rs
+++ b/src/gdk/keys.rs
@@ -15,18 +15,14 @@
 
 //! Keyboard Handling Functions
 
+use glib::translate::FromGlibPtr;
 use gdk::ffi;
-use std::ffi::CStr;
 use libc::{c_uint, c_char};
 
 pub fn keyval_name(keyval: u32) -> Option<String> {
-    let tmp = unsafe { ffi::gdk_keyval_name(keyval as c_uint) as *const c_char };
-
-    if tmp.is_null() {
-        None
-    } else {
-        unsafe {
-            return Some(String::from_utf8_lossy(CStr::from_ptr(tmp).to_bytes()).into_owned());
-        }
+    unsafe {
+        FromGlibPtr::borrow(
+            ffi::gdk_keyval_name(keyval as c_uint) as *const c_char
+        )
     }
 }

--- a/src/gdk/rt.rs
+++ b/src/gdk/rt.rs
@@ -16,8 +16,8 @@
 //! General — Library initialization and miscellaneous functions
 
 use std::ptr;
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 use gdk::ffi;
-use std::ffi::CString;
 
 pub fn init() {
     unsafe { ffi::gdk_init(ptr::null_mut(), ptr::null_mut()) }
@@ -32,12 +32,9 @@ pub fn parse_args(argc: *mut c_int, argv: *mut *mut *mut c_char) {
 }*/
 
 pub fn get_display_arg_name() -> Option<String> {
-    let tmp = unsafe { ffi::gdk_get_display_arg_name() };
-
-    if tmp.is_null() {
-        None
-    } else {
-        unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp)).to_string()) }
+    unsafe {
+        FromGlibPtr::borrow(
+            ffi::gdk_get_display_arg_name())
     }
 }
 
@@ -47,17 +44,15 @@ pub fn notify_startup_complete() {
 
 pub fn notify_startup_complete_with_id(startup_id: &str) {
     unsafe {
-        let c_str = CString::from_slice(startup_id.as_bytes());
-
-        ffi::gdk_notify_startup_complete_with_id(c_str.as_ptr())
+        let mut tmp_startup_id = startup_id.to_tmp_for_borrow();
+        ffi::gdk_notify_startup_complete_with_id(tmp_startup_id.to_glib_ptr());
     }
 }
 
 pub fn set_allowed_backends(backends: &str) {
     unsafe {
-        let c_str = CString::from_slice(backends.as_bytes());
-
-        ffi::gdk_set_allowed_backends(c_str.as_ptr())
+        let mut tmp_backends = backends.to_tmp_for_borrow();
+        ffi::gdk_set_allowed_backends(tmp_backends.to_glib_ptr())
     }
 }
 
@@ -73,9 +68,8 @@ pub fn get_program_class() -> Option<String> {
 
 pub fn set_program_class(program_class: &str) {
     unsafe {
-        let c_str = CString::from_slice(program_class.as_bytes());
-
-        ffi::gdk_set_program_class(c_str.as_ptr())
+        let mut tmp_program_class = program_class.to_tmp_for_borrow();
+        ffi::gdk_set_program_class(tmp_program_class.to_glib_ptr())
     }
 }
 

--- a/src/gdk/rt.rs
+++ b/src/gdk/rt.rs
@@ -57,12 +57,9 @@ pub fn set_allowed_backends(backends: &str) {
 }
 
 pub fn get_program_class() -> Option<String> {
-    let tmp = unsafe { ffi::gdk_get_program_class() };
-
-    if tmp.is_null() {
-        None
-    } else {
-        unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp)).to_string()) }
+    unsafe {
+        FromGlibPtr::borrow(
+            ffi::gdk_get_program_class())
     }
 }
 

--- a/src/gdk/widgets/app_launch_context.rs
+++ b/src/gdk/widgets/app_launch_context.rs
@@ -17,7 +17,7 @@
 
 use gdk::{self, ffi};
 use libc::c_int;
-use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 
 // FIXME: should inherit from GAppLaunchContext
 #[repr(C)]
@@ -45,9 +45,8 @@ impl AppLaunchContext {
 
     pub fn set_icon_name(&self, icon_name: &str) {
         unsafe {
-            let c_str = CString::from_slice(icon_name.as_bytes());
-
-            ffi::gdk_app_launch_context_set_icon_name(self.pointer, c_str.as_ptr())
+            let mut tmp_icon_name = icon_name.to_tmp_for_borrow();
+            ffi::gdk_app_launch_context_set_icon_name(self.pointer, tmp_icon_name.to_glib_ptr())
         }
     }
 }

--- a/src/gdk/widgets/atom.rs
+++ b/src/gdk/widgets/atom.rs
@@ -14,8 +14,8 @@
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
 use gdk::ffi;
-use glib::translate::{ToGlibPtr, ToTmp};
-use libc::{c_char, c_void};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use libc::{c_char};
 
 #[derive(Copy)]
 pub struct Atom {
@@ -59,19 +59,10 @@ impl Atom {
         }
     }
 
-    // FIXME : tmp pointer should be freed
     pub fn name(&self) -> Option<String> {
-        let tmp = unsafe { ffi::gdk_atom_name(self.pointer) as *const c_char };
-
-        if tmp.is_null() {
-            None
-        } else {
-            unsafe {
-                let ret = Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp)).to_string());
-
-                ::libc::funcs::c95::stdlib::free(tmp as *mut c_void);
-                ret
-            }
+        unsafe {
+            FromGlibPtr::take(
+                ffi::gdk_atom_name(self.pointer) as *const c_char)
         }
     }
 

--- a/src/gdk/widgets/atom.rs
+++ b/src/gdk/widgets/atom.rs
@@ -14,7 +14,7 @@
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
 use gdk::ffi;
-use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 use libc::{c_char, c_void};
 
 #[derive(Copy)]
@@ -31,9 +31,8 @@ impl Atom {
 
     pub fn intern(atom_name: &str, only_if_exists: bool) -> Option<Atom> {
         let tmp = unsafe {
-            let c_str = CString::from_slice(atom_name.as_bytes());
-
-            ffi::gdk_atom_intern(c_str.as_ptr(), ::glib::to_gboolean(only_if_exists))
+            let mut tmp_atom_name = atom_name.to_tmp_for_borrow();
+            ffi::gdk_atom_intern(tmp_atom_name.to_glib_ptr(), ::glib::to_gboolean(only_if_exists))
         };
 
         if tmp.is_null() {
@@ -47,9 +46,8 @@ impl Atom {
 
     pub fn intern_static_string(atom_name: &str) -> Option<Atom> {
         let tmp = unsafe {
-            let c_str = CString::from_slice(atom_name.as_bytes());
-
-            ffi::gdk_atom_intern_static_string(c_str.as_ptr())
+            let mut tmp_atom_name = atom_name.to_tmp_for_borrow();
+            ffi::gdk_atom_intern_static_string(tmp_atom_name.to_glib_ptr())
         };
 
         if tmp.is_null() {

--- a/src/gdk/widgets/cursor.rs
+++ b/src/gdk/widgets/cursor.rs
@@ -16,7 +16,7 @@
 //! Cursors — Standard and pixmap cursors
 
 use gdk::{self, ffi};
-use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 //use libc::{c_int};
 
 #[repr(C)]
@@ -52,9 +52,8 @@ impl Cursor {
 
     pub fn new_from_name(display: &gdk::Display, name: &str) -> Option<Cursor> {
         let tmp = unsafe {
-            let c_str = CString::from_slice(name.as_bytes());
-
-            ffi::gdk_cursor_new_from_name(display.unwrap_pointer(), c_str.as_ptr())
+            let mut tmp_name = name.to_tmp_for_borrow();
+            ffi::gdk_cursor_new_from_name(display.unwrap_pointer(), tmp_name.to_glib_ptr())
         };
 
         if tmp.is_null() {

--- a/src/gdk/widgets/device.rs
+++ b/src/gdk/widgets/device.rs
@@ -18,6 +18,7 @@
 use gdk::{self, ffi};
 use libc::{c_uint};
 use glib::to_bool;
+use glib::translate::{FromGlibPtr};
 
 #[repr(C)]
 #[derive(Copy)]
@@ -27,12 +28,9 @@ pub struct Device {
 
 impl Device {
     pub fn get_name(&self) -> Option<String> {
-        let tmp = unsafe { ffi::gdk_device_get_name(self.pointer) };
-
-        if tmp.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gdk_device_get_name(self.pointer))
         }
     }
 

--- a/src/gdk/widgets/display.rs
+++ b/src/gdk/widgets/display.rs
@@ -17,7 +17,7 @@
 
 use gdk::{self, ffi};
 use libc::{c_uint};
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 use glib::to_bool;
 
 #[repr(C)]
@@ -55,12 +55,9 @@ impl Display {
     }
 
     pub fn get_name(&self) -> Option<String> {
-        let tmp = unsafe { ffi::gdk_display_get_name(self.pointer) };
-
-        if tmp.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gdk_display_get_name(self.pointer))
         }
     }
 

--- a/src/gdk/widgets/display.rs
+++ b/src/gdk/widgets/display.rs
@@ -17,7 +17,7 @@
 
 use gdk::{self, ffi};
 use libc::{c_uint};
-use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 use glib::to_bool;
 
 #[repr(C)]
@@ -29,9 +29,8 @@ pub struct Display {
 impl Display {
     pub fn open(display_name: &str) -> Option<Display> {
         let tmp = unsafe {
-            let c_str = CString::from_slice(display_name.as_bytes());
-
-            ffi::gdk_display_open(c_str.as_ptr())
+            let mut tmp_display_name = display_name.to_tmp_for_borrow();
+            ffi::gdk_display_open(tmp_display_name.to_glib_ptr())
         };
 
         if tmp.is_null() {
@@ -222,9 +221,8 @@ impl Display {
 
     pub fn notify_startup_complete(&self, startup_id: &str) {
         unsafe {
-            let c_str = CString::from_slice(startup_id.as_bytes());
-
-            ffi::gdk_display_notify_startup_complete(self.pointer, c_str.as_ptr())
+            let mut tmp_startup_id = startup_id.to_tmp_for_borrow();
+            ffi::gdk_display_notify_startup_complete(self.pointer, tmp_startup_id.to_glib_ptr())
         }
     }
 }

--- a/src/gdk/widgets/display_manager.rs
+++ b/src/gdk/widgets/display_manager.rs
@@ -16,7 +16,7 @@
 //! GdkDisplayManager — Maintains a list of all open GdkDisplays
 
 use gdk::{self, ffi};
-use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 
 #[repr(C)]
 #[derive(Copy)]
@@ -53,9 +53,8 @@ impl DisplayManager {
 
     pub fn open_display(&self, name: &str) -> Option<gdk::Display> {
         let tmp = unsafe {
-            let c_str = CString::from_slice(name.as_bytes());
-
-            ffi::gdk_display_manager_open_display(self.pointer, c_str.as_ptr())
+            let mut tmp_name = name.to_tmp_for_borrow();
+            ffi::gdk_display_manager_open_display(self.pointer, tmp_name.to_glib_ptr())
         };
 
         if tmp.is_null() {

--- a/src/gdk/widgets/pixbuf.rs
+++ b/src/gdk/widgets/pixbuf.rs
@@ -15,10 +15,10 @@
 
 /// The GdkPixbuf structure contains information that describes an image in memory.
 
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 use gdk::{self, ffi};
 use c_vec::CVec;
 use std::ptr::Unique;
-use std::ffi::CString;
 
 #[repr(C)]
 #[derive(Copy)]
@@ -75,16 +75,11 @@ impl Pixbuf {
     }
 
     pub fn get_option(&self, key: &str) -> Option<String> {
-        let tmp = unsafe {
-            let c_str = CString::from_slice(key.as_bytes());
-
-            ffi::gdk_pixbuf_get_option(self.pointer as *const ffi::C_GdkPixbuf, c_str.as_ptr())
-        };
-
-        if tmp.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp)).to_string()) }
+        unsafe {
+            let mut tmp_key = key.to_tmp_for_borrow();
+            FromGlibPtr::borrow(
+                ffi::gdk_pixbuf_get_option(self.pointer as *const ffi::C_GdkPixbuf,
+                                           tmp_key.to_glib_ptr()))
         }
     }
 

--- a/src/gdk/widgets/screen.rs
+++ b/src/gdk/widgets/screen.rs
@@ -15,8 +15,9 @@
 
 //! GdkScreen — Object representing a physical screen
 
+use glib::translate::{FromGlibPtr};
 use gdk::{self, ffi};
-use libc::{c_int, c_char, c_void};
+use libc::{c_int, c_char};
 
 #[repr(C)]
 #[derive(Copy)]
@@ -102,17 +103,9 @@ impl Screen {
     }
 
     pub fn make_display_name(&self) -> Option<String> {
-        let tmp = unsafe { ffi::gdk_screen_make_display_name(self.pointer) as *const c_char };
-
-        if tmp.is_null() {
-            None
-        } else {
-            unsafe {
-                let ret = Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp)).to_string());
-
-                ::libc::funcs::c95::stdlib::free(tmp as *mut c_void);
-                ret
-            }
+        unsafe {
+            FromGlibPtr::take(
+                ffi::gdk_screen_make_display_name(self.pointer) as *const c_char)
         }
     }
 
@@ -149,17 +142,10 @@ impl Screen {
     }
 
     pub fn get_monitor_plug_name(&self, monitor_num: i32) -> Option<String> {
-        let tmp = unsafe { ffi::gdk_screen_get_monitor_plug_name(self.pointer, monitor_num as c_int) as *const c_char };
-
-        if tmp.is_null() {
-            None
-        } else {
-            unsafe {
-                let ret = Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp)).to_string());
-
-                ::libc::funcs::c95::stdlib::free(tmp as *mut c_void);
-                ret
-            }
+        unsafe {
+            FromGlibPtr::take(
+                ffi::gdk_screen_get_monitor_plug_name(self.pointer,
+                                                      monitor_num as c_int) as *const c_char)
         }
     }
 

--- a/src/gdk/widgets/window.rs
+++ b/src/gdk/widgets/window.rs
@@ -19,7 +19,7 @@ use gdk::{self, ffi};
 use libc::{c_int};
 use std::ffi::CString;
 use std::ptr;
-use glib::translate::{StackBox, ToGlib, ToGlibPtr, ToTemp, from_glib};
+use glib::translate::{StackBox, ToGlib, ToGlibPtr, ToTmp, from_glib};
 
 /// Attributes to use for a newly-created window.
 pub struct WindowAttr {
@@ -63,14 +63,14 @@ impl WindowAttr {
     }
 }
 
-impl <'a> ToTemp for &'a WindowAttr {
-    type Temp = StackBox<ffi::C_GdkWindowAttr, Option<CString>>;
+impl <'a> ToTmp for &'a WindowAttr {
+    type Tmp = StackBox<ffi::C_GdkWindowAttr, Option<CString>>;
 
-    fn to_temp_for_borrow(self) -> StackBox<ffi::C_GdkWindowAttr, Option<CString>> {
-        let mut title = self.title.to_temp_for_borrow();
+    fn to_tmp_for_borrow(self) -> StackBox<ffi::C_GdkWindowAttr, Option<CString>> {
+        let mut tmp_title = self.title.to_tmp_for_borrow();
 
         let attrs = ffi::C_GdkWindowAttr {
-            title: title.to_glib(),
+            title: tmp_title.to_glib(),
             event_mask: self.event_mask,
             x: self.x.unwrap_or(0),
             y: self.y.unwrap_or(0),
@@ -86,7 +86,7 @@ impl <'a> ToTemp for &'a WindowAttr {
             type_hint: self.type_hint.unwrap_or(gdk::WindowTypeHint::Normal),
         };
 
-        StackBox(attrs, title)
+        StackBox(attrs, tmp_title)
     }
 }
 
@@ -101,8 +101,8 @@ impl Window {
             Some(s) => s.unwrap_pointer(),
             None => ::std::ptr::null_mut()
         };
-        let mut attrs = attributes.to_temp_for_borrow();
-        let tmp = unsafe { ffi::gdk_window_new(t_parent, attrs.to_glib(), attributes.get_mask()) };
+        let mut tmp_attributes = attributes.to_tmp_for_borrow();
+        let tmp = unsafe { ffi::gdk_window_new(t_parent, tmp_attributes.to_glib(), attributes.get_mask()) };
 
         if tmp.is_null() {
             None
@@ -424,8 +424,8 @@ impl Window {
 
     pub fn set_title(&self, title: &str) {
         unsafe {
-            let mut title = title.to_temp_for_borrow();
-            ffi::gdk_window_set_title(self.pointer, title.to_glib())
+            let mut tmp_title = title.to_tmp_for_borrow();
+            ffi::gdk_window_set_title(self.pointer, tmp_title.to_glib())
         }
     }
 
@@ -587,8 +587,8 @@ impl Window {
 
     pub fn set_icon_name(&self, name: &str) {
         unsafe {
-            let mut name = name.to_temp_for_borrow();
-            ffi::gdk_window_set_icon_name(self.pointer, name.to_glib())
+            let mut tmp_name = name.to_tmp_for_borrow();
+            ffi::gdk_window_set_icon_name(self.pointer, tmp_name.to_glib())
         }
     }
 
@@ -598,15 +598,15 @@ impl Window {
 
     pub fn set_role(&self, role: &str) {
         unsafe {
-            let mut role = role.to_temp_for_borrow();
-            ffi::gdk_window_set_role(self.pointer, role.to_glib())
+            let mut tmp_role = role.to_tmp_for_borrow();
+            ffi::gdk_window_set_role(self.pointer, tmp_role.to_glib())
         }
     }
 
     pub fn set_startup_id(&self, startup_id: &str) {
         unsafe {
-            let mut startup_id = startup_id.to_temp_for_borrow();
-            ffi::gdk_window_set_startup_id(self.pointer, startup_id.to_glib())
+            let mut tmp_startup_id = startup_id.to_tmp_for_borrow();
+            ffi::gdk_window_set_startup_id(self.pointer, tmp_startup_id.to_glib())
         }
     }
 

--- a/src/gdk/widgets/window.rs
+++ b/src/gdk/widgets/window.rs
@@ -70,7 +70,7 @@ impl <'a> ToTmp for &'a WindowAttr {
         let mut tmp_title = self.title.to_tmp_for_borrow();
 
         let attrs = ffi::C_GdkWindowAttr {
-            title: tmp_title.to_glib(),
+            title: tmp_title.to_glib_ptr(),
             event_mask: self.event_mask,
             x: self.x.unwrap_or(0),
             y: self.y.unwrap_or(0),
@@ -102,7 +102,7 @@ impl Window {
             None => ::std::ptr::null_mut()
         };
         let mut tmp_attributes = attributes.to_tmp_for_borrow();
-        let tmp = unsafe { ffi::gdk_window_new(t_parent, tmp_attributes.to_glib(), attributes.get_mask()) };
+        let tmp = unsafe { ffi::gdk_window_new(t_parent, tmp_attributes.to_glib_ptr(), attributes.get_mask()) };
 
         if tmp.is_null() {
             None
@@ -425,7 +425,7 @@ impl Window {
     pub fn set_title(&self, title: &str) {
         unsafe {
             let mut tmp_title = title.to_tmp_for_borrow();
-            ffi::gdk_window_set_title(self.pointer, tmp_title.to_glib())
+            ffi::gdk_window_set_title(self.pointer, tmp_title.to_glib_ptr())
         }
     }
 
@@ -588,7 +588,7 @@ impl Window {
     pub fn set_icon_name(&self, name: &str) {
         unsafe {
             let mut tmp_name = name.to_tmp_for_borrow();
-            ffi::gdk_window_set_icon_name(self.pointer, tmp_name.to_glib())
+            ffi::gdk_window_set_icon_name(self.pointer, tmp_name.to_glib_ptr())
         }
     }
 
@@ -599,14 +599,14 @@ impl Window {
     pub fn set_role(&self, role: &str) {
         unsafe {
             let mut tmp_role = role.to_tmp_for_borrow();
-            ffi::gdk_window_set_role(self.pointer, tmp_role.to_glib())
+            ffi::gdk_window_set_role(self.pointer, tmp_role.to_glib_ptr())
         }
     }
 
     pub fn set_startup_id(&self, startup_id: &str) {
         unsafe {
             let mut tmp_startup_id = startup_id.to_tmp_for_borrow();
-            ffi::gdk_window_set_startup_id(self.pointer, tmp_startup_id.to_glib())
+            ffi::gdk_window_set_startup_id(self.pointer, tmp_startup_id.to_glib_ptr())
         }
     }
 

--- a/src/gtk/rt.rs
+++ b/src/gtk/rt.rs
@@ -16,6 +16,7 @@
 use libc::c_uint;
 use std::ptr;
 use gtk::ffi;
+use glib::translate::{FromGlibPtr};
 use glib::{to_bool, to_gboolean};
 
 pub fn init() {
@@ -88,12 +89,8 @@ pub fn get_interface_age() -> u32 {
 }
 
 pub fn check_version(required_major: u32, required_minor: u32, required_micro: u32) -> Option<String> {
-    let c_str = unsafe { ffi::gtk_check_version(required_major as c_uint, required_minor as c_uint, required_micro as c_uint) };
-
-    
-    if c_str.is_null() {
-        None
-    } else {
-        unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&c_str)).to_string()) }
+    unsafe {
+        FromGlibPtr::borrow(
+            ffi::gtk_check_version(required_major as c_uint, required_minor as c_uint, required_micro as c_uint))
     }
  }

--- a/src/gtk/traits/actionable.rs
+++ b/src/gtk/traits/actionable.rs
@@ -15,7 +15,7 @@
 
 //! GtkActionable — An interface for widgets that can be associated with actions
 
-use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 use gtk::cast::GTK_ACTIONABLE;
 use gtk::{self, ffi};
 
@@ -34,17 +34,15 @@ pub trait ActionableTrait: gtk::WidgetTrait {
 
     fn set_action_name(&self, action_name: &str) {
         unsafe {
-            let c_str = CString::from_slice(action_name.as_bytes());
-
-            ffi::gtk_actionable_set_action_name(GTK_ACTIONABLE(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_action_name = action_name.to_tmp_for_borrow();
+            ffi::gtk_actionable_set_action_name(GTK_ACTIONABLE(self.unwrap_widget()), tmp_action_name.to_glib_ptr())
         }
     }
 
     fn set_detailed_action_name(&self, detailed_action_name: &str) {
         unsafe {
-            let c_str = CString::from_slice(detailed_action_name.as_bytes());
-
-            ffi::gtk_actionable_set_detailed_action_name(GTK_ACTIONABLE(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_detailed_action_name = detailed_action_name.to_tmp_for_borrow();
+            ffi::gtk_actionable_set_detailed_action_name(GTK_ACTIONABLE(self.unwrap_widget()), tmp_detailed_action_name.to_glib_ptr())
         }
     }
 }

--- a/src/gtk/traits/actionable.rs
+++ b/src/gtk/traits/actionable.rs
@@ -15,20 +15,15 @@
 
 //! GtkActionable — An interface for widgets that can be associated with actions
 
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 use gtk::cast::GTK_ACTIONABLE;
 use gtk::{self, ffi};
 
 pub trait ActionableTrait: gtk::WidgetTrait {
     fn get_action_name(&self) -> Option<String> {
         unsafe {
-            let tmp_pointer = ffi::gtk_actionable_get_action_name(GTK_ACTIONABLE(self.unwrap_widget()));
-
-            if tmp_pointer.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp_pointer)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_actionable_get_action_name(GTK_ACTIONABLE(self.unwrap_widget())))
         }
     }
 

--- a/src/gtk/traits/app_chooser.rs
+++ b/src/gtk/traits/app_chooser.rs
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
+use glib::translate::{FromGlibPtr};
 use gtk::{self, ffi};
 use gtk::cast::GTK_APP_CHOOSER;
 
@@ -28,12 +29,9 @@ pub trait AppChooserTrait: gtk::WidgetTrait {
     }
 
     fn get_content_info(&self) -> Option<String> {
-        let tmp_pointer = unsafe { ffi::gtk_app_chooser_get_content_type(GTK_APP_CHOOSER(self.unwrap_widget())) };
-
-        if tmp_pointer.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp_pointer)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gtk_app_chooser_get_content_type(GTK_APP_CHOOSER(self.unwrap_widget())))
         }
     }
 

--- a/src/gtk/traits/button.rs
+++ b/src/gtk/traits/button.rs
@@ -15,7 +15,8 @@
 
 use std::mem;
 use libc::c_float;
-use std::ffi::{CString};
+use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 
 use gtk::{ReliefStyle, PositionType};
 use gtk::cast::GTK_BUTTON;
@@ -79,9 +80,8 @@ pub trait ButtonTrait: gtk::WidgetTrait + gtk::ContainerTrait {
 
     fn set_label(&mut self, label: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(label.as_bytes());
-
-            ffi::gtk_button_set_label(GTK_BUTTON(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_label = label.to_tmp_for_borrow();
+            ffi::gtk_button_set_label(GTK_BUTTON(self.unwrap_widget()), tmp_label.to_glib_ptr())
         }
     }
 

--- a/src/gtk/traits/button.rs
+++ b/src/gtk/traits/button.rs
@@ -15,7 +15,6 @@
 
 use std::mem;
 use libc::c_float;
-use std::ffi::CString;
 use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 
 use gtk::{ReliefStyle, PositionType};
@@ -149,11 +148,11 @@ pub trait ButtonTrait: gtk::WidgetTrait + gtk::ContainerTrait {
 
     fn connect_clicked_signal(&self, handler: Box<ButtonClickedHandler>) {
         let data = unsafe { mem::transmute::<Box<Box<ButtonClickedHandler>>, ffi::gpointer>(Box::new(handler)) };
-        let c_str = CString::from_slice("clicked".as_bytes());
+        let mut tmp_name = "clicked".to_tmp_for_borrow();
 
         unsafe {
             ffi::g_signal_connect_data(self.unwrap_widget() as ffi::gpointer,
-                                       c_str.as_ptr(),
+                                       tmp_name.to_glib_ptr(),
                                        Some(mem::transmute(widget_destroy_callback)),
                                        data,
                                        Some(drop_widget_destroy_handler as extern "C" fn(ffi::gpointer, *const ffi::C_GClosure)),

--- a/src/gtk/traits/button.rs
+++ b/src/gtk/traits/button.rs
@@ -16,7 +16,7 @@
 use std::mem;
 use libc::c_float;
 use std::ffi::CString;
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 
 use gtk::{ReliefStyle, PositionType};
 use gtk::cast::GTK_BUTTON;
@@ -68,13 +68,8 @@ pub trait ButtonTrait: gtk::WidgetTrait + gtk::ContainerTrait {
 
     fn get_label(&self) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_button_get_label(GTK_BUTTON(self.unwrap_widget()));
-
-            if c_str.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&c_str)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_button_get_label(GTK_BUTTON(self.unwrap_widget())))
         }
     }
 

--- a/src/gtk/traits/cell_layout.rs
+++ b/src/gtk/traits/cell_layout.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 use gtk::{self, ffi};
 use gtk::cast::{GTK_CELL_LAYOUT, GTK_CELL_RENDERER};
 use glib;
@@ -68,11 +68,13 @@ pub trait CellLayoutTrait: gtk::WidgetTrait {
     }
 
     fn add_attribute<T: gtk::CellRendererTrait>(&self, cell: &T, attribute: &str, column: i32) {
-        let c_str = CString::from_slice(attribute.as_bytes());
-
         unsafe {
-                ffi::gtk_cell_layout_add_attribute(GTK_CELL_LAYOUT(self.unwrap_widget()), GTK_CELL_RENDERER(cell.unwrap_widget()),
-                    c_str.as_ptr(), column)
+            let mut tmp_attribute = attribute.to_tmp_for_borrow();
+            ffi::gtk_cell_layout_add_attribute(
+                GTK_CELL_LAYOUT(self.unwrap_widget()),
+                GTK_CELL_RENDERER(cell.unwrap_widget()),
+                tmp_attribute.to_glib_ptr(),
+                column)
             }
     }
 

--- a/src/gtk/traits/combo_box.rs
+++ b/src/gtk/traits/combo_box.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
 use gtk::cast::GTK_COMBO_BOX;
@@ -74,12 +74,9 @@ pub trait ComboBoxTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrait 
     }
 
     fn get_active_id(&self) -> Option<String> {
-        let tmp = unsafe { ffi::gtk_combo_box_get_active_id(GTK_COMBO_BOX(self.unwrap_widget())) };
-
-        if tmp.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gtk_combo_box_get_active_id(GTK_COMBO_BOX(self.unwrap_widget())))
         }
     }
 

--- a/src/gtk/traits/combo_box.rs
+++ b/src/gtk/traits/combo_box.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
 use gtk::cast::GTK_COMBO_BOX;
@@ -85,9 +85,8 @@ pub trait ComboBoxTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrait 
 
     fn set_active_id(&self, active_id: &str) -> bool {
         unsafe {
-            let c_str = CString::from_slice(active_id.as_bytes());
-
-            to_bool(ffi::gtk_combo_box_set_active_id(GTK_COMBO_BOX(self.unwrap_widget()), c_str.as_ptr()))
+            let mut tmp_active_id = active_id.to_tmp_for_borrow();
+            to_bool(ffi::gtk_combo_box_set_active_id(GTK_COMBO_BOX(self.unwrap_widget()), tmp_active_id.to_glib_ptr()))
         }
     }
 

--- a/src/gtk/traits/dialog.rs
+++ b/src/gtk/traits/dialog.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 use gtk::cast::GTK_DIALOG;
 use gtk::ffi;
 use gtk;
@@ -29,9 +29,8 @@ pub trait DialogTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrait + 
 
     fn add_button(&self, button_text: &str, response_id: i32) -> Option<gtk::Button> {
         let tmp_pointer = unsafe {
-            let c_str = CString::from_slice(button_text.as_bytes());
-
-            ffi::gtk_dialog_add_button(GTK_DIALOG(self.unwrap_widget()), c_str.as_ptr(), response_id)
+            let mut tmp_button_text = button_text.to_tmp_for_borrow();
+            ffi::gtk_dialog_add_button(GTK_DIALOG(self.unwrap_widget()), tmp_button_text.to_glib_ptr(), response_id)
         };
 
         if tmp_pointer.is_null() {

--- a/src/gtk/traits/editable.rs
+++ b/src/gtk/traits/editable.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::ffi::CString;
+use libc::{c_char, c_int};
 use gtk::cast::GTK_EDITABLE;
 use gtk::{self, ffi};
 use glib::translate::{FromGlibPtr};
@@ -40,13 +40,12 @@ pub trait EditableTrait: gtk::WidgetTrait {
         }
     }
 
-    fn insert_text(&mut self, new_text: &str, new_text_length: i32, position: i32) {
+    fn insert_text(&mut self, new_text: &str, position: &mut i32) {
         unsafe {
-            let c_str = CString::from_slice(new_text.as_bytes());
-
+            // Don't need a null-terminated string here
             ffi::gtk_editable_insert_text(GTK_EDITABLE(self.unwrap_widget()),
-                                              c_str.as_ptr(),
-                                              new_text_length,
+                                              new_text.as_ptr() as *const c_char,
+                                              new_text.len() as c_int,
                                               position)
         }
     }

--- a/src/gtk/traits/editable.rs
+++ b/src/gtk/traits/editable.rs
@@ -16,6 +16,7 @@
 use std::ffi::CString;
 use gtk::cast::GTK_EDITABLE;
 use gtk::{self, ffi};
+use glib::translate::{FromGlibPtr};
 use glib::{to_bool, to_gboolean};
 
 pub trait EditableTrait: gtk::WidgetTrait {
@@ -57,14 +58,9 @@ pub trait EditableTrait: gtk::WidgetTrait {
     }
 
     fn get_chars(&self, start_pos: i32, end_pos: i32) -> Option<String> {
-        let chars = unsafe {
-            ffi::gtk_editable_get_chars(GTK_EDITABLE(self.unwrap_widget()), start_pos, end_pos)
-        };
-
-        if chars.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&chars)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gtk_editable_get_chars(GTK_EDITABLE(self.unwrap_widget()), start_pos, end_pos))
         }
     }
 

--- a/src/gtk/traits/entry.rs
+++ b/src/gtk/traits/entry.rs
@@ -14,7 +14,7 @@
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
 use libc::{c_int, c_float, c_double};
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 use libc;
 
 use gtk::{EntryIconPosition, ImageType, InputPurpose, InputHints};
@@ -44,13 +44,8 @@ pub trait EntryTrait: gtk::WidgetTrait {
 
     fn get_text(&self) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_entry_get_text(GTK_ENTRY(self.unwrap_widget()));
-
-            if c_str.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&c_str)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_entry_get_text(GTK_ENTRY(self.unwrap_widget())))
         }
     }
 
@@ -137,13 +132,8 @@ pub trait EntryTrait: gtk::WidgetTrait {
 
     fn placeholder(&self) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_entry_get_placeholder_text(GTK_ENTRY(self.unwrap_widget()));
-
-            if c_str.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&c_str)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_entry_get_placeholder_text(GTK_ENTRY(self.unwrap_widget())))
         }
     }
 
@@ -257,25 +247,15 @@ pub trait EntryTrait: gtk::WidgetTrait {
 
     fn get_icon_stock(&self, icon_pos: EntryIconPosition) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_entry_get_icon_stock(GTK_ENTRY(self.unwrap_widget()), icon_pos);
-
-            if c_str.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&c_str)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_entry_get_icon_stock(GTK_ENTRY(self.unwrap_widget()), icon_pos))
         }
     }
 
     fn get_icon_name(&self, icon_pos: EntryIconPosition) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_entry_get_icon_name(GTK_ENTRY(self.unwrap_widget()), icon_pos);
-            
-            if c_str.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&c_str)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_entry_get_icon_name(GTK_ENTRY(self.unwrap_widget()), icon_pos))
         }
     }
 

--- a/src/gtk/traits/entry.rs
+++ b/src/gtk/traits/entry.rs
@@ -14,7 +14,7 @@
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
 use libc::{c_int, c_float, c_double};
-use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 use libc;
 
 use gtk::{EntryIconPosition, ImageType, InputPurpose, InputHints};
@@ -37,9 +37,8 @@ pub trait EntryTrait: gtk::WidgetTrait {
 
     fn set_text(&mut self, text: String) -> () {
         unsafe {
-            let c_str = CString::from_slice(text.as_bytes());
-
-            ffi::gtk_entry_set_text(GTK_ENTRY(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_text = text.to_tmp_for_borrow();
+            ffi::gtk_entry_set_text(GTK_ENTRY(self.unwrap_widget()), tmp_text.to_glib_ptr())
         }
     }
 
@@ -131,9 +130,8 @@ pub trait EntryTrait: gtk::WidgetTrait {
 
     fn set_placeholder(&mut self, text: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(text.as_bytes());
-
-            ffi::gtk_entry_set_placeholder_text(GTK_ENTRY(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_text = text.to_tmp_for_borrow();
+            ffi::gtk_entry_set_placeholder_text(GTK_ENTRY(self.unwrap_widget()), tmp_text.to_glib_ptr())
         }
     }
 
@@ -239,17 +237,15 @@ pub trait EntryTrait: gtk::WidgetTrait {
 
     fn set_icon_from_stock(&mut self, icon_pos: EntryIconPosition, stock_id: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(stock_id.as_bytes());
-
-            ffi::gtk_entry_set_icon_from_stock(GTK_ENTRY(self.unwrap_widget()), icon_pos, c_str.as_ptr());
+            let mut tmp_stock_id = stock_id.to_tmp_for_borrow();
+            ffi::gtk_entry_set_icon_from_stock(GTK_ENTRY(self.unwrap_widget()), icon_pos, tmp_stock_id.to_glib_ptr());
         }
     }
 
     fn set_icon_from_icon_name(&mut self, icon_pos: EntryIconPosition, icon_name: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(icon_name.as_bytes());
-
-            ffi::gtk_entry_set_icon_from_icon_name(GTK_ENTRY(self.unwrap_widget()), icon_pos, c_str.as_ptr())
+            let mut tmp_icon_name = icon_name.to_tmp_for_borrow();
+            ffi::gtk_entry_set_icon_from_icon_name(GTK_ENTRY(self.unwrap_widget()), icon_pos, tmp_icon_name.to_glib_ptr())
         }
     }
 
@@ -307,9 +303,8 @@ pub trait EntryTrait: gtk::WidgetTrait {
 
     fn set_icon_tooltip_text(&mut self, icon_pos: EntryIconPosition, tooltip: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(tooltip.as_bytes());
-
-            ffi::gtk_entry_set_icon_tooltip_text(GTK_ENTRY(self.unwrap_widget()), icon_pos, c_str.as_ptr())
+            let mut tmp_tooltip = tooltip.to_tmp_for_borrow();
+            ffi::gtk_entry_set_icon_tooltip_text(GTK_ENTRY(self.unwrap_widget()), icon_pos, tmp_tooltip.to_glib_ptr())
         }
     }
 
@@ -329,9 +324,8 @@ pub trait EntryTrait: gtk::WidgetTrait {
 
     fn set_icon_tooltip_markup(&mut self, icon_pos: EntryIconPosition, tooltip: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(tooltip.as_bytes());
-
-            ffi::gtk_entry_set_icon_tooltip_markup(GTK_ENTRY(self.unwrap_widget()), icon_pos, c_str.as_ptr())
+            let mut tmp_tooltip = tooltip.to_tmp_for_borrow();
+            ffi::gtk_entry_set_icon_tooltip_markup(GTK_ENTRY(self.unwrap_widget()), icon_pos, tmp_tooltip.to_glib_ptr())
         }
     }
 

--- a/src/gtk/traits/entry.rs
+++ b/src/gtk/traits/entry.rs
@@ -15,7 +15,6 @@
 
 use libc::{c_int, c_float, c_double};
 use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
-use libc;
 
 use gtk::{EntryIconPosition, ImageType, InputPurpose, InputHints};
 use gtk::cast::GTK_ENTRY;
@@ -290,15 +289,9 @@ pub trait EntryTrait: gtk::WidgetTrait {
 
     fn get_icon_tooltip_text(&self, icon_pos: EntryIconPosition) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_entry_get_icon_tooltip_text(GTK_ENTRY(self.unwrap_widget()), icon_pos);
-            let ret = if c_str.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&c_str)).to_string())
-            };
-
-            ::libc::funcs::c95::stdlib::free(c_str as *mut libc::c_void);
-            ret
+            FromGlibPtr::take(
+                ffi::gtk_entry_get_icon_tooltip_text(GTK_ENTRY(self.unwrap_widget()),
+                                                     icon_pos))
         }
     }
 
@@ -311,15 +304,9 @@ pub trait EntryTrait: gtk::WidgetTrait {
 
     fn get_icon_tooltip_markup(&self, icon_pos: EntryIconPosition) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_entry_get_icon_tooltip_markup(GTK_ENTRY(self.unwrap_widget()), icon_pos);
-            let ret = if c_str.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&c_str)).to_string())
-            };
-
-            ::libc::funcs::c95::stdlib::free(c_str as *mut libc::c_void);
-            ret
+            FromGlibPtr::take(
+                ffi::gtk_entry_get_icon_tooltip_markup(GTK_ENTRY(self.unwrap_widget()),
+                                                       icon_pos))
         }
     }
 

--- a/src/gtk/traits/file_chooser.rs
+++ b/src/gtk/traits/file_chooser.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 use gtk::{self, FFIWidget};
 use gtk::cast::GTK_FILE_CHOOSER;
 use gtk::ffi;
@@ -79,13 +79,8 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
 
     fn get_current_name(&self) -> Option<String> {
         unsafe {
-            let name = ffi::gtk_file_chooser_get_current_name(GTK_FILE_CHOOSER(self.unwrap_widget()));
-
-            if name.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&name)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_file_chooser_get_current_name(GTK_FILE_CHOOSER(self.unwrap_widget())))
         }
     }
 
@@ -98,13 +93,8 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
 
     fn get_filename(&self) -> Option<String> {
         unsafe {
-            let filename = ffi::gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(self.unwrap_widget()));
-
-            if filename.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&filename)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(self.unwrap_widget())))
         }
     }
 
@@ -157,13 +147,8 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
 
     fn get_current_folder(&self) -> Option<String> {
         unsafe {
-            let filename = ffi::gtk_file_chooser_get_current_folder(GTK_FILE_CHOOSER(self.unwrap_widget()));
-
-            if filename.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&filename)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_file_chooser_get_current_folder(GTK_FILE_CHOOSER(self.unwrap_widget())))
         }
     }
 
@@ -176,13 +161,8 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
 
     fn get_uri(&self) -> Option<String> {
         unsafe {
-            let uri = ffi::gtk_file_chooser_get_uri(GTK_FILE_CHOOSER(self.unwrap_widget()));
-
-            if uri.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&uri)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_file_chooser_get_uri(GTK_FILE_CHOOSER(self.unwrap_widget())))
         }
     }
 
@@ -227,13 +207,8 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
 
     fn get_current_folder_uri(&self) -> Option<String> {
         unsafe {
-            let uri = ffi::gtk_file_chooser_get_current_folder_uri(GTK_FILE_CHOOSER(self.unwrap_widget()));
-
-            if uri.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&uri)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_file_chooser_get_current_folder_uri(GTK_FILE_CHOOSER(self.unwrap_widget())))
         }
     }
 
@@ -271,25 +246,15 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
 
     fn get_preview_filename(&self) -> Option<String> {
         unsafe {
-            let filename = ffi::gtk_file_chooser_get_preview_filename(GTK_FILE_CHOOSER(self.unwrap_widget()));
-
-            if filename.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&filename)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_file_chooser_get_preview_filename(GTK_FILE_CHOOSER(self.unwrap_widget())))
         }
     }
 
     fn get_preview_uri(&self) -> Option<String> {
         unsafe {
-            let uri = ffi::gtk_file_chooser_get_preview_uri(GTK_FILE_CHOOSER(self.unwrap_widget()));
-
-            if uri.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&uri)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_file_chooser_get_preview_uri(GTK_FILE_CHOOSER(self.unwrap_widget())))
         }
     }
 

--- a/src/gtk/traits/file_chooser.rs
+++ b/src/gtk/traits/file_chooser.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 use gtk::{self, FFIWidget};
 use gtk::cast::GTK_FILE_CHOOSER;
 use gtk::ffi;
@@ -72,9 +72,8 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
 
     fn set_current_name(&self, name: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(name.as_bytes());
-
-            ffi::gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_name = name.to_tmp_for_borrow();
+            ffi::gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(self.unwrap_widget()), tmp_name.to_glib_ptr())
         }
     }
 
@@ -92,9 +91,8 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
 
     fn set_filename(&self, filename: &str) -> bool {
         unsafe {
-            let c_str = CString::from_slice(filename.as_bytes());
-
-            to_bool(ffi::gtk_file_chooser_set_filename(GTK_FILE_CHOOSER(self.unwrap_widget()), c_str.as_ptr()))
+            let mut tmp_filename = filename.to_tmp_for_borrow();
+            to_bool(ffi::gtk_file_chooser_set_filename(GTK_FILE_CHOOSER(self.unwrap_widget()), tmp_filename.to_glib_ptr()))
         }
     }
 
@@ -112,17 +110,15 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
 
     fn select_filename(&self, filename: &str) -> bool {
         unsafe {
-            let c_str = CString::from_slice(filename.as_bytes());
-
-            to_bool(ffi::gtk_file_chooser_select_filename(GTK_FILE_CHOOSER(self.unwrap_widget()), c_str.as_ptr()))
+            let mut tmp_filename = filename.to_tmp_for_borrow();
+            to_bool(ffi::gtk_file_chooser_select_filename(GTK_FILE_CHOOSER(self.unwrap_widget()), tmp_filename.to_glib_ptr()))
         }
     }
 
     fn unselect_filename(&self, filename: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(filename.as_bytes());
-
-            ffi::gtk_file_chooser_unselect_filename(GTK_FILE_CHOOSER(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_filename = filename.to_tmp_for_borrow();
+            ffi::gtk_file_chooser_unselect_filename(GTK_FILE_CHOOSER(self.unwrap_widget()), tmp_filename.to_glib_ptr())
         }
     }
 
@@ -154,9 +150,8 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
 
     fn set_current_folder(&self, filename: &str) -> bool {
         unsafe {
-            let c_str = CString::from_slice(filename.as_bytes());
-
-            to_bool(ffi::gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(self.unwrap_widget()), c_str.as_ptr()))
+            let mut tmp_filename = filename.to_tmp_for_borrow();
+            to_bool(ffi::gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(self.unwrap_widget()), tmp_filename.to_glib_ptr()))
         }
     }
 
@@ -174,9 +169,8 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
 
     fn set_uri(&self, uri: &str) -> bool {
         unsafe {
-            let c_str = CString::from_slice(uri.as_bytes());
-
-            to_bool(ffi::gtk_file_chooser_set_uri(GTK_FILE_CHOOSER(self.unwrap_widget()), c_str.as_ptr()))
+            let mut tmp_uri = uri.to_tmp_for_borrow();
+            to_bool(ffi::gtk_file_chooser_set_uri(GTK_FILE_CHOOSER(self.unwrap_widget()), tmp_uri.to_glib_ptr()))
         }
     }
 
@@ -194,17 +188,15 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
 
     fn select_uri(&self, uri: &str) -> bool {
         unsafe {
-            let c_str = CString::from_slice(uri.as_bytes());
-
-            to_bool(ffi::gtk_file_chooser_select_uri(GTK_FILE_CHOOSER(self.unwrap_widget()), c_str.as_ptr()))
+            let mut tmp_uri = uri.to_tmp_for_borrow();
+            to_bool(ffi::gtk_file_chooser_select_uri(GTK_FILE_CHOOSER(self.unwrap_widget()), tmp_uri.to_glib_ptr()))
         }
     }
 
     fn unselect_uri(&self, uri: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(uri.as_bytes());
-
-            ffi::gtk_file_chooser_unselect_uri(GTK_FILE_CHOOSER(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_uri = uri.to_tmp_for_borrow();
+            ffi::gtk_file_chooser_unselect_uri(GTK_FILE_CHOOSER(self.unwrap_widget()), tmp_uri.to_glib_ptr())
         }
     }
 
@@ -228,9 +220,8 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
 
     fn set_current_folder_uri(&self, uri: &str) -> bool {
         unsafe {
-            let c_str = CString::from_slice(uri.as_bytes());
-
-            to_bool(ffi::gtk_file_chooser_set_current_folder_uri(GTK_FILE_CHOOSER(self.unwrap_widget()), c_str.as_ptr()))
+            let mut tmp_uri = uri.to_tmp_for_borrow();
+            to_bool(ffi::gtk_file_chooser_set_current_folder_uri(GTK_FILE_CHOOSER(self.unwrap_widget()), tmp_uri.to_glib_ptr()))
         }
     }
 
@@ -338,33 +329,29 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
 
     fn add_shortcut_folder(&self, folder: &str, error: &mut glib::Error) -> bool {
         unsafe {
-            let c_str = CString::from_slice(folder.as_bytes());
-
-            to_bool(ffi::gtk_file_chooser_add_shortcut_folder(GTK_FILE_CHOOSER(self.unwrap_widget()), c_str.as_ptr(), &mut error.unwrap()))
+            let mut tmp_folder = folder.to_tmp_for_borrow();
+            to_bool(ffi::gtk_file_chooser_add_shortcut_folder(GTK_FILE_CHOOSER(self.unwrap_widget()), tmp_folder.to_glib_ptr(), &mut error.unwrap()))
         }
     }
 
     fn remove_shortcut_folder(&self, folder: &str, error: &mut glib::Error) -> bool {
         unsafe {
-            let c_str = CString::from_slice(folder.as_bytes());
-
-            to_bool(ffi::gtk_file_chooser_remove_shortcut_folder(GTK_FILE_CHOOSER(self.unwrap_widget()), c_str.as_ptr(), &mut error.unwrap()))
+            let mut tmp_folder = folder.to_tmp_for_borrow();
+            to_bool(ffi::gtk_file_chooser_remove_shortcut_folder(GTK_FILE_CHOOSER(self.unwrap_widget()), tmp_folder.to_glib_ptr(), &mut error.unwrap()))
         }
     }
 
     fn add_shortcut_folder_uri(&self, uri: &str, error: &mut glib::Error) -> bool {
         unsafe {
-            let c_str = CString::from_slice(uri.as_bytes());
-
-            to_bool(ffi::gtk_file_chooser_add_shortcut_folder(GTK_FILE_CHOOSER(self.unwrap_widget()), c_str.as_ptr(), &mut error.unwrap()))
+            let mut tmp_uri = uri.to_tmp_for_borrow();
+            to_bool(ffi::gtk_file_chooser_add_shortcut_folder(GTK_FILE_CHOOSER(self.unwrap_widget()), tmp_uri.to_glib_ptr(), &mut error.unwrap()))
         }
     }
 
     fn remove_shortcut_folder_uri(&self, uri: &str, error: &mut glib::Error) -> bool {
         unsafe {
-            let c_str = CString::from_slice(uri.as_bytes());
-
-            to_bool(ffi::gtk_file_chooser_remove_shortcut_folder(GTK_FILE_CHOOSER(self.unwrap_widget()), c_str.as_ptr(), &mut error.unwrap()))
+            let mut tmp_uri = uri.to_tmp_for_borrow();
+            to_bool(ffi::gtk_file_chooser_remove_shortcut_folder(GTK_FILE_CHOOSER(self.unwrap_widget()), tmp_uri.to_glib_ptr(), &mut error.unwrap()))
         }
     }
 }

--- a/src/gtk/traits/font_chooser.rs
+++ b/src/gtk/traits/font_chooser.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 use gtk::cast::{GTK_FONT_CHOOSER};
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
@@ -26,12 +26,9 @@ pub trait FontChooserTrait: gtk::WidgetTrait {
     }
 
     fn get_font(&self) -> Option<String> {
-        let tmp = unsafe { ffi::gtk_font_chooser_get_font(GTK_FONT_CHOOSER(self.unwrap_widget())) as *const c_char };
-
-        if tmp.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gtk_font_chooser_get_font(GTK_FONT_CHOOSER(self.unwrap_widget())) as *const c_char)
         }
     }
 
@@ -44,13 +41,9 @@ pub trait FontChooserTrait: gtk::WidgetTrait {
 
     fn get_preview_text(&self) -> Option<String> {
         unsafe {
-            let tmp = ffi::gtk_font_chooser_get_preview_text(GTK_FONT_CHOOSER(self.unwrap_widget()));
-
-            if tmp.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&(tmp as *const c_char))).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_font_chooser_get_preview_text(GTK_FONT_CHOOSER(self.unwrap_widget()))
+                    as *const c_char)
         }
     }
 

--- a/src/gtk/traits/font_chooser.rs
+++ b/src/gtk/traits/font_chooser.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 use gtk::cast::{GTK_FONT_CHOOSER};
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
@@ -37,9 +37,8 @@ pub trait FontChooserTrait: gtk::WidgetTrait {
 
     fn set_font(&self, font_name: &str) {
         unsafe {
-            let c_str = CString::from_slice(font_name.as_bytes());
-
-            ffi::gtk_font_chooser_set_font(GTK_FONT_CHOOSER(self.unwrap_widget()), c_str.as_ptr() as *mut c_char)
+            let mut tmp_font_name = font_name.to_tmp_for_borrow();
+            ffi::gtk_font_chooser_set_font(GTK_FONT_CHOOSER(self.unwrap_widget()), tmp_font_name.to_glib_ptr() as *mut c_char)
         }
     }
 
@@ -57,9 +56,8 @@ pub trait FontChooserTrait: gtk::WidgetTrait {
 
     fn set_preview_text(&self, text: &str) {
         unsafe {
-            let c_str = CString::from_slice(text.as_bytes());
-
-            ffi::gtk_font_chooser_set_preview_text(GTK_FONT_CHOOSER(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_text = text.to_tmp_for_borrow();
+            ffi::gtk_font_chooser_set_preview_text(GTK_FONT_CHOOSER(self.unwrap_widget()), tmp_text.to_glib_ptr())
         }
     }
 

--- a/src/gtk/traits/frame.rs
+++ b/src/gtk/traits/frame.rs
@@ -13,25 +13,20 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::ptr;
 use libc::c_float;
-use std::ffi::CString;
 
-use glib::translate::{FromGlibPtr};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 use gtk::ShadowType;
 use gtk::cast::GTK_FRAME;
 use gtk::{self, ffi};
 
 pub trait FrameTrait: gtk::WidgetTrait + gtk::ContainerTrait {
     fn set_label(&mut self, label: Option<&str>) -> () {
-        match label {
-            Some(l) => unsafe {
-                let c_str = CString::from_slice(l.as_bytes());
-
-                ffi::gtk_frame_set_label(GTK_FRAME(self.unwrap_widget()), c_str.as_ptr())
-            },
-            None    => unsafe { ffi::gtk_frame_set_label(GTK_FRAME(self.unwrap_widget()), ptr::null()) }
-        };
+        unsafe {
+            let mut tmp_label = label.to_tmp_for_borrow();
+            ffi::gtk_frame_set_label(GTK_FRAME(self.unwrap_widget()),
+                                     tmp_label.to_glib_ptr());
+        }
     }
 
     fn set_label_widget<T: gtk::WidgetTrait>(&mut self, label_widget: &T) -> () {

--- a/src/gtk/traits/frame.rs
+++ b/src/gtk/traits/frame.rs
@@ -17,6 +17,7 @@ use std::ptr;
 use libc::c_float;
 use std::ffi::CString;
 
+use glib::translate::{FromGlibPtr};
 use gtk::ShadowType;
 use gtk::cast::GTK_FRAME;
 use gtk::{self, ffi};
@@ -61,12 +62,9 @@ pub trait FrameTrait: gtk::WidgetTrait + gtk::ContainerTrait {
     }
 
     fn get_label(&self) -> Option<String> {
-        let c_str = unsafe { ffi::gtk_frame_get_label(GTK_FRAME(self.unwrap_widget())) };
-        
-        if c_str.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&c_str)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gtk_frame_get_label(GTK_FRAME(self.unwrap_widget())))
         }
     }
 

--- a/src/gtk/traits/label.rs
+++ b/src/gtk/traits/label.rs
@@ -14,7 +14,7 @@
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
 use libc::{c_int, c_double};
-use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
@@ -24,17 +24,15 @@ use gtk::cast::GTK_LABEL;
 pub trait LabelTrait: gtk::WidgetTrait {
     fn set_label(&mut self, text: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(text.as_bytes());
-
-            ffi::gtk_label_set_label(GTK_LABEL(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_text = text.to_tmp_for_borrow();
+            ffi::gtk_label_set_label(GTK_LABEL(self.unwrap_widget()), tmp_text.to_glib_ptr())
         }
     }
 
     fn set_text(&mut self, text: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(text.as_bytes());
-
-	    ffi::gtk_label_set_text(GTK_LABEL(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_text = text.to_tmp_for_borrow();
+	    ffi::gtk_label_set_text(GTK_LABEL(self.unwrap_widget()), tmp_text.to_glib_ptr())
         }
     }
 
@@ -46,33 +44,29 @@ pub trait LabelTrait: gtk::WidgetTrait {
 
     fn set_markup(&mut self, text: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(text.as_bytes());
-
-            ffi::gtk_label_set_markup(GTK_LABEL(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_text = text.to_tmp_for_borrow();
+            ffi::gtk_label_set_markup(GTK_LABEL(self.unwrap_widget()), tmp_text.to_glib_ptr())
         }
     }
 
     fn set_markup_with_mnemonic(&mut self, text: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(text.as_bytes());
-
-            ffi::gtk_label_set_markup_with_mnemonic(GTK_LABEL(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_text = text.to_tmp_for_borrow();
+            ffi::gtk_label_set_markup_with_mnemonic(GTK_LABEL(self.unwrap_widget()), tmp_text.to_glib_ptr())
         }
     }
 
     fn set_pattern(&mut self, text: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(text.as_bytes());
-
-            ffi::gtk_label_set_pattern(GTK_LABEL(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_text = text.to_tmp_for_borrow();
+            ffi::gtk_label_set_pattern(GTK_LABEL(self.unwrap_widget()), tmp_text.to_glib_ptr())
         }
     }
 
     fn set_text_with_mnemonic(&mut self, text: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(text.as_bytes());
-
-            ffi::gtk_label_set_text_with_mnemonic(GTK_LABEL(self.unwrap_widget()), c_str.as_ptr());
+            let mut tmp_text = text.to_tmp_for_borrow();
+            ffi::gtk_label_set_text_with_mnemonic(GTK_LABEL(self.unwrap_widget()), tmp_text.to_glib_ptr());
         }
     }
 

--- a/src/gtk/traits/label.rs
+++ b/src/gtk/traits/label.rs
@@ -14,7 +14,7 @@
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
 use libc::{c_int, c_double};
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
@@ -161,35 +161,22 @@ pub trait LabelTrait: gtk::WidgetTrait {
 
     fn get_text(&self) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_label_get_text(GTK_LABEL(self.unwrap_widget()));
-
-            if c_str.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&c_str)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_label_get_text(GTK_LABEL(self.unwrap_widget())))
         }
     }
 
     fn get_label(&self) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_label_get_label(GTK_LABEL(self.unwrap_widget()));
-            if c_str.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&c_str)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_label_get_label(GTK_LABEL(self.unwrap_widget())))
         }
     }
 
     fn get_current_uri(&self) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_label_get_current_uri(GTK_LABEL(self.unwrap_widget()));
-            if c_str.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&c_str)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_label_get_current_uri(GTK_LABEL(self.unwrap_widget())))
         }
     }
 

--- a/src/gtk/traits/menu_item.rs
+++ b/src/gtk/traits/menu_item.rs
@@ -15,7 +15,6 @@
 
 //! The widget used for item in menus
 
-use std::ffi::CString;
 use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 use gtk::{self, ffi};
 use gtk::cast::GTK_MENU_ITEM;
@@ -69,10 +68,10 @@ pub trait MenuItemTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrait 
     }
 
     fn set_label(&mut self, label: &str) {
-        let c_str = CString::from_slice(label.as_bytes());
-
         unsafe {
-            ffi::gtk_menu_item_set_label(GTK_MENU_ITEM(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_label = label.to_tmp_for_borrow();
+            ffi::gtk_menu_item_set_label(GTK_MENU_ITEM(self.unwrap_widget()),
+                                         tmp_label.to_glib_ptr())
         }
     }
 

--- a/src/gtk/traits/menu_item.rs
+++ b/src/gtk/traits/menu_item.rs
@@ -16,7 +16,7 @@
 //! The widget used for item in menus
 
 use std::ffi::CString;
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 use gtk::{self, ffi};
 use gtk::cast::GTK_MENU_ITEM;
 use glib::{to_bool, to_gboolean};
@@ -63,13 +63,8 @@ pub trait MenuItemTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrait 
 
     fn get_accel_path(&self) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_menu_item_get_accel_path(GTK_MENU_ITEM(self.unwrap_widget()));
-
-            if c_str.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&c_str)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_menu_item_get_accel_path(GTK_MENU_ITEM(self.unwrap_widget())))
         }
     }
 
@@ -83,13 +78,8 @@ pub trait MenuItemTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrait 
 
     fn get_label(&self) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_menu_item_get_label(GTK_MENU_ITEM(self.unwrap_widget()));
-
-            if c_str.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&c_str)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_menu_item_get_label(GTK_MENU_ITEM(self.unwrap_widget())))
         }
     }
 

--- a/src/gtk/traits/menu_item.rs
+++ b/src/gtk/traits/menu_item.rs
@@ -16,6 +16,7 @@
 //! The widget used for item in menus
 
 use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 use gtk::{self, ffi};
 use gtk::cast::GTK_MENU_ITEM;
 use glib::{to_bool, to_gboolean};
@@ -55,9 +56,8 @@ pub trait MenuItemTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrait 
 
     fn set_accel_path(&mut self, accel_path: &str) {
         unsafe {
-            let c_str = CString::from_slice(accel_path.as_bytes());
-
-            ffi::gtk_menu_item_set_accel_path(GTK_MENU_ITEM(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_accel_path = accel_path.to_tmp_for_borrow();
+            ffi::gtk_menu_item_set_accel_path(GTK_MENU_ITEM(self.unwrap_widget()), tmp_accel_path.to_glib_ptr())
         }
     }
 

--- a/src/gtk/traits/recent_chooser.rs
+++ b/src/gtk/traits/recent_chooser.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 use gtk::cast::{GTK_RECENT_CHOOSER};
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
@@ -88,13 +88,9 @@ pub trait RecentChooserTrait: gtk::WidgetTrait + FFIWidget {
 
     fn get_current_uri(&self) -> Option<String> {
         unsafe {
-            let tmp = ffi::gtk_recent_chooser_get_current_uri(GTK_RECENT_CHOOSER(self.unwrap_widget()));
-
-            if tmp.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&(tmp as *const c_char))).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_recent_chooser_get_current_uri(GTK_RECENT_CHOOSER(self.unwrap_widget()))
+                    as *const c_char)
         }
     }
 

--- a/src/gtk/traits/recent_chooser.rs
+++ b/src/gtk/traits/recent_chooser.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 use gtk::cast::{GTK_RECENT_CHOOSER};
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
@@ -110,9 +110,8 @@ pub trait RecentChooserTrait: gtk::WidgetTrait + FFIWidget {
 
     fn unselect_uri(&self, uri: &str) -> bool {
         unsafe {
-            let c_str = CString::from_slice(uri.as_bytes());
-
-            to_bool(ffi::gtk_recent_chooser_unselect_uri(GTK_RECENT_CHOOSER(self.unwrap_widget()), c_str.as_ptr()))
+            let mut tmp_uri = uri.to_tmp_for_borrow();
+            to_bool(ffi::gtk_recent_chooser_unselect_uri(GTK_RECENT_CHOOSER(self.unwrap_widget()), tmp_uri.to_glib_ptr()))
         }
     }
 

--- a/src/gtk/traits/text_buffer.rs
+++ b/src/gtk/traits/text_buffer.rs
@@ -13,16 +13,15 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 use gtk::{self, ffi};
 use gtk::cast::GTK_TEXT_BUFFER;
 
 pub trait TextBufferTrait: gtk::WidgetTrait {
     fn set_text(&self, text: String) {
         unsafe {
-        	let c_str = CString::from_slice(text.as_bytes());
-
-            ffi::gtk_text_buffer_set_text(GTK_TEXT_BUFFER(self.unwrap_widget()), c_str.as_ptr(), text.len() as i32)
+            let mut tmp_text = text.to_tmp_for_borrow();
+            ffi::gtk_text_buffer_set_text(GTK_TEXT_BUFFER(self.unwrap_widget()), tmp_text.to_glib_ptr(), text.len() as i32)
         }
     }
 

--- a/src/gtk/traits/tool_button.rs
+++ b/src/gtk/traits/tool_button.rs
@@ -14,6 +14,7 @@
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 use gtk::cast::GTK_TOOLBUTTON;
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
@@ -21,17 +22,15 @@ use glib::{to_bool, to_gboolean};
 pub trait ToolButtonTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrait + gtk::ToolItemTrait {
     fn set_label(&mut self, label: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(label.as_bytes());
-
-            ffi::gtk_tool_button_set_label(GTK_TOOLBUTTON(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_label = label.to_tmp_for_borrow();
+            ffi::gtk_tool_button_set_label(GTK_TOOLBUTTON(self.unwrap_widget()), tmp_label.to_glib_ptr())
         }
     }
 
     fn set_stock_id(&mut self, stock_id: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(stock_id.as_bytes());
-
-            ffi::gtk_tool_button_set_stock_id(GTK_TOOLBUTTON(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_stock_id = stock_id.to_tmp_for_borrow();
+            ffi::gtk_tool_button_set_stock_id(GTK_TOOLBUTTON(self.unwrap_widget()), tmp_stock_id.to_glib_ptr())
         }
     }
 

--- a/src/gtk/traits/tool_button.rs
+++ b/src/gtk/traits/tool_button.rs
@@ -13,7 +13,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::ffi::CString;
 use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 use gtk::cast::GTK_TOOLBUTTON;
 use gtk::{self, ffi};
@@ -35,10 +34,10 @@ pub trait ToolButtonTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrai
     }
 
     fn set_icon_name(&mut self, icon_name: &str) -> () {
-        let c_str = CString::from_slice(icon_name.as_bytes());
-
         unsafe {
-            ffi::gtk_tool_button_set_icon_name(GTK_TOOLBUTTON(self.unwrap_widget()), c_str.as_ptr());
+            let mut tmp_icon_name = icon_name.to_tmp_for_borrow();
+            ffi::gtk_tool_button_set_icon_name(GTK_TOOLBUTTON(self.unwrap_widget()),
+                                               tmp_icon_name.to_glib_ptr());
         }
     }
 

--- a/src/gtk/traits/tool_button.rs
+++ b/src/gtk/traits/tool_button.rs
@@ -14,7 +14,7 @@
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::ffi::CString;
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 use gtk::cast::GTK_TOOLBUTTON;
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
@@ -44,37 +44,22 @@ pub trait ToolButtonTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrai
 
     fn get_label(&self) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_tool_button_get_label(GTK_TOOLBUTTON(self.unwrap_widget()));
-
-            if c_str.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&c_str)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_tool_button_get_label(GTK_TOOLBUTTON(self.unwrap_widget())))
         }
     }
 
     fn get_stock_id(&self) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_tool_button_get_stock_id(GTK_TOOLBUTTON(self.unwrap_widget()));
-
-            if c_str.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&c_str)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_tool_button_get_stock_id(GTK_TOOLBUTTON(self.unwrap_widget())))
         }
     }
 
     fn get_icon_name(&self) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_tool_button_get_icon_name(GTK_TOOLBUTTON(self.unwrap_widget()));
-
-            if c_str.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&c_str)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_tool_button_get_icon_name(GTK_TOOLBUTTON(self.unwrap_widget())))
         }
     }
 

--- a/src/gtk/traits/tool_item.rs
+++ b/src/gtk/traits/tool_item.rs
@@ -14,6 +14,7 @@
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
 use gtk::cast::GTK_TOOLITEM;
@@ -78,9 +79,8 @@ pub trait ToolItemTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrait 
 
     fn set_tooltip_markup(&mut self, markup: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(markup.as_bytes());
-
-            ffi::gtk_tool_item_set_tooltip_markup(GTK_TOOLITEM(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_markup = markup.to_tmp_for_borrow();
+            ffi::gtk_tool_item_set_tooltip_markup(GTK_TOOLITEM(self.unwrap_widget()), tmp_markup.to_glib_ptr())
         }
     }
 

--- a/src/gtk/traits/tool_item.rs
+++ b/src/gtk/traits/tool_item.rs
@@ -13,7 +13,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::ffi::CString;
 use glib::translate::{ToGlibPtr, ToTmp};
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
@@ -70,10 +69,10 @@ pub trait ToolItemTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrait 
     }
 
     fn set_tooltip_text(&mut self, text: &str) -> () {
-        let c_str = CString::from_slice(text.as_bytes());
-
         unsafe {
-            ffi::gtk_tool_item_set_tooltip_text(GTK_TOOLITEM(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_text = text.to_tmp_for_borrow();
+            ffi::gtk_tool_item_set_tooltip_text(GTK_TOOLITEM(self.unwrap_widget()),
+                                                tmp_text.to_glib_ptr())
         }
     }
 

--- a/src/gtk/traits/widget.rs
+++ b/src/gtk/traits/widget.rs
@@ -14,7 +14,7 @@
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
 use libc::{c_int, c_char, self};
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 use gtk::ffi;
 use glib::{to_bool, to_gboolean};
 use gdk;
@@ -97,13 +97,8 @@ pub trait WidgetTrait: gtk::FFIWidget + gtk::GObjectTrait {
 
     fn get_name(&self) -> Option<String> {
         unsafe {
-            let tmp = ffi::gtk_widget_get_name(self.unwrap_widget());
-
-            if tmp.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_widget_get_name(self.unwrap_widget()))
         }
     }
 
@@ -313,16 +308,9 @@ pub trait WidgetTrait: gtk::FFIWidget + gtk::GObjectTrait {
 
     fn get_tooltip_markup(&self) -> Option<String> {
         unsafe {
-            let tmp = ffi::gtk_widget_get_tooltip_markup(self.unwrap_widget());
-
-            if tmp.is_null() {
-                None
-            } else {
-                let ret = String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&(tmp as *const i8))).to_string();
-
-                libc::funcs::c95::stdlib::free(tmp as *mut libc::c_void);
-                Some(ret)
-            }
+            FromGlibPtr::take(
+                ffi::gtk_widget_get_tooltip_markup(self.unwrap_widget())
+                    as *const c_char)
         }
     }
 
@@ -336,16 +324,9 @@ pub trait WidgetTrait: gtk::FFIWidget + gtk::GObjectTrait {
 
     fn get_tooltip_text(&self) -> Option<String> {
         unsafe {
-            let tmp = ffi::gtk_widget_get_tooltip_text(self.unwrap_widget());
-
-            if tmp.is_null() {
-                None
-            } else {
-                let ret = String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&(tmp as *const i8))).to_string();
-
-                libc::funcs::c95::stdlib::free(tmp as *mut libc::c_void);
-                Some(ret)
-            }
+            FromGlibPtr::take(
+                ffi::gtk_widget_get_tooltip_text(self.unwrap_widget())
+                    as *const c_char)
         }
     }
 

--- a/src/gtk/traits/widget.rs
+++ b/src/gtk/traits/widget.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use libc::{c_int, c_char, self};
+use libc::{c_int, c_char};
 use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 use gtk::ffi;
 use glib::{to_bool, to_gboolean};

--- a/src/gtk/traits/widget.rs
+++ b/src/gtk/traits/widget.rs
@@ -14,7 +14,7 @@
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
 use libc::{c_int, c_char, self};
-use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 use gtk::ffi;
 use glib::{to_bool, to_gboolean};
 use gdk;
@@ -91,9 +91,8 @@ pub trait WidgetTrait: gtk::FFIWidget + gtk::GObjectTrait {
     }
 
     fn set_name(&self, name: &str) {
-        let c_str = CString::from_slice(name.as_bytes());
-
-        unsafe { ffi::gtk_widget_set_name(self.unwrap_widget(), c_str.as_ptr()) }
+        let mut tmp_name = name.to_tmp_for_borrow();
+        unsafe { ffi::gtk_widget_set_name(self.unwrap_widget(), tmp_name.to_glib_ptr()) }
     }
 
     fn get_name(&self) -> Option<String> {
@@ -194,9 +193,8 @@ pub trait WidgetTrait: gtk::FFIWidget + gtk::GObjectTrait {
     }
 
     fn override_symbolic_color(&self, name: &str, color: &gdk_ffi::C_GdkRGBA) {
-        let c_str = CString::from_slice(name.as_bytes());
-
-        unsafe { ffi::gtk_widget_override_symbolic_color(self.unwrap_widget(), c_str.as_ptr(), color); }
+        let mut tmp_name = name.to_tmp_for_borrow();
+        unsafe { ffi::gtk_widget_override_symbolic_color(self.unwrap_widget(), tmp_name.to_glib_ptr(), color); }
     }
 
     fn override_cursor(&self, cursor: &gdk_ffi::C_GdkRGBA, secondary_cursor: &gdk_ffi::C_GdkRGBA) {
@@ -330,9 +328,8 @@ pub trait WidgetTrait: gtk::FFIWidget + gtk::GObjectTrait {
 
     fn set_tooltip_markup(&self, markup: &str) {
         unsafe {
-            let c_str = CString::from_slice(markup.as_bytes());
-
-            ffi::gtk_widget_set_tooltip_markup(self.unwrap_widget(), c_str.as_ptr() as *mut c_char);
+            let mut tmp_markup = markup.to_tmp_for_borrow();
+            ffi::gtk_widget_set_tooltip_markup(self.unwrap_widget(), tmp_markup.to_glib_ptr() as *mut c_char);
         }
     }
 
@@ -354,8 +351,8 @@ pub trait WidgetTrait: gtk::FFIWidget + gtk::GObjectTrait {
 
     fn set_tooltip_text(&self, text: &str) {
         unsafe {
-            let c_str = CString::from_slice(text.as_bytes());
-            ffi::gtk_widget_set_tooltip_text(self.unwrap_widget(), c_str.as_ptr() as *mut c_char);
+            let mut tmp_text = text.to_tmp_for_borrow();
+            ffi::gtk_widget_set_tooltip_text(self.unwrap_widget(), tmp_text.to_glib_ptr() as *mut c_char);
         }
     }
 
@@ -685,9 +682,8 @@ pub trait WidgetTrait: gtk::FFIWidget + gtk::GObjectTrait {
 
     fn child_notify(&self, child_property: &str) {
         unsafe {
-            let c_str = CString::from_slice(child_property.as_bytes());
-
-            ffi::gtk_widget_child_notify(self.unwrap_widget(), c_str.as_ptr())
+            let mut tmp_child_property = child_property.to_tmp_for_borrow();
+            ffi::gtk_widget_child_notify(self.unwrap_widget(), tmp_child_property.to_glib_ptr())
         }
     }
 

--- a/src/gtk/traits/window.rs
+++ b/src/gtk/traits/window.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::ffi::{CString};
+use glib::translate::{ToGlibPtr, ToTmp};
 use gtk::{self, ffi};
 use glib::to_gboolean;
 use gtk::cast::GTK_WINDOW;
@@ -22,9 +22,8 @@ use gtk::WindowPosition;
 pub trait WindowTrait : gtk::WidgetTrait {
     fn set_title(&mut self, title: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(title.as_bytes());
-
-            ffi::gtk_window_set_title(GTK_WINDOW(self.unwrap_widget()), c_str.as_ptr());
+            let mut tmp_title = title.to_tmp_for_borrow();
+            ffi::gtk_window_set_title(GTK_WINDOW(self.unwrap_widget()), tmp_title.to_glib_ptr());
         }
     }
 

--- a/src/gtk/traits/window.rs
+++ b/src/gtk/traits/window.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 use gtk::{self, ffi};
 use glib::to_gboolean;
 use gtk::cast::GTK_WINDOW;
@@ -35,13 +35,8 @@ pub trait WindowTrait : gtk::WidgetTrait {
 
     fn get_title(&self) -> Option<String> {
         unsafe {
-            let c_title = ffi::gtk_window_get_title(GTK_WINDOW(self.unwrap_widget()));
-
-            if c_title.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&c_title)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_window_get_title(GTK_WINDOW(self.unwrap_widget())))
         }
     }
 

--- a/src/gtk/widgets/about_dialog.rs
+++ b/src/gtk/widgets/about_dialog.rs
@@ -18,6 +18,7 @@ use glib::{to_bool, to_gboolean};
 use gtk::FFIWidget;
 use gtk::cast::GTK_ABOUT_DIALOG;
 use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 
 struct_Widget!(AboutDialog);
 
@@ -46,9 +47,8 @@ impl AboutDialog {
 
     pub fn set_program_name(&self, name: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(name.as_bytes());
-
-            ffi::gtk_about_dialog_set_program_name(GTK_ABOUT_DIALOG(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_name = name.to_tmp_for_borrow();
+            ffi::gtk_about_dialog_set_program_name(GTK_ABOUT_DIALOG(self.unwrap_widget()), tmp_name.to_glib_ptr())
         };
     }
 
@@ -66,9 +66,8 @@ impl AboutDialog {
 
     pub fn set_version(&self, version: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(version.as_bytes());
-
-            ffi::gtk_about_dialog_set_version(GTK_ABOUT_DIALOG(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_version = version.to_tmp_for_borrow();
+            ffi::gtk_about_dialog_set_version(GTK_ABOUT_DIALOG(self.unwrap_widget()), tmp_version.to_glib_ptr())
         };
     }
 
@@ -86,9 +85,8 @@ impl AboutDialog {
 
     pub fn set_copyright(&self, copyright: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(copyright.as_bytes());
-
-            ffi::gtk_about_dialog_set_copyright(GTK_ABOUT_DIALOG(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_copyright = copyright.to_tmp_for_borrow();
+            ffi::gtk_about_dialog_set_copyright(GTK_ABOUT_DIALOG(self.unwrap_widget()), tmp_copyright.to_glib_ptr())
         };
     }
 
@@ -106,9 +104,8 @@ impl AboutDialog {
 
     pub fn set_comments(&self, comments: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(comments.as_bytes());
-
-            ffi::gtk_about_dialog_set_comments(GTK_ABOUT_DIALOG(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_comments = comments.to_tmp_for_borrow();
+            ffi::gtk_about_dialog_set_comments(GTK_ABOUT_DIALOG(self.unwrap_widget()), tmp_comments.to_glib_ptr())
         };
     }
 
@@ -126,9 +123,8 @@ impl AboutDialog {
 
     pub fn set_license(&self, license: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(license.as_bytes());
-
-            ffi::gtk_about_dialog_set_license(GTK_ABOUT_DIALOG(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_license = license.to_tmp_for_borrow();
+            ffi::gtk_about_dialog_set_license(GTK_ABOUT_DIALOG(self.unwrap_widget()), tmp_license.to_glib_ptr())
         };
     }
 
@@ -162,9 +158,8 @@ impl AboutDialog {
 
     pub fn set_website(&self, website: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(website.as_bytes());
-
-            ffi::gtk_about_dialog_set_website(GTK_ABOUT_DIALOG(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_website = website.to_tmp_for_borrow();
+            ffi::gtk_about_dialog_set_website(GTK_ABOUT_DIALOG(self.unwrap_widget()), tmp_website.to_glib_ptr())
         };
     }
 
@@ -182,9 +177,8 @@ impl AboutDialog {
 
     pub fn set_website_label(&self, website_label: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(website_label.as_bytes());
-
-            ffi::gtk_about_dialog_set_website_label(GTK_ABOUT_DIALOG(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_website_label = website_label.to_tmp_for_borrow();
+            ffi::gtk_about_dialog_set_website_label(GTK_ABOUT_DIALOG(self.unwrap_widget()), tmp_website_label.to_glib_ptr())
         };
     }
 

--- a/src/gtk/widgets/about_dialog.rs
+++ b/src/gtk/widgets/about_dialog.rs
@@ -258,9 +258,10 @@ impl AboutDialog {
 
     pub fn set_translator_credits(&self, translator_credits: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(translator_credits.as_bytes());
-
-            ffi::gtk_about_dialog_set_translator_credits(GTK_ABOUT_DIALOG(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_translator_credits = translator_credits.to_tmp_for_borrow();
+            ffi::gtk_about_dialog_set_translator_credits(
+                GTK_ABOUT_DIALOG(self.unwrap_widget()),
+                tmp_translator_credits.to_glib_ptr())
         };
     }
 
@@ -287,9 +288,10 @@ impl AboutDialog {
 
     pub fn set_logo_icon_name(&self, logo_icon_name: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(logo_icon_name.as_bytes());
-
-            ffi::gtk_about_dialog_set_logo_icon_name(GTK_ABOUT_DIALOG(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_logo_icon_name = logo_icon_name.to_tmp_for_borrow();
+            ffi::gtk_about_dialog_set_logo_icon_name(
+                GTK_ABOUT_DIALOG(self.unwrap_widget()),
+                tmp_logo_icon_name.to_glib_ptr())
         };
     }
 
@@ -303,9 +305,11 @@ impl AboutDialog {
         }
         tmp_vec.push(::std::ptr::null_mut());
         unsafe {
-            let c_str = CString::from_slice(section_name.as_bytes());
-
-            ffi::gtk_about_dialog_add_credit_section(GTK_ABOUT_DIALOG(self.unwrap_widget()), c_str.as_ptr(), tmp_vec.as_slice().as_ptr())
+            let mut tmp_section_name = section_name.to_tmp_for_borrow();
+            ffi::gtk_about_dialog_add_credit_section(
+                GTK_ABOUT_DIALOG(self.unwrap_widget()),
+                tmp_section_name.to_glib_ptr(),
+                tmp_vec.as_slice().as_ptr())
         }
     }
 

--- a/src/gtk/widgets/about_dialog.rs
+++ b/src/gtk/widgets/about_dialog.rs
@@ -18,7 +18,7 @@ use glib::{to_bool, to_gboolean};
 use gtk::FFIWidget;
 use gtk::cast::GTK_ABOUT_DIALOG;
 use std::ffi::CString;
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 
 struct_Widget!(AboutDialog);
 
@@ -35,13 +35,8 @@ impl AboutDialog {
 
     pub fn get_program_name(&self) -> Option<String> {
         unsafe {
-            let name = ffi::gtk_about_dialog_get_program_name(GTK_ABOUT_DIALOG(self.unwrap_widget()));
-
-            if name.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&name)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_about_dialog_get_program_name(GTK_ABOUT_DIALOG(self.unwrap_widget())))
         }
     }
 
@@ -54,13 +49,8 @@ impl AboutDialog {
 
     pub fn get_version(&self) -> Option<String> {
         unsafe {
-            let version = ffi::gtk_about_dialog_get_version(GTK_ABOUT_DIALOG(self.unwrap_widget()));
-
-            if version.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&version)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_about_dialog_get_version(GTK_ABOUT_DIALOG(self.unwrap_widget())))
         }
     }
 
@@ -73,13 +63,8 @@ impl AboutDialog {
 
     pub fn get_copyright(&self) -> Option<String> {
         unsafe {
-            let copyright = ffi::gtk_about_dialog_get_copyright(GTK_ABOUT_DIALOG(self.unwrap_widget()));
-
-            if copyright.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&copyright)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_about_dialog_get_copyright(GTK_ABOUT_DIALOG(self.unwrap_widget())))
         }
     }
 
@@ -92,13 +77,8 @@ impl AboutDialog {
 
     pub fn get_comments(&self) -> Option<String> {
         unsafe {
-            let comments = ffi::gtk_about_dialog_get_comments(GTK_ABOUT_DIALOG(self.unwrap_widget()));
-
-            if comments.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&comments)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_about_dialog_get_comments(GTK_ABOUT_DIALOG(self.unwrap_widget())))
         }
     }
 
@@ -111,13 +91,8 @@ impl AboutDialog {
 
     pub fn get_license(&self) -> Option<String> {
         unsafe {
-            let license = ffi::gtk_about_dialog_get_license(GTK_ABOUT_DIALOG(self.unwrap_widget()));
-
-            if license.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&license)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_about_dialog_get_license(GTK_ABOUT_DIALOG(self.unwrap_widget())))
         }
     }
 
@@ -146,13 +121,8 @@ impl AboutDialog {
 
     pub fn get_website(&self) -> Option<String> {
         unsafe {
-            let website = ffi::gtk_about_dialog_get_website(GTK_ABOUT_DIALOG(self.unwrap_widget()));
-
-            if website.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&website)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_about_dialog_get_website(GTK_ABOUT_DIALOG(self.unwrap_widget())))
         }
     }
 
@@ -165,13 +135,8 @@ impl AboutDialog {
 
     pub fn get_website_label(&self) -> Option<String> {
         unsafe {
-            let website_label = ffi::gtk_about_dialog_get_website_label(GTK_ABOUT_DIALOG(self.unwrap_widget()));
-
-            if website_label.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&website_label)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_about_dialog_get_website_label(GTK_ABOUT_DIALOG(self.unwrap_widget())))
         }
     }
 
@@ -286,13 +251,8 @@ impl AboutDialog {
 
     pub fn get_translator_credits(&self) -> Option<String> {
         unsafe {
-            let translator_credits = ffi::gtk_about_dialog_get_translator_credits(GTK_ABOUT_DIALOG(self.unwrap_widget()));
-
-            if translator_credits.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&translator_credits)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_about_dialog_get_translator_credits(GTK_ABOUT_DIALOG(self.unwrap_widget())))
         }
     }
 
@@ -320,13 +280,8 @@ impl AboutDialog {
 
     pub fn get_logo_icon_name(&self) -> Option<String> {
         unsafe {
-            let logo_icon_name = ffi::gtk_about_dialog_get_logo_icon_name(GTK_ABOUT_DIALOG(self.unwrap_widget()));
-
-            if logo_icon_name.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&logo_icon_name)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_about_dialog_get_logo_icon_name(GTK_ABOUT_DIALOG(self.unwrap_widget())))
         }
     }
 

--- a/src/gtk/widgets/app_chooser_dialog.rs
+++ b/src/gtk/widgets/app_chooser_dialog.rs
@@ -16,7 +16,6 @@
 use gtk::{self, ffi};
 use gtk::FFIWidget;
 use gtk::cast::{GTK_WINDOW, GTK_APP_CHOOSER_DIALOG};
-use std::ffi::CString;
 use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 
 struct_Widget!(AppChooserDialog);
@@ -24,12 +23,14 @@ struct_Widget!(AppChooserDialog);
 impl AppChooserDialog {
     pub fn new_for_content_type(parent: Option<gtk::Window>, flags: gtk::DialogFlags, content_type: &str) -> Option<AppChooserDialog> {
         let tmp_pointer = unsafe {
-            let c_str = CString::from_slice(content_type.as_bytes());
-
-            ffi::gtk_app_chooser_dialog_new_for_content_type(match parent {
+            let parent = match parent {
                 Some(ref p) => GTK_WINDOW(p.unwrap_widget()),
                 None => ::std::ptr::null_mut()
-            }, flags, c_str.as_ptr())
+            };
+            let mut tmp_content_type = content_type.to_tmp_for_borrow();
+
+            ffi::gtk_app_chooser_dialog_new_for_content_type(parent, flags,
+                                                             tmp_content_type.to_glib_ptr())
         };
 
         if tmp_pointer.is_null() {

--- a/src/gtk/widgets/app_chooser_dialog.rs
+++ b/src/gtk/widgets/app_chooser_dialog.rs
@@ -17,6 +17,7 @@ use gtk::{self, ffi};
 use gtk::FFIWidget;
 use gtk::cast::{GTK_WINDOW, GTK_APP_CHOOSER_DIALOG};
 use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 
 struct_Widget!(AppChooserDialog);
 
@@ -50,9 +51,8 @@ impl AppChooserDialog {
 
     pub fn set_heading(&self, heading: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(heading.as_bytes());
-
-            ffi::gtk_app_chooser_dialog_set_heading(GTK_APP_CHOOSER_DIALOG(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_heading = heading.to_tmp_for_borrow();
+            ffi::gtk_app_chooser_dialog_set_heading(GTK_APP_CHOOSER_DIALOG(self.unwrap_widget()), tmp_heading.to_glib_ptr())
         }
     }
 

--- a/src/gtk/widgets/app_chooser_dialog.rs
+++ b/src/gtk/widgets/app_chooser_dialog.rs
@@ -17,7 +17,7 @@ use gtk::{self, ffi};
 use gtk::FFIWidget;
 use gtk::cast::{GTK_WINDOW, GTK_APP_CHOOSER_DIALOG};
 use std::ffi::CString;
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 
 struct_Widget!(AppChooserDialog);
 
@@ -58,13 +58,8 @@ impl AppChooserDialog {
 
     pub fn get_heading(&self) -> Option<String> {
         unsafe {
-            let tmp_pointer = ffi::gtk_app_chooser_dialog_get_heading(GTK_APP_CHOOSER_DIALOG(self.unwrap_widget()));
-
-            if tmp_pointer.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp_pointer)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_app_chooser_dialog_get_heading(GTK_APP_CHOOSER_DIALOG(self.unwrap_widget())))
         }
     }
 }

--- a/src/gtk/widgets/app_chooser_widget.rs
+++ b/src/gtk/widgets/app_chooser_widget.rs
@@ -17,7 +17,7 @@
 
 use gtk::cast::GTK_APP_CHOOSER_WIDGET;
 use gtk::{self, ffi};
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 use glib::{to_bool, to_gboolean};
 
 struct_Widget!(AppChooserWidget);
@@ -89,12 +89,9 @@ impl AppChooserWidget {
     }
 
     pub fn get_default_text(&mut self) -> Option<String> {
-        let tmp_pointer = unsafe { ffi::gtk_app_chooser_widget_get_default_text(GTK_APP_CHOOSER_WIDGET(self.pointer)) };
-
-        if tmp_pointer.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp_pointer)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gtk_app_chooser_widget_get_default_text(GTK_APP_CHOOSER_WIDGET(self.pointer)))
         }
     }
 }

--- a/src/gtk/widgets/app_chooser_widget.rs
+++ b/src/gtk/widgets/app_chooser_widget.rs
@@ -17,7 +17,7 @@
 
 use gtk::cast::GTK_APP_CHOOSER_WIDGET;
 use gtk::{self, ffi};
-use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 use glib::{to_bool, to_gboolean};
 
 struct_Widget!(AppChooserWidget);
@@ -25,9 +25,8 @@ struct_Widget!(AppChooserWidget);
 impl AppChooserWidget {
     pub fn new(content_type: &str) -> Option<AppChooserWidget> {
         let tmp_pointer = unsafe {
-            let c_str = CString::from_slice(content_type.as_bytes());
-
-            ffi::gtk_app_chooser_widget_new(c_str.as_ptr())
+            let mut tmp_content_type = content_type.to_tmp_for_borrow();
+            ffi::gtk_app_chooser_widget_new(tmp_content_type.to_glib_ptr())
         };
         check_pointer!(tmp_pointer, AppChooserWidget)
     }
@@ -84,9 +83,8 @@ impl AppChooserWidget {
 
     pub fn set_default_text(&self, text: &str) {
         unsafe {
-            let c_str = CString::from_slice(text.as_bytes());
-
-            ffi::gtk_app_chooser_widget_set_default_text(GTK_APP_CHOOSER_WIDGET(self.pointer), c_str.as_ptr())
+            let mut tmp_text = text.to_tmp_for_borrow();
+            ffi::gtk_app_chooser_widget_set_default_text(GTK_APP_CHOOSER_WIDGET(self.pointer), tmp_text.to_glib_ptr())
         }
     }
 

--- a/src/gtk/widgets/aspect_frame.rs
+++ b/src/gtk/widgets/aspect_frame.rs
@@ -16,9 +16,8 @@
 //! A frame that constrains its child to a particular aspect ratio
 
 use libc::c_float;
-use std::ptr;
-use std::ffi::CString;
 
+use glib::translate::{ToGlibPtr, ToTmp};
 use gtk::cast::GTK_ASPECTFRAME;
 use gtk::{self, ffi};
 use glib::to_gboolean;
@@ -28,13 +27,11 @@ struct_Widget!(AspectFrame);
 
 impl AspectFrame {
     pub fn new(label: Option<&str>, x_align: f32, y_align: f32, ratio: f32, obey_child: bool) -> Option<AspectFrame> {
-        let tmp_pointer = match label {
-            Some(l) => unsafe {
-                let c_str = CString::from_slice(l.as_bytes());
-
-                ffi::gtk_aspect_frame_new(c_str.as_ptr(), x_align as c_float, y_align as c_float, ratio as c_float, to_gboolean(obey_child))
-            },
-            None => unsafe { ffi::gtk_aspect_frame_new(ptr::null(), x_align as c_float, y_align as c_float, ratio as c_float, to_gboolean(obey_child)) }
+        let tmp_pointer = unsafe {
+            let mut tmp_label = label.to_tmp_for_borrow();
+            ffi::gtk_aspect_frame_new(tmp_label.to_glib_ptr(),
+                                      x_align as c_float, y_align as c_float,
+                                      ratio as c_float, to_gboolean(obey_child))
         };
         check_pointer!(tmp_pointer, AspectFrame)
     }

--- a/src/gtk/widgets/builder.rs
+++ b/src/gtk/widgets/builder.rs
@@ -17,6 +17,7 @@ use gtk::ffi::{self, C_GtkBuilder};
 use libc::c_long;
 use gtk::traits::GObjectTrait;
 use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 
 #[repr(C)]
 #[derive(Copy)]
@@ -39,9 +40,8 @@ impl Builder {
 
     pub fn new_from_file(file_name: &str) -> Option<Builder> {
         let tmp = unsafe {
-            let c_str = CString::from_slice(file_name.as_bytes());
-
-            ffi::gtk_builder_new_from_file(c_str.as_ptr())
+            let mut tmp_file_name = file_name.to_tmp_for_borrow();
+            ffi::gtk_builder_new_from_file(tmp_file_name.to_glib_ptr())
         };
 
         if tmp.is_null() {
@@ -55,9 +55,8 @@ impl Builder {
 
     pub fn new_from_resource(resource_path: &str) -> Option<Builder> {
         let tmp = unsafe {
-            let c_str = CString::from_slice(resource_path.as_bytes());
-
-            ffi::gtk_builder_new_from_resource(c_str.as_ptr())
+            let mut tmp_resource_path = resource_path.to_tmp_for_borrow();
+            ffi::gtk_builder_new_from_resource(tmp_resource_path.to_glib_ptr())
         };
 
         if tmp.is_null() {

--- a/src/gtk/widgets/button.rs
+++ b/src/gtk/widgets/button.rs
@@ -17,6 +17,7 @@
 
 use gtk::{self, ffi};
 use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 #[cfg(any(feature = "GTK_3_10",feature = "GTK_3_12", feature = "GTK_3_14"))]
 use gtk::IconSize;
 
@@ -42,9 +43,8 @@ impl Button {
 
     pub fn new_with_label(label: &str) -> Option<Button> {
         let tmp_pointer = unsafe {
-            let c_str = CString::from_slice(label.as_bytes());
-
-            ffi::gtk_button_new_with_label(c_str.as_ptr())
+            let mut tmp_label = label.to_tmp_for_borrow();
+            ffi::gtk_button_new_with_label(tmp_label.to_glib_ptr())
         };
         check_pointer!(tmp_pointer, Button)
     }

--- a/src/gtk/widgets/button.rs
+++ b/src/gtk/widgets/button.rs
@@ -16,7 +16,6 @@
 //! A widget that emits a signal when clicked on
 
 use gtk::{self, ffi};
-use std::ffi::CString;
 use glib::translate::{ToGlibPtr, ToTmp};
 #[cfg(any(feature = "GTK_3_10",feature = "GTK_3_12", feature = "GTK_3_14"))]
 use gtk::IconSize;
@@ -50,29 +49,26 @@ impl Button {
     }
 
     pub fn new_with_mnemonic(mnemonic: &str) -> Option<Button> {
-        let c_str = CString::from_slice(mnemonic.as_bytes());
-
         let tmp_pointer = unsafe {
-                ffi::gtk_button_new_with_mnemonic(c_str.as_ptr())
+            let mut tmp_mnemonic = mnemonic.to_tmp_for_borrow();
+            ffi::gtk_button_new_with_mnemonic(tmp_mnemonic.to_glib_ptr())
         };
         check_pointer!(tmp_pointer, Button)
     }
 
     #[cfg(any(feature = "GTK_3_10",feature = "GTK_3_12", feature = "GTK_3_14"))]
     pub fn new_from_icon_name(icon_name: &str, size: IconSize) -> Option<Button> {
-        let c_str = CString::from_slice(icon_name.as_bytes());
-
         let tmp_pointer = unsafe {
-            ffi::gtk_button_new_from_icon_name(c_str.as_ptr(), size)
+            let mut tmp_icon_name = icon_name.to_tmp_for_borrow();
+            ffi::gtk_button_new_from_icon_name(tmp_icon_name.to_glib_ptr(), size)
         };
         check_pointer!(tmp_pointer, Button)
     }
 
     pub fn new_from_stock(stock_id: &str) -> Option<Button> {
-        let c_str = CString::from_slice(stock_id.as_bytes());
-
         let tmp_pointer = unsafe {
-            ffi::gtk_button_new_from_stock(c_str.as_ptr())
+            let mut tmp_stock_id = stock_id.to_tmp_for_borrow();
+            ffi::gtk_button_new_from_stock(tmp_stock_id.to_glib_ptr())
         };
         check_pointer!(tmp_pointer, Button)
     }

--- a/src/gtk/widgets/check_button.rs
+++ b/src/gtk/widgets/check_button.rs
@@ -16,6 +16,7 @@
 //! Create widgets with a discrete toggle button
 
 use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 use gtk::{self, ffi};
 
 /// CheckButton — Create widgets with a discrete toggle button
@@ -29,9 +30,8 @@ impl CheckButton {
 
     pub fn new_with_label(label: &str) -> Option<CheckButton> {
         let tmp_pointer = unsafe {
-            let c_str = CString::from_slice(label.as_bytes());
-
-            ffi::gtk_check_button_new_with_label(c_str.as_ptr())
+            let mut tmp_label = label.to_tmp_for_borrow();
+            ffi::gtk_check_button_new_with_label(tmp_label.to_glib_ptr())
         };
         check_pointer!(tmp_pointer, CheckButton)
     }

--- a/src/gtk/widgets/check_button.rs
+++ b/src/gtk/widgets/check_button.rs
@@ -15,7 +15,6 @@
 
 //! Create widgets with a discrete toggle button
 
-use std::ffi::CString;
 use glib::translate::{ToGlibPtr, ToTmp};
 use gtk::{self, ffi};
 
@@ -37,10 +36,9 @@ impl CheckButton {
     }
 
     pub fn new_with_mnemonic(mnemonic: &str) -> Option<CheckButton> {
-        let c_str = CString::from_slice(mnemonic.as_bytes());
-
         let tmp_pointer = unsafe {
-            ffi::gtk_check_button_new_with_mnemonic(c_str.as_ptr())
+            let mut tmp_mnemonic = mnemonic.to_tmp_for_borrow();
+            ffi::gtk_check_button_new_with_mnemonic(tmp_mnemonic.to_glib_ptr())
         };
         check_pointer!(tmp_pointer, CheckButton)
     }

--- a/src/gtk/widgets/check_menu_item.rs
+++ b/src/gtk/widgets/check_menu_item.rs
@@ -16,7 +16,6 @@
 //! The widget used for item in menus
 
 use gtk::{self, ffi};
-use std::ffi::CString;
 use glib::translate::{ToGlibPtr, ToTmp};
 
 /// CheckMenuItem — The widget used for item in menus
@@ -37,10 +36,10 @@ impl CheckMenuItem {
     }
 
     pub fn new_with_mnemonic(mnemonic: &str) -> Option<CheckMenuItem> {
-        let c_str = CString::from_slice(mnemonic.as_bytes());
-
         let tmp_pointer = unsafe {
-            ffi::gtk_check_menu_item_new_with_mnemonic(c_str.as_ptr())
+            let mut tmp_mnemonic = mnemonic.to_tmp_for_borrow();
+            ffi::gtk_check_menu_item_new_with_mnemonic(
+                    tmp_mnemonic.to_glib_ptr())
         };
         check_pointer!(tmp_pointer, CheckMenuItem)
     }

--- a/src/gtk/widgets/check_menu_item.rs
+++ b/src/gtk/widgets/check_menu_item.rs
@@ -17,6 +17,7 @@
 
 use gtk::{self, ffi};
 use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 
 /// CheckMenuItem — The widget used for item in menus
 struct_Widget!(CheckMenuItem);
@@ -29,9 +30,8 @@ impl CheckMenuItem {
 
     pub fn new_with_label(label: &str) -> Option<CheckMenuItem> {
         let tmp_pointer = unsafe {
-            let c_str = CString::from_slice(label.as_bytes());
-
-            ffi::gtk_check_menu_item_new_with_label(c_str.as_ptr())
+            let mut tmp_label = label.to_tmp_for_borrow();
+            ffi::gtk_check_menu_item_new_with_label(tmp_label.to_glib_ptr())
         };
         check_pointer!(tmp_pointer, CheckMenuItem)
     }

--- a/src/gtk/widgets/color_button.rs
+++ b/src/gtk/widgets/color_button.rs
@@ -15,7 +15,7 @@
 
 //! A button to launch a color selection dialog
 
-use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 use gtk::cast::GTK_COLORBUTTON;
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
@@ -96,9 +96,8 @@ impl ColorButton {
 
     pub fn set_title(&mut self, title: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(title.as_bytes());
-
-            ffi::gtk_color_button_set_title(GTK_COLORBUTTON(self.pointer), c_str.as_ptr());
+            let mut tmp_title = title.to_tmp_for_borrow();
+            ffi::gtk_color_button_set_title(GTK_COLORBUTTON(self.pointer), tmp_title.to_glib_ptr());
         }
     }
 

--- a/src/gtk/widgets/color_button.rs
+++ b/src/gtk/widgets/color_button.rs
@@ -15,7 +15,7 @@
 
 //! A button to launch a color selection dialog
 
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 use gtk::cast::GTK_COLORBUTTON;
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
@@ -103,13 +103,8 @@ impl ColorButton {
 
     pub fn get_title(&self) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_color_button_get_title(GTK_COLORBUTTON(self.pointer));
-
-            if c_str.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&c_str)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_color_button_get_title(GTK_COLORBUTTON(self.pointer)))
         }
     }
 }

--- a/src/gtk/widgets/color_chooser_dialog.rs
+++ b/src/gtk/widgets/color_chooser_dialog.rs
@@ -16,16 +16,15 @@
 use gtk::{self, ffi};
 use gtk::FFIWidget;
 use gtk::cast::{GTK_WINDOW};
-use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 
 struct_Widget!(ColorChooserDialog);
 
 impl ColorChooserDialog {
     pub fn new(title: &str, parent: Option<gtk::Window>) -> Option<ColorChooserDialog> {
         let tmp_pointer = unsafe {
-            let c_str = CString::from_slice(title.as_bytes());
-
-            ffi::gtk_color_chooser_dialog_new(c_str.as_ptr(),
+            let mut tmp_title = title.to_tmp_for_borrow();
+            ffi::gtk_color_chooser_dialog_new(tmp_title.to_glib_ptr(),
                 match parent {
                     Some(ref p) => GTK_WINDOW(p.unwrap_widget()),
                     None => ::std::ptr::null_mut()

--- a/src/gtk/widgets/combo_box_text.rs
+++ b/src/gtk/widgets/combo_box_text.rs
@@ -17,7 +17,7 @@
 
 use gtk::{self, ffi};
 use gtk::cast::GTK_COMBO_BOX_TEXT;
-use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 use libc::c_char;
 
 struct_Widget!(ComboBoxText);
@@ -35,52 +35,53 @@ impl ComboBoxText {
 
     pub fn append(&self, id: &str, text: &str) {
         unsafe {
-            let c_id = CString::from_slice(id.as_bytes());
-            let c_text = CString::from_slice(text.as_bytes());
-
-            ffi::gtk_combo_box_text_append(GTK_COMBO_BOX_TEXT(self.pointer), c_id.as_ptr(), c_text.as_ptr())
+            let mut tmp_id = id.to_tmp_for_borrow();
+            let mut tmp_text = text.to_tmp_for_borrow();
+            ffi::gtk_combo_box_text_append(GTK_COMBO_BOX_TEXT(self.pointer),
+                                           tmp_id.to_glib_ptr(),
+                                           tmp_text.to_glib_ptr())
         }
     }
 
     pub fn prepend(&self, id: &str, text: &str) {
         unsafe {
-            let c_id = CString::from_slice(id.as_bytes());
-            let c_text = CString::from_slice(text.as_bytes());
-
-            ffi::gtk_combo_box_text_prepend(GTK_COMBO_BOX_TEXT(self.pointer), c_id.as_ptr(), c_text.as_ptr())
+            let mut tmp_id = id.to_tmp_for_borrow();
+            let mut tmp_text = text.to_tmp_for_borrow();
+            ffi::gtk_combo_box_text_prepend(GTK_COMBO_BOX_TEXT(self.pointer),
+                                            tmp_id.to_glib_ptr(),
+                                            tmp_text.to_glib_ptr())
         }
     }
 
     pub fn insert(&self, position: i32, id: &str, text: &str) {
         unsafe {
-            let c_id = CString::from_slice(id.as_bytes());
-            let c_text = CString::from_slice(text.as_bytes());
-
-            ffi::gtk_combo_box_text_insert(GTK_COMBO_BOX_TEXT(self.pointer), position, c_id.as_ptr(), c_text.as_ptr())
+            let mut tmp_id = id.to_tmp_for_borrow();
+            let mut tmp_text = text.to_tmp_for_borrow();
+            ffi::gtk_combo_box_text_insert(GTK_COMBO_BOX_TEXT(self.pointer),
+                                           position,
+                                           tmp_id.to_glib_ptr(),
+                                           tmp_text.to_glib_ptr())
         }
     }
 
     pub fn append_text(&self, text: &str) {
         unsafe {
-            let c_str = CString::from_slice(text.as_bytes());
-
-            ffi::gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(self.pointer), c_str.as_ptr())
+            let mut tmp_text = text.to_tmp_for_borrow();
+            ffi::gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(self.pointer), tmp_text.to_glib_ptr())
         }
     }
 
     pub fn prepend_text(&self, text: &str) {
         unsafe {
-            let c_str = CString::from_slice(text.as_bytes());
-
-            ffi::gtk_combo_box_text_prepend_text(GTK_COMBO_BOX_TEXT(self.pointer), c_str.as_ptr())
+            let mut tmp_text = text.to_tmp_for_borrow();
+            ffi::gtk_combo_box_text_prepend_text(GTK_COMBO_BOX_TEXT(self.pointer), tmp_text.to_glib_ptr())
         }
     }
 
     pub fn insert_text(&self, position: i32, text: &str) {
         unsafe {
-            let c_str = CString::from_slice(text.as_bytes());
-
-            ffi::gtk_combo_box_text_insert_text(GTK_COMBO_BOX_TEXT(self.pointer), position, c_str.as_ptr())
+            let mut tmp_text = text.to_tmp_for_borrow();
+            ffi::gtk_combo_box_text_insert_text(GTK_COMBO_BOX_TEXT(self.pointer), position, tmp_text.to_glib_ptr())
         }
     }
 

--- a/src/gtk/widgets/combo_box_text.rs
+++ b/src/gtk/widgets/combo_box_text.rs
@@ -17,7 +17,7 @@
 
 use gtk::{self, ffi};
 use gtk::cast::GTK_COMBO_BOX_TEXT;
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 use libc::c_char;
 
 struct_Widget!(ComboBoxText);
@@ -94,12 +94,9 @@ impl ComboBoxText {
     }
 
     pub fn get_active_text(&self) -> Option<String> {
-        let tmp = unsafe { ffi::gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(self.pointer)) as *const c_char };
-
-        if tmp.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(self.pointer)) as *const c_char)
         }
     }
 }

--- a/src/gtk/widgets/entry_buffer.rs
+++ b/src/gtk/widgets/entry_buffer.rs
@@ -17,6 +17,7 @@
 
 use libc::{c_int, c_uint};
 use std::ffi::CString;
+use glib::translate::{FromGlibPtr};
 use gtk::ffi;
 
 // TODO:
@@ -51,13 +52,8 @@ impl EntryBuffer {
 
     pub fn get_text(&self) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_entry_buffer_get_text(self.pointer);
-
-            if c_str.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&c_str)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_entry_buffer_get_text(self.pointer))
         }
     }
 

--- a/src/gtk/widgets/entry_buffer.rs
+++ b/src/gtk/widgets/entry_buffer.rs
@@ -16,8 +16,7 @@
 //! Text buffer for gtk::Entry
 
 use libc::{c_int, c_uint};
-use std::ffi::CString;
-use glib::translate::{FromGlibPtr};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 use gtk::ffi;
 
 // TODO:
@@ -35,11 +34,10 @@ pub struct EntryBuffer {
 }
 
 impl EntryBuffer {
-    pub fn new(initial_chars: &str) -> Option<EntryBuffer> {
+    pub fn new(initial_chars: Option<&str>) -> Option<EntryBuffer> {
         let tmp_pointer = unsafe {
-            let c_str = CString::from_slice(initial_chars.as_bytes());
-
-            ffi::gtk_entry_buffer_new(c_str.as_ptr(), initial_chars.len() as c_int)
+            let mut tmp_initial_chars = initial_chars.to_tmp_for_borrow();
+            ffi::gtk_entry_buffer_new(tmp_initial_chars.to_glib_ptr(), -1)
         };
         if tmp_pointer.is_null() {
             None
@@ -58,10 +56,9 @@ impl EntryBuffer {
     }
 
     pub fn set_text(&mut self, text: &str) -> () {
-        let c_str = CString::from_slice(text.as_bytes());
-
         unsafe {
-            ffi::gtk_entry_buffer_set_text(self.pointer, c_str.as_ptr(), text.len() as c_int);
+            let mut tmp_text = text.to_tmp_for_borrow();
+            ffi::gtk_entry_buffer_set_text(self.pointer, tmp_text.to_glib_ptr(), -1);
         }
     }
 
@@ -91,9 +88,9 @@ impl EntryBuffer {
 
     pub fn insert_text(&mut self, position: u32, text: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(text.as_bytes());
-
-            ffi::gtk_entry_buffer_insert_text(self.pointer, position as c_uint, c_str.as_ptr(), text.len() as c_int);
+            let mut tmp_text = text.to_tmp_for_borrow();
+            ffi::gtk_entry_buffer_insert_text(self.pointer, position as c_uint,
+                                              tmp_text.to_glib_ptr(), -1);
         }
     }
 
@@ -111,9 +108,9 @@ impl EntryBuffer {
 
     pub fn emit_inserted_text(&mut self, position: u32, text: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(text.as_bytes());
-
-            ffi::gtk_entry_buffer_emit_inserted_text(self.pointer, position as c_uint, c_str.as_ptr(), text.len() as c_int);
+            let mut tmp_text = text.to_tmp_for_borrow();
+            ffi::gtk_entry_buffer_emit_inserted_text(self.pointer, position as c_uint,
+                                                     tmp_text.to_glib_ptr(), -1);
         }
     }
 

--- a/src/gtk/widgets/entry_completion.rs
+++ b/src/gtk/widgets/entry_completion.rs
@@ -18,7 +18,7 @@
 use gtk::{self, ffi};
 use gtk::TreeModel;
 use gtk::cast::GTK_ENTRY_COMPLETION;
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 use libc::c_char;
 
 struct_Widget!(EntryCompletion);
@@ -86,12 +86,9 @@ impl EntryCompletion {
     }
 
     pub fn get_completion_prefix(&self) -> Option<String> {
-        let tmp_pointer = unsafe { ffi::gtk_entry_completion_get_completion_prefix(GTK_ENTRY_COMPLETION(self.pointer)) };
-
-        if tmp_pointer.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp_pointer)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gtk_entry_completion_get_completion_prefix(GTK_ENTRY_COMPLETION(self.pointer)))
         }
     }
 

--- a/src/gtk/widgets/entry_completion.rs
+++ b/src/gtk/widgets/entry_completion.rs
@@ -69,15 +69,13 @@ impl EntryCompletion {
     }
 
     pub fn compute_prefix(&self, key: &str) -> Option<String> {
-        let tmp_pointer = unsafe {
+        unsafe {
             let mut tmp_key = key.to_tmp_for_borrow();
-            ffi::gtk_entry_completion_compute_prefix(GTK_ENTRY_COMPLETION(self.pointer), tmp_key.to_glib_ptr()) as *const c_char
-        };
-
-        if tmp_pointer.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp_pointer)).to_string()) }
+            FromGlibPtr::borrow(
+                ffi::gtk_entry_completion_compute_prefix(
+                    GTK_ENTRY_COMPLETION(self.pointer),
+                    tmp_key.to_glib_ptr())
+                as *const c_char)
         }
     }
 

--- a/src/gtk/widgets/entry_completion.rs
+++ b/src/gtk/widgets/entry_completion.rs
@@ -18,7 +18,7 @@
 use gtk::{self, ffi};
 use gtk::TreeModel;
 use gtk::cast::GTK_ENTRY_COMPLETION;
-use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 use libc::c_char;
 
 struct_Widget!(EntryCompletion);
@@ -70,9 +70,8 @@ impl EntryCompletion {
 
     pub fn compute_prefix(&self, key: &str) -> Option<String> {
         let tmp_pointer = unsafe {
-            let c_str = CString::from_slice(key.as_bytes());
-
-            ffi::gtk_entry_completion_compute_prefix(GTK_ENTRY_COMPLETION(self.pointer), c_str.as_ptr()) as *const c_char
+            let mut tmp_key = key.to_tmp_for_borrow();
+            ffi::gtk_entry_completion_compute_prefix(GTK_ENTRY_COMPLETION(self.pointer), tmp_key.to_glib_ptr()) as *const c_char
         };
 
         if tmp_pointer.is_null() {
@@ -102,17 +101,15 @@ impl EntryCompletion {
 
     pub fn insert_action_text(&self, index_: i32, text: &str) {
         unsafe {
-            let c_str = CString::from_slice(text.as_bytes());
-
-            ffi::gtk_entry_completion_insert_action_text(GTK_ENTRY_COMPLETION(self.pointer), index_, c_str.as_ptr())
+            let mut tmp_text = text.to_tmp_for_borrow();
+            ffi::gtk_entry_completion_insert_action_text(GTK_ENTRY_COMPLETION(self.pointer), index_, tmp_text.to_glib_ptr())
         }
     }
 
     pub fn insert_action_markup(&self, index_: i32, markup: &str) {
         unsafe {
-            let c_str = CString::from_slice(markup.as_bytes());
-
-            ffi::gtk_entry_completion_insert_action_markup(GTK_ENTRY_COMPLETION(self.pointer), index_, c_str.as_ptr())
+            let mut tmp_markup = markup.to_tmp_for_borrow();
+            ffi::gtk_entry_completion_insert_action_markup(GTK_ENTRY_COMPLETION(self.pointer), index_, tmp_markup.to_glib_ptr())
         }
     }
 

--- a/src/gtk/widgets/expander.rs
+++ b/src/gtk/widgets/expander.rs
@@ -18,6 +18,7 @@
 use libc::c_int;
 use std::ffi::CString;
 
+use glib::translate::{FromGlibPtr};
 use gtk::cast::GTK_EXPANDER;
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
@@ -86,13 +87,8 @@ impl Expander {
 
     pub fn get_label(&self) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_expander_get_label(GTK_EXPANDER(self.pointer));
-            
-            if c_str.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&c_str)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_expander_get_label(GTK_EXPANDER(self.pointer)))
         }
     }
 

--- a/src/gtk/widgets/expander.rs
+++ b/src/gtk/widgets/expander.rs
@@ -16,9 +16,8 @@
 //! A container which can hide its child
 
 use libc::c_int;
-use std::ffi::CString;
 
-use glib::translate::{FromGlibPtr};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 use gtk::cast::GTK_EXPANDER;
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
@@ -29,17 +28,17 @@ struct_Widget!(Expander);
 
 impl Expander {
     pub fn new(label: &str) -> Option<Expander> {
-        let c_str = CString::from_slice(label.as_bytes());
         let tmp_pointer = unsafe {
-            ffi::gtk_expander_new(c_str.as_ptr())
+            let mut tmp_label = label.to_tmp_for_borrow();
+            ffi::gtk_expander_new(tmp_label.to_glib_ptr())
         };
         check_pointer!(tmp_pointer, Expander)
     }
 
     pub fn new_with_mnemonic(mnemonic: &str) -> Option<Expander> {
-        let c_str = CString::from_slice(mnemonic.as_bytes());
         let tmp_pointer = unsafe {
-            ffi::gtk_expander_new_with_mnemonic(c_str.as_ptr())
+            let mut tmp_mnemonic = mnemonic.to_tmp_for_borrow();
+            ffi::gtk_expander_new_with_mnemonic(tmp_mnemonic.to_glib_ptr())
         };
         check_pointer!(tmp_pointer, Expander)
     }
@@ -93,10 +92,9 @@ impl Expander {
     }
 
     pub fn set_label(&mut self, label: &str) -> () {
-        let c_str = CString::from_slice(label.as_bytes());
-
         unsafe {
-            ffi::gtk_expander_set_label(GTK_EXPANDER(self.pointer), c_str.as_ptr());
+            let mut tmp_label = label.to_tmp_for_borrow();
+            ffi::gtk_expander_set_label(GTK_EXPANDER(self.pointer), tmp_label.to_glib_ptr());
         }
     }
 

--- a/src/gtk/widgets/file_filter.rs
+++ b/src/gtk/widgets/file_filter.rs
@@ -14,7 +14,6 @@
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
 use gtk::ffi;
-use std::ffi::CString;
 use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 
 pub struct FileFilter {
@@ -33,10 +32,9 @@ impl FileFilter {
     }
 
     pub fn set_name(&self, name: &str) -> () {
-        let c_str = CString::from_slice(name.as_bytes());
-
         unsafe {
-            ffi::gtk_file_filter_set_name(self.pointer, c_str.as_ptr())
+            let mut tmp_name = name.to_tmp_for_borrow();
+            ffi::gtk_file_filter_set_name(self.pointer, tmp_name.to_glib_ptr())
         };
     }
 
@@ -55,10 +53,9 @@ impl FileFilter {
     }
 
     pub fn add_pattern(&self, pattern: &str) -> () {
-        let c_str = CString::from_slice(pattern.as_bytes());
-
         unsafe {
-            ffi::gtk_file_filter_add_pattern(self.pointer, c_str.as_ptr())
+            let mut tmp_pattern = pattern.to_tmp_for_borrow();
+            ffi::gtk_file_filter_add_pattern(self.pointer, tmp_pattern.to_glib_ptr())
         };
     }
 

--- a/src/gtk/widgets/file_filter.rs
+++ b/src/gtk/widgets/file_filter.rs
@@ -15,7 +15,7 @@
 
 use gtk::ffi;
 use std::ffi::CString;
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 
 pub struct FileFilter {
     pointer : *mut ffi::C_GtkFileFilter
@@ -42,13 +42,8 @@ impl FileFilter {
 
     pub fn get_name(&self) -> Option<String> {
         unsafe {
-            let name = ffi::gtk_file_filter_get_name(self.pointer);
-
-            if name.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&name)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_file_filter_get_name(self.pointer))
         }
     }
 

--- a/src/gtk/widgets/file_filter.rs
+++ b/src/gtk/widgets/file_filter.rs
@@ -15,6 +15,7 @@
 
 use gtk::ffi;
 use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 
 pub struct FileFilter {
     pointer : *mut ffi::C_GtkFileFilter
@@ -53,9 +54,8 @@ impl FileFilter {
 
     pub fn add_mime_type(&self, mime_type: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(mime_type.as_bytes());
-
-            ffi::gtk_file_filter_add_mime_type(self.pointer, c_str.as_ptr())
+            let mut tmp_mime_type = mime_type.to_tmp_for_borrow();
+            ffi::gtk_file_filter_add_mime_type(self.pointer, tmp_mime_type.to_glib_ptr())
         };
     }
 

--- a/src/gtk/widgets/font_button.rs
+++ b/src/gtk/widgets/font_button.rs
@@ -15,7 +15,6 @@
 
 //! A button to launch a font chooser dialog
 
-use std::ffi::CString;
 use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
@@ -87,10 +86,9 @@ impl FontButton {
     }
 
     pub fn set_title(&mut self, title: &str) -> () {
-        let c_str = CString::from_slice(title.as_bytes());
-
         unsafe {
-            ffi::gtk_font_button_set_title(GTK_FONTBUTTON(self.pointer), c_str.as_ptr());
+            let mut tmp_title = title.to_tmp_for_borrow();
+            ffi::gtk_font_button_set_title(GTK_FONTBUTTON(self.pointer), tmp_title.to_glib_ptr());
         }
     }
 

--- a/src/gtk/widgets/font_button.rs
+++ b/src/gtk/widgets/font_button.rs
@@ -16,7 +16,7 @@
 //! A button to launch a font chooser dialog
 
 use std::ffi::CString;
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
 use gtk::cast::GTK_FONTBUTTON;
@@ -49,13 +49,8 @@ impl FontButton {
 
     pub fn get_font_name(&self) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_font_button_get_font_name(GTK_FONTBUTTON(self.pointer));
-
-            if c_str.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&c_str)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_font_button_get_font_name(GTK_FONTBUTTON(self.pointer)))
         }
     }
 
@@ -101,13 +96,8 @@ impl FontButton {
 
     pub fn get_title(&self) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_font_button_get_title(GTK_FONTBUTTON(self.pointer));
-            
-            if c_str.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&c_str)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_font_button_get_title(GTK_FONTBUTTON(self.pointer)))
         }
     }
 }

--- a/src/gtk/widgets/font_button.rs
+++ b/src/gtk/widgets/font_button.rs
@@ -16,6 +16,7 @@
 //! A button to launch a font chooser dialog
 
 use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
 use gtk::cast::GTK_FONTBUTTON;
@@ -35,17 +36,15 @@ impl FontButton {
 
     pub fn new_with_font(font_name: &str) -> Option<FontButton> {
         let tmp_pointer = unsafe {
-            let c_str = CString::from_slice(font_name.as_bytes());
-
-            ffi::gtk_font_button_new_with_font(c_str.as_ptr())
+            let mut tmp_font_name = font_name.to_tmp_for_borrow();
+            ffi::gtk_font_button_new_with_font(tmp_font_name.to_glib_ptr())
         };
         check_pointer!(tmp_pointer, FontButton)
     }
 
     pub fn set_font_name(&mut self, font_name: &str) -> bool {
-        let c_str = CString::from_slice(font_name.as_bytes());
-
-        unsafe { to_bool(ffi::gtk_font_button_set_font_name(GTK_FONTBUTTON(self.pointer), c_str.as_ptr())) }
+        let mut tmp_font_name = font_name.to_tmp_for_borrow();
+        unsafe { to_bool(ffi::gtk_font_button_set_font_name(GTK_FONTBUTTON(self.pointer), tmp_font_name.to_glib_ptr())) }
     }
 
     pub fn get_font_name(&self) -> Option<String> {

--- a/src/gtk/widgets/font_chooser_dialog.rs
+++ b/src/gtk/widgets/font_chooser_dialog.rs
@@ -16,16 +16,15 @@
 use gtk::{self, ffi};
 use gtk::FFIWidget;
 use gtk::cast::{GTK_WINDOW};
-use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 
 struct_Widget!(FontChooserDialog);
 
 impl FontChooserDialog {
     pub fn new(title: &str, parent: Option<gtk::Window>) -> Option<FontChooserDialog> {
         let tmp = unsafe {
-            let c_str = CString::from_slice(title.as_bytes());
-
-            ffi::gtk_font_chooser_dialog_new(c_str.as_ptr(),
+            let mut tmp_title = title.to_tmp_for_borrow();
+            ffi::gtk_font_chooser_dialog_new(tmp_title.to_glib_ptr(),
                 match parent {
                     Some(ref p) => GTK_WINDOW(p.unwrap_widget()),
                     None => GTK_WINDOW(::std::ptr::null_mut())

--- a/src/gtk/widgets/frame.rs
+++ b/src/gtk/widgets/frame.rs
@@ -15,9 +15,7 @@
 
 //! A bin with a decorative frame and optional label
 
-use std::ptr;
-use std::ffi::CString;
-
+use glib::translate::{ToGlibPtr, ToTmp};
 use gtk::{self, ffi};
 
 /// Frame — A bin with a decorative frame and optional label
@@ -25,13 +23,9 @@ struct_Widget!(Frame);
 
 impl Frame {
     pub fn new(label: Option<&str>) -> Option<Frame> {
-        let tmp_pointer = match label {
-            Some(l) => unsafe {
-            	let c_str = CString::from_slice(l.as_bytes());
-
-            	ffi::gtk_frame_new(c_str.as_ptr())
-            },
-            None => unsafe { ffi::gtk_frame_new(ptr::null()) }
+        let tmp_pointer = unsafe {
+            let mut tmp_label = label.to_tmp_for_borrow();
+            ffi::gtk_frame_new(tmp_label.to_glib_ptr())
         };
         check_pointer!(tmp_pointer, Frame)
     }

--- a/src/gtk/widgets/gtype.rs
+++ b/src/gtk/widgets/gtype.rs
@@ -19,6 +19,7 @@
 pub mod g_type {
     use gtk::ffi;
     use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
     use glib_ffi::{self};
 
     pub fn name(_type: glib_ffi::GType) -> Option<String> {
@@ -33,9 +34,8 @@ pub mod g_type {
 
     pub fn from_name(name: &str) -> glib_ffi::GType {
         unsafe {
-            let c_str = CString::from_slice(name.as_bytes());
-
-            ffi::g_type_from_name(c_str.as_ptr())
+            let mut tmp_name = name.to_tmp_for_borrow();
+            ffi::g_type_from_name(tmp_name.to_glib_ptr())
         }
     }
 

--- a/src/gtk/widgets/gtype.rs
+++ b/src/gtk/widgets/gtype.rs
@@ -19,16 +19,13 @@
 pub mod g_type {
     use gtk::ffi;
     use std::ffi::CString;
-use glib::translate::{ToGlibPtr, ToTmp};
+    use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
     use glib_ffi::{self};
 
     pub fn name(_type: glib_ffi::GType) -> Option<String> {
-        let tmp_pointer = unsafe { ffi::g_type_name(_type) };
-
-        if tmp_pointer.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp_pointer)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::g_type_name(_type))
         }
     }
 

--- a/src/gtk/widgets/header_bar.rs
+++ b/src/gtk/widgets/header_bar.rs
@@ -20,6 +20,7 @@
 use gtk::cast::{GTK_HEADER_BAR};
 use gtk::{self, ffi};
 use std::ffi::CString;
+use glib::translate::{FromGlibPtr};
 use glib::{to_bool, to_gboolean};
 
 /// GtkHeaderBar — A Box::new(with) a centered child
@@ -40,12 +41,9 @@ impl HeaderBar {
     }
 
     pub fn get_title(&self) -> Option<String> {
-        let c_title = unsafe { ffi::gtk_header_bar_get_title(GTK_HEADER_BAR(self.pointer)) };
-
-        if c_title.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&c_title)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gtk_header_bar_get_title(GTK_HEADER_BAR(self.pointer)))
         }
     }
 
@@ -58,12 +56,9 @@ impl HeaderBar {
     }
 
     pub fn get_subtitle(&self) -> Option<String> {
-        let c_subtitle = unsafe { ffi::gtk_header_bar_get_title(GTK_HEADER_BAR(self.pointer)) };
-
-        if c_subtitle.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&c_subtitle)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gtk_header_bar_get_title(GTK_HEADER_BAR(self.pointer)))
         }
     }
 

--- a/src/gtk/widgets/header_bar.rs
+++ b/src/gtk/widgets/header_bar.rs
@@ -19,8 +19,7 @@
 
 use gtk::cast::{GTK_HEADER_BAR};
 use gtk::{self, ffi};
-use std::ffi::CString;
-use glib::translate::{FromGlibPtr};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 use glib::{to_bool, to_gboolean};
 
 /// GtkHeaderBar — A Box::new(with) a centered child
@@ -33,10 +32,10 @@ impl HeaderBar {
     }
 
     pub fn set_title(&mut self, title: &str) {
-        let c_str = CString::from_slice(title.as_bytes());
-
         unsafe {
-            ffi::gtk_header_bar_set_title(GTK_HEADER_BAR(self.pointer), c_str.as_ptr())
+            let mut tmp_title = title.to_tmp_for_borrow();
+            ffi::gtk_header_bar_set_title(GTK_HEADER_BAR(self.pointer),
+                                          tmp_title.to_glib_ptr())
         }
     }
 
@@ -48,10 +47,10 @@ impl HeaderBar {
     }
 
     pub fn set_subtitle(&mut self, subtitle: &str) {
-        let c_str = CString::from_slice(subtitle.as_bytes());
-
         unsafe {
-            ffi::gtk_header_bar_set_subtitle(GTK_HEADER_BAR(self.pointer), c_str.as_ptr())
+            let mut tmp_subtitle = subtitle.to_tmp_for_borrow();
+            ffi::gtk_header_bar_set_subtitle(GTK_HEADER_BAR(self.pointer),
+                                             tmp_subtitle.to_glib_ptr())
         }
     }
 

--- a/src/gtk/widgets/image.rs
+++ b/src/gtk/widgets/image.rs
@@ -18,7 +18,6 @@
 use gtk::{self, ffi};
 use gtk::cast::GTK_IMAGE;
 use gtk::FFIWidget;
-use std::ffi::CString;
 use glib::translate::{ToGlibPtr, ToTmp};
 
 /// Image — A widget displaying an image
@@ -34,27 +33,26 @@ impl Image {
     }
 
     pub fn new_from_icon_name(icon_name: &str, size: gtk::IconSize) -> Option<Image> {
-        let c_str = CString::from_slice(icon_name.as_bytes());
-
         let tmp_pointer = unsafe {
-            ffi::gtk_image_new_from_icon_name(c_str.as_ptr(), size)
+            let mut tmp_icon_name = icon_name.to_tmp_for_borrow();
+            ffi::gtk_image_new_from_icon_name(tmp_icon_name.to_glib_ptr(), size)
         };
         check_pointer!(tmp_pointer, Image)
     }
 
     pub fn set_from_file(&self, filename: &str) {
-        let c_str = CString::from_slice(filename.as_bytes());
-
         unsafe {
-            ffi::gtk_image_set_from_file(GTK_IMAGE(self.unwrap_widget()), c_str.as_ptr());
+            let mut tmp_filename = filename.to_tmp_for_borrow();
+            ffi::gtk_image_set_from_file(GTK_IMAGE(self.unwrap_widget()),
+                                         tmp_filename.to_glib_ptr());
         };
     }
 
     pub fn set_from_icon_name(&self, icon_name: &str, size: gtk::IconSize) {
-        let c_str = CString::from_slice(icon_name.as_bytes());
-
         unsafe {
-            ffi::gtk_image_set_from_icon_name(GTK_IMAGE(self.unwrap_widget()), c_str.as_ptr(), size)
+            let mut tmp_icon_name = icon_name.to_tmp_for_borrow();
+            ffi::gtk_image_set_from_icon_name(GTK_IMAGE(self.unwrap_widget()),
+                                              tmp_icon_name.to_glib_ptr(), size)
         };
     }
 }

--- a/src/gtk/widgets/image.rs
+++ b/src/gtk/widgets/image.rs
@@ -19,6 +19,7 @@ use gtk::{self, ffi};
 use gtk::cast::GTK_IMAGE;
 use gtk::FFIWidget;
 use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 
 /// Image — A widget displaying an image
 struct_Widget!(Image);
@@ -26,9 +27,8 @@ struct_Widget!(Image);
 impl Image {
     pub fn new_from_file(filename: &str) -> Option<Image> {
         let tmp_pointer = unsafe {
-            let c_str = CString::from_slice(filename.as_bytes());
-
-            ffi::gtk_image_new_from_file(c_str.as_ptr())
+            let mut tmp_filename = filename.to_tmp_for_borrow();
+            ffi::gtk_image_new_from_file(tmp_filename.to_glib_ptr())
         };
         check_pointer!(tmp_pointer, Image)
     }

--- a/src/gtk/widgets/info_bar.rs
+++ b/src/gtk/widgets/info_bar.rs
@@ -16,7 +16,7 @@
 //! Report important messages to the user
 
 use libc::c_int;
-use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 
 use gtk::MessageType;
 use gtk::cast::GTK_INFOBAR;
@@ -40,8 +40,8 @@ impl InfoBar {
 
     pub fn add_button(&mut self, button_text: &str, response_id: i32) -> gtk::Button {
         let button = unsafe {
-            let c_str = CString::from_slice(button_text.as_bytes());
-            ffi::gtk_info_bar_add_button(GTK_INFOBAR(self.pointer), c_str.as_ptr(), response_id as c_int)
+            let mut tmp_button_text = button_text.to_tmp_for_borrow();
+            ffi::gtk_info_bar_add_button(GTK_INFOBAR(self.pointer), tmp_button_text.to_glib_ptr(), response_id as c_int)
         };
         gtk::FFIWidget::wrap_widget(button)
     }

--- a/src/gtk/widgets/label.rs
+++ b/src/gtk/widgets/label.rs
@@ -16,6 +16,7 @@
 //! A widget that displays a small to medium amount of text
 
 use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 use gtk::{self, ffi};
 
 /// Label — A widget that displays a small to medium amount of text
@@ -32,8 +33,8 @@ struct_Widget!(Label);
 impl Label {
     pub fn new(text: &str) -> Option<Label> {
         let tmp_pointer = unsafe {
-            let c_str = CString::from_slice(text.as_bytes());
-            ffi::gtk_label_new(c_str.as_ptr())
+            let mut tmp_text = text.to_tmp_for_borrow();
+            ffi::gtk_label_new(tmp_text.to_glib_ptr())
         };
         check_pointer!(tmp_pointer, Label)
     }

--- a/src/gtk/widgets/label.rs
+++ b/src/gtk/widgets/label.rs
@@ -15,7 +15,6 @@
 
 //! A widget that displays a small to medium amount of text
 
-use std::ffi::CString;
 use glib::translate::{ToGlibPtr, ToTmp};
 use gtk::{self, ffi};
 
@@ -40,9 +39,9 @@ impl Label {
     }
 
     pub fn new_with_mnemonic(text: &str) -> Option<Label> {
-        let c_str = CString::from_slice(text.as_bytes());
         let tmp_pointer = unsafe {
-            ffi::gtk_label_new_with_mnemonic(c_str.as_ptr())
+            let mut tmp_text = text.to_tmp_for_borrow();
+            ffi::gtk_label_new_with_mnemonic(tmp_text.to_glib_ptr())
         };
         check_pointer!(tmp_pointer, Label)
     }

--- a/src/gtk/widgets/level_bar.rs
+++ b/src/gtk/widgets/level_bar.rs
@@ -17,6 +17,7 @@
 
 use libc::c_double;
 use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
@@ -116,9 +117,8 @@ impl LevelBar {
 
     pub fn get_offset_value(&self, name: &str) -> Option<f64> {
         let value = 0.;
-        let c_str = CString::from_slice(name.as_bytes());
-
-        match unsafe { ffi::gtk_level_bar_get_offset_value(GTK_LEVELBAR(self.pointer), c_str.as_ptr(), &value) }{
+        let mut tmp_name = name.to_tmp_for_borrow();
+        match unsafe { ffi::gtk_level_bar_get_offset_value(GTK_LEVELBAR(self.pointer), tmp_name.to_glib_ptr(), &value) }{
             0132     => None,
             _        => Some(value)
         }

--- a/src/gtk/widgets/level_bar.rs
+++ b/src/gtk/widgets/level_bar.rs
@@ -16,7 +16,6 @@
 //! A bar that can used as a level indicator
 
 use libc::c_double;
-use std::ffi::CString;
 use glib::translate::{ToGlibPtr, ToTmp};
 
 use gtk::{self, ffi};
@@ -101,26 +100,41 @@ impl LevelBar {
     }
 
     pub fn add_offset_value(&mut self, name: &str, value: f64) -> () {
-        let c_str = CString::from_slice(name.as_bytes());
         unsafe {
-            ffi::gtk_level_bar_add_offset_value(GTK_LEVELBAR(self.pointer), c_str.as_ptr(), value as c_double)
+            let mut tmp_name = name.to_tmp_for_borrow();
+            ffi::gtk_level_bar_add_offset_value(
+                GTK_LEVELBAR(self.pointer),
+                tmp_name.to_glib_ptr(),
+                value as c_double)
         }
     }
 
     pub fn remove_offset_value(&mut self, name: &str) -> () {
-        let c_str = CString::from_slice(name.as_bytes());
-
         unsafe {
-            ffi::gtk_level_bar_remove_offset_value(GTK_LEVELBAR(self.pointer), c_str.as_ptr());
+            let mut tmp_name = name.to_tmp_for_borrow();
+            ffi::gtk_level_bar_remove_offset_value(
+                GTK_LEVELBAR(self.pointer),
+                tmp_name.to_glib_ptr());
         }
     }
 
     pub fn get_offset_value(&self, name: &str) -> Option<f64> {
-        let value = 0.;
-        let mut tmp_name = name.to_tmp_for_borrow();
-        match unsafe { ffi::gtk_level_bar_get_offset_value(GTK_LEVELBAR(self.pointer), tmp_name.to_glib_ptr(), &value) }{
-            0132     => None,
-            _        => Some(value)
+        unsafe {
+            let mut value = 0.;
+            let mut tmp_name = name.to_tmp_for_borrow();
+
+            let res = to_bool(
+                ffi::gtk_level_bar_get_offset_value(
+                    GTK_LEVELBAR(self.pointer),
+                    tmp_name.to_glib_ptr(),
+                    &mut value));
+
+            if res {
+                Some(value)
+            }
+            else {
+                None
+            }
         }
     }
 }

--- a/src/gtk/widgets/link_button.rs
+++ b/src/gtk/widgets/link_button.rs
@@ -16,6 +16,7 @@
 //! Create buttons bound to a URL
 
 use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 use gtk::cast::GTK_LINKBUTTON;
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
@@ -30,9 +31,8 @@ struct_Widget!(LinkButton);
 impl LinkButton {
     pub fn new(uri: &str) -> Option<LinkButton> {
         let tmp_pointer = unsafe {
-            let c_str = CString::from_slice(uri.as_bytes());
-
-            ffi::gtk_link_button_new(c_str.as_ptr())
+            let mut tmp_uri = uri.to_tmp_for_borrow();
+            ffi::gtk_link_button_new(tmp_uri.to_glib_ptr())
         };
         check_pointer!(tmp_pointer, LinkButton)
     }

--- a/src/gtk/widgets/link_button.rs
+++ b/src/gtk/widgets/link_button.rs
@@ -15,7 +15,6 @@
 
 //! Create buttons bound to a URL
 
-use std::ffi::CString;
 use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 use gtk::cast::GTK_LINKBUTTON;
 use gtk::{self, ffi};
@@ -38,11 +37,10 @@ impl LinkButton {
     }
 
     pub fn new_with_label(uri: &str, label: &str) -> Option<LinkButton> {
-        let c_uri = CString::from_slice(uri.as_bytes());
-        let c_label = CString::from_slice(label.as_bytes());
-
         let tmp_pointer = unsafe {
-            ffi::gtk_link_button_new_with_label(c_uri.as_ptr(), c_label.as_ptr())
+            let mut tmp_uri = uri.to_tmp_for_borrow();
+            let mut tmp_label = label.to_tmp_for_borrow();
+            ffi::gtk_link_button_new_with_label(tmp_uri.as_ptr(), tmp_label.as_ptr())
         };
         check_pointer!(tmp_pointer, LinkButton)
     }
@@ -55,10 +53,9 @@ impl LinkButton {
     }
 
     pub fn set_uri(&mut self, uri: &str) -> () {
-        let c_str = CString::from_slice(uri.as_bytes());
-
         unsafe {
-            ffi::gtk_link_button_set_uri(GTK_LINKBUTTON(self.pointer), c_str.as_ptr())
+            let mut tmp_uri = uri.to_tmp_for_borrow();
+            ffi::gtk_link_button_set_uri(GTK_LINKBUTTON(self.pointer), tmp_uri.as_ptr())
         }
     }
 

--- a/src/gtk/widgets/link_button.rs
+++ b/src/gtk/widgets/link_button.rs
@@ -16,7 +16,7 @@
 //! Create buttons bound to a URL
 
 use std::ffi::CString;
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 use gtk::cast::GTK_LINKBUTTON;
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
@@ -49,13 +49,8 @@ impl LinkButton {
 
     pub fn get_uri(&self) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_link_button_get_uri(GTK_LINKBUTTON(self.pointer));
-
-            if c_str.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&c_str)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_link_button_get_uri(GTK_LINKBUTTON(self.pointer)))
         }
     }
 

--- a/src/gtk/widgets/list_store.rs
+++ b/src/gtk/widgets/list_store.rs
@@ -17,7 +17,7 @@ use glib::{to_bool, Value, Type};
 use glib::translate::ToGlib;
 use gtk::{self, ffi};
 use gtk::TreeIter;
-use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 use std::num::ToPrimitive;
 
 pub struct ListStore {
@@ -38,9 +38,8 @@ impl ListStore {
 
     pub fn set_string(&self, iter: &TreeIter, column: i32, text: &str) {
         unsafe {
-            let text_c = CString::from_slice(text.as_bytes());
-
-            ffi::gtk_list_store_set(self.pointer, iter.unwrap_pointer(), column, text_c.as_ptr(), -1)
+            let mut tmp_text = text.to_tmp_for_borrow();
+            ffi::gtk_list_store_set(self.pointer, iter.unwrap_pointer(), column, tmp_text.to_glib_ptr(), -1)
         }
     }
 

--- a/src/gtk/widgets/menu_item.rs
+++ b/src/gtk/widgets/menu_item.rs
@@ -16,7 +16,6 @@
 //! The widget used for item in menus
 
 use gtk::{self, ffi};
-use std::ffi::CString;
 use glib::translate::{ToGlibPtr, ToTmp};
 
 /// MenuItem — The widget used for item in menus
@@ -37,10 +36,9 @@ impl MenuItem {
     }
 
     pub fn new_with_mnemonic(mnemonic: &str) -> Option<MenuItem> {
-        let c_str = CString::from_slice(mnemonic.as_bytes());
-
         let tmp_pointer = unsafe {
-            ffi::gtk_menu_item_new_with_mnemonic(c_str.as_ptr())
+            let mut tmp_mnemonic = mnemonic.to_tmp_for_borrow();
+            ffi::gtk_menu_item_new_with_mnemonic(tmp_mnemonic.to_glib_ptr())
         };
         check_pointer!(tmp_pointer, MenuItem)
     }

--- a/src/gtk/widgets/menu_item.rs
+++ b/src/gtk/widgets/menu_item.rs
@@ -17,6 +17,7 @@
 
 use gtk::{self, ffi};
 use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 
 /// MenuItem — The widget used for item in menus
 struct_Widget!(MenuItem);
@@ -29,9 +30,8 @@ impl MenuItem {
 
     pub fn new_with_label(label: &str) -> Option<MenuItem> {
         let tmp_pointer = unsafe {
-            let c_str = CString::from_slice(label.as_bytes());
-
-            ffi::gtk_menu_item_new_with_label(c_str.as_ptr())
+            let mut tmp_label = label.to_tmp_for_borrow();
+            ffi::gtk_menu_item_new_with_label(tmp_label.to_glib_ptr())
         };
         check_pointer!(tmp_pointer, MenuItem)
     }

--- a/src/gtk/widgets/menu_tool_button.rs
+++ b/src/gtk/widgets/menu_tool_button.rs
@@ -20,6 +20,7 @@ use std::ptr;
 use gtk::cast::GTK_MENUTOOLBUTTON;
 use gtk::{self, ffi};
 use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 
 /// MenuToolButton — A ToolItem containing a button with an additional dropdown menu
 struct_Widget!(MenuToolButton);
@@ -49,18 +50,16 @@ impl MenuToolButton {
 
     pub fn new_from_stock(stock_id: &str) -> Option<MenuToolButton> {
         let tmp_pointer = unsafe {
-            let c_str = CString::from_slice(stock_id.as_bytes());
-
-            ffi::gtk_menu_tool_button_new_from_stock(c_str.as_ptr())
+            let mut tmp_stock_id = stock_id.to_tmp_for_borrow();
+            ffi::gtk_menu_tool_button_new_from_stock(tmp_stock_id.to_glib_ptr())
         };
         check_pointer!(tmp_pointer, MenuToolButton)
     }
 
     pub fn set_arrow_tooltip_text(&mut self, text: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(text.as_bytes());
-
-            ffi::gtk_menu_tool_button_set_arrow_tooltip_text(GTK_MENUTOOLBUTTON(self.pointer), c_str.as_ptr())
+            let mut tmp_text = text.to_tmp_for_borrow();
+            ffi::gtk_menu_tool_button_set_arrow_tooltip_text(GTK_MENUTOOLBUTTON(self.pointer), tmp_text.to_glib_ptr())
         }
     }
 

--- a/src/gtk/widgets/menu_tool_button.rs
+++ b/src/gtk/widgets/menu_tool_button.rs
@@ -19,7 +19,6 @@ use std::ptr;
 
 use gtk::cast::GTK_MENUTOOLBUTTON;
 use gtk::{self, ffi};
-use std::ffi::CString;
 use glib::translate::{ToGlibPtr, ToTmp};
 
 /// MenuToolButton — A ToolItem containing a button with an additional dropdown menu
@@ -28,22 +27,13 @@ struct_Widget!(MenuToolButton);
 impl MenuToolButton {
     pub fn new<T: gtk::WidgetTrait>(icon_widget: Option<&T>, label: Option<&str>) -> Option<MenuToolButton> {
         let tmp_pointer = unsafe {
-            match label {
-                Some(l) => {
-                    let c_str = CString::from_slice(l.as_bytes());
+            let mut tmp_label = label.to_tmp_for_borrow();
+            let icon_widget_ptr = match icon_widget {
+                Some(i) => i.unwrap_widget(),
+                None    => ptr::null_mut(),
+            };
 
-                    match icon_widget {
-                        Some(i) => ffi::gtk_menu_tool_button_new(i.unwrap_widget(), c_str.as_ptr()),
-                        None    => ffi::gtk_menu_tool_button_new(ptr::null_mut(), c_str.as_ptr())
-                    }
-                },
-                None    => {
-                    match icon_widget {
-                        Some(i) => ffi::gtk_menu_tool_button_new(i.unwrap_widget(), ptr::null()),
-                        None    => ffi::gtk_menu_tool_button_new(ptr::null_mut(), ptr::null())
-                    }
-                }
-            }
+            ffi::gtk_menu_tool_button_new(icon_widget_ptr, tmp_label.to_glib_ptr())
         };
         check_pointer!(tmp_pointer, MenuToolButton)
     }
@@ -64,10 +54,11 @@ impl MenuToolButton {
     }
 
     pub fn set_arrow_tooltip_markup(&mut self, markup: &str) -> () {
-        let c_str = CString::from_slice(markup.as_bytes());
-
         unsafe {
-            ffi::gtk_menu_tool_button_set_arrow_tooltip_markup(GTK_MENUTOOLBUTTON(self.pointer), c_str.as_ptr())
+            let mut tmp_markup = markup.to_tmp_for_borrow();
+            ffi::gtk_menu_tool_button_set_arrow_tooltip_markup(
+                GTK_MENUTOOLBUTTON(self.pointer),
+                tmp_markup.to_glib_ptr())
         }
     }
 }

--- a/src/gtk/widgets/message_dialog.rs
+++ b/src/gtk/widgets/message_dialog.rs
@@ -16,7 +16,7 @@
 use gtk::{self, ffi};
 use gtk::FFIWidget;
 use gtk::cast::{GTK_MESSAGE_DIALOG, GTK_WINDOW};
-use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 
 struct_Widget!(MessageDialog);
 
@@ -48,9 +48,8 @@ impl MessageDialog {
 
     pub fn set_markup(&self, markup: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(markup.as_bytes());
-
-            ffi::gtk_message_dialog_set_markup(GTK_MESSAGE_DIALOG(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_markup = markup.to_tmp_for_borrow();
+            ffi::gtk_message_dialog_set_markup(GTK_MESSAGE_DIALOG(self.unwrap_widget()), tmp_markup.to_glib_ptr())
         }
     }
 

--- a/src/gtk/widgets/note_book.rs
+++ b/src/gtk/widgets/note_book.rs
@@ -19,6 +19,7 @@ use gtk::{self, ffi};
 use gtk::cast::GTK_NOTEBOOK;
 use gtk::FFIWidget;
 use std::ffi::CString;
+use glib::translate::{FromGlibPtr};
 use glib::{to_bool, to_gboolean};
 
 /// GtkNotebook — A tabbed notebook container
@@ -122,13 +123,8 @@ impl NoteBook {
 
     pub fn get_group_name(&mut self) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_notebook_get_group_name(GTK_NOTEBOOK(self.pointer));
-
-            if c_str.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&c_str)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_notebook_get_group_name(GTK_NOTEBOOK(self.pointer)))
         }
     }
 

--- a/src/gtk/widgets/note_book.rs
+++ b/src/gtk/widgets/note_book.rs
@@ -18,8 +18,7 @@
 use gtk::{self, ffi};
 use gtk::cast::GTK_NOTEBOOK;
 use gtk::FFIWidget;
-use std::ffi::CString;
-use glib::translate::{FromGlibPtr};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 use glib::{to_bool, to_gboolean};
 
 /// GtkNotebook — A tabbed notebook container
@@ -114,10 +113,10 @@ impl NoteBook {
     }
 
     pub fn set_group_name(&mut self, group_name: &str) {
-        let c_str = CString::from_slice(group_name.as_bytes());
-
         unsafe {
-            ffi::gtk_notebook_set_group_name(GTK_NOTEBOOK(self.pointer), c_str.as_ptr())
+            let mut tmp_group_name = group_name.to_tmp_for_borrow();
+            ffi::gtk_notebook_set_group_name(GTK_NOTEBOOK(self.pointer),
+                                             tmp_group_name.to_glib_ptr())
         }
     }
 
@@ -270,25 +269,19 @@ impl NoteBook {
     }
 
     pub fn set_tab_label_text<T: gtk::WidgetTrait>(&mut self, child: &T, tab_text: &str) {
-        let c_str = CString::from_slice(tab_text.as_bytes());
-
         unsafe {
+            let mut tmp_tab_text = tab_text.to_tmp_for_borrow();
             ffi::gtk_notebook_set_tab_label_text(GTK_NOTEBOOK(self.pointer),
                                                  child.unwrap_widget(),
-                                                 c_str.as_ptr())
+                                                 tmp_tab_text.to_glib_ptr())
         }
     }
 
     pub fn get_tab_label_text<T: gtk::WidgetTrait>(&mut self, child: &T) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_notebook_get_tab_label_text(GTK_NOTEBOOK(self.pointer),
-                                                             child.unwrap_widget());
-            
-            if c_str.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&c_str)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_notebook_get_tab_label_text(GTK_NOTEBOOK(self.pointer),
+                                                     child.unwrap_widget()))
         }
     }
 
@@ -313,25 +306,19 @@ impl NoteBook {
     }
 
     pub fn set_menu_label_text<T: gtk::WidgetTrait>(&mut self, child: &T, tab_text: &str) {
-        let c_str = CString::from_slice(tab_text.as_bytes());
-
         unsafe {
+            let mut tmp_tab_text = tab_text.to_tmp_for_borrow();
             ffi::gtk_notebook_set_menu_label_text(GTK_NOTEBOOK(self.pointer),
                                                   child.unwrap_widget(),
-                                                  c_str.as_ptr())
+                                                  tmp_tab_text.to_glib_ptr())
         }
     }
 
     pub fn get_menu_label_text<T: gtk::WidgetTrait>(&mut self, child: &T) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_notebook_get_menu_label_text(GTK_NOTEBOOK(self.pointer),
-                                                              child.unwrap_widget());
-
-            if c_str.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&c_str)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_notebook_get_menu_label_text(GTK_NOTEBOOK(self.pointer),
+                                                              child.unwrap_widget()))
         }
     }
 

--- a/src/gtk/widgets/paper_size.rs
+++ b/src/gtk/widgets/paper_size.rs
@@ -14,22 +14,20 @@
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
 use gtk::{self, ffi};
-use glib::translate::{FromGlibPtr};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 use glib::{to_bool, to_gboolean};
 use gtk::FFIWidget;
 use gtk::cast::{GTK_PAPER_SIZE};
 use glib;
-use std::ffi::CString;
 
 // FIXME: PaperSize is not a widget nor a GObject -> GBoxed
 struct_Widget!(PaperSize);
 
 impl PaperSize {
     pub fn new(name: &str) -> Option<PaperSize> {
-        let c_str = CString::from_slice(name.as_bytes());
-
         let tmp_pointer = unsafe {
-            ffi::gtk_paper_size_new(c_str.as_ptr())
+            let mut tmp_name = name.to_tmp_for_borrow();
+            ffi::gtk_paper_size_new(tmp_name.to_glib_ptr())
         };
 
         if tmp_pointer.is_null() {
@@ -40,10 +38,12 @@ impl PaperSize {
     }
 
     pub fn new_from_ppd(ppd_name: &str, ppd_display_name: &str, width: f64, height: f64) -> Option<PaperSize> {
-        let c_str = CString::from_slice(ppd_name.as_bytes());
-        let c_str2 = CString::from_slice(ppd_display_name.as_bytes());
         let tmp_pointer = unsafe {
-            ffi::gtk_paper_size_new_from_ppd(c_str.as_ptr(), c_str2.as_ptr(), width, height)
+            let mut tmp_ppd_name = ppd_name.to_tmp_for_borrow();
+            let mut tmp_ppd_display_name = ppd_display_name.to_tmp_for_borrow();
+            ffi::gtk_paper_size_new_from_ppd(tmp_ppd_name.to_glib_ptr(),
+                                             tmp_ppd_display_name.to_glib_ptr(),
+                                             width, height)
         };
 
         if tmp_pointer.is_null() {
@@ -54,10 +54,12 @@ impl PaperSize {
     }
 
     pub fn new_custom(name: &str, display_name: &str, width: f64, height: f64, unit: gtk::Unit) -> Option<PaperSize> {
-        let c_str = CString::from_slice(name.as_bytes());
-        let c_str2 = CString::from_slice(display_name.as_bytes());
         let tmp_pointer = unsafe {
-            ffi::gtk_paper_size_new_custom(c_str.as_ptr(), c_str2.as_ptr(), width, height, unit)
+            let mut tmp_name = name.to_tmp_for_borrow();
+            let mut tmp_display_name = display_name.to_tmp_for_borrow();
+            ffi::gtk_paper_size_new_custom(tmp_name.to_glib_ptr(),
+                                           tmp_display_name.to_glib_ptr(),
+                                           width, height, unit)
         };
 
         if tmp_pointer.is_null() {

--- a/src/gtk/widgets/paper_size.rs
+++ b/src/gtk/widgets/paper_size.rs
@@ -14,6 +14,7 @@
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
 use gtk::{self, ffi};
+use glib::translate::{FromGlibPtr};
 use glib::{to_bool, to_gboolean};
 use gtk::FFIWidget;
 use gtk::cast::{GTK_PAPER_SIZE};
@@ -98,32 +99,23 @@ impl PaperSize {
     }
 
     pub fn get_name(&self) -> Option<String> {
-        let tmp = unsafe { ffi::gtk_paper_size_get_name(GTK_PAPER_SIZE(self.unwrap_widget())) };
-
-        if tmp.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gtk_paper_size_get_name(GTK_PAPER_SIZE(self.unwrap_widget())))
         }
     }
 
     pub fn get_display_name_name(&self) -> Option<String> {
-        let tmp = unsafe { ffi::gtk_paper_size_get_display_name(GTK_PAPER_SIZE(self.unwrap_widget())) };
-
-        if tmp.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gtk_paper_size_get_display_name(GTK_PAPER_SIZE(self.unwrap_widget())))
         }
     }
 
     pub fn get_ppd_name(&self) -> Option<String> {
-        let tmp = unsafe { ffi::gtk_paper_size_get_ppd_name(GTK_PAPER_SIZE(self.unwrap_widget())) };
-
-        if tmp.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gtk_paper_size_get_ppd_name(GTK_PAPER_SIZE(self.unwrap_widget())))
         }
     }
 
@@ -160,12 +152,9 @@ impl PaperSize {
     }
 
     pub fn get_default() -> Option<String> {
-        let tmp = unsafe { ffi::gtk_paper_size_get_default() };
-
-        if tmp.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gtk_paper_size_get_default())
         }
     }
 }

--- a/src/gtk/widgets/print_settings.rs
+++ b/src/gtk/widgets/print_settings.rs
@@ -17,7 +17,6 @@ use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
 use gtk::FFIWidget;
 use gtk::cast::{GTK_PRINT_SETTINGS, GTK_PAPER_SIZE};
-use std::ffi::CString;
 use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 
 struct_Widget!(PrintSettings);
@@ -44,10 +43,11 @@ impl PrintSettings {
     }
 
     pub fn has_key(&self, key: &str) -> bool {
-        let c_str = CString::from_slice(key.as_bytes());
-
         unsafe {
-            to_bool(ffi::gtk_print_settings_has_key(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr()))
+            let mut tmp_key = key.to_tmp_for_borrow();
+            to_bool(
+                ffi::gtk_print_settings_has_key(GTK_PRINT_SETTINGS(self.unwrap_widget()),
+                                                tmp_key.to_glib_ptr()))
         }
     }
 
@@ -61,9 +61,12 @@ impl PrintSettings {
 
     pub fn set(&self, key: &str, value: &str) {
         unsafe {
-            let c_str = CString::from_slice(key.as_bytes());
+            let mut tmp_key = key.to_tmp_for_borrow();
             let mut tmp_value = value.to_tmp_for_borrow();
-            ffi::gtk_print_settings_set(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr(), tmp_value.to_glib_ptr())
+            ffi::gtk_print_settings_set(GTK_PRINT_SETTINGS(
+                self.unwrap_widget()),
+                tmp_key.to_glib_ptr(),
+                tmp_value.to_glib_ptr())
         }
     }
 

--- a/src/gtk/widgets/print_settings.rs
+++ b/src/gtk/widgets/print_settings.rs
@@ -18,7 +18,7 @@ use glib::{to_bool, to_gboolean};
 use gtk::FFIWidget;
 use gtk::cast::{GTK_PRINT_SETTINGS, GTK_PAPER_SIZE};
 use std::ffi::CString;
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 
 struct_Widget!(PrintSettings);
 
@@ -54,13 +54,8 @@ impl PrintSettings {
     pub fn get(&self, key: &str) -> Option<String> {
         unsafe {
             let mut tmp_key = key.to_tmp_for_borrow();
-            let tmp = ffi::gtk_print_settings_get(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_key.to_glib_ptr());
-
-            if tmp.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_print_settings_get(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_key.to_glib_ptr()))
         }
     }
 
@@ -150,12 +145,9 @@ impl PrintSettings {
     }
 
     pub fn get_printer(&self) -> Option<String> {
-        let tmp = unsafe { ffi::gtk_print_settings_get_printer(GTK_PRINT_SETTINGS(self.unwrap_widget())) };
-
-        if tmp.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gtk_print_settings_get_printer(GTK_PRINT_SETTINGS(self.unwrap_widget())))
         }
     }
 
@@ -299,12 +291,9 @@ impl PrintSettings {
     }
 
     pub fn get_default_source(&self) -> Option<String> {
-        let tmp = unsafe { ffi::gtk_print_settings_get_default_source(GTK_PRINT_SETTINGS(self.unwrap_widget())) };
-
-        if tmp.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gtk_print_settings_get_default_source(GTK_PRINT_SETTINGS(self.unwrap_widget())))
         }
     }
 
@@ -316,12 +305,9 @@ impl PrintSettings {
     }
 
     pub fn get_media_type(&self) -> Option<String> {
-        let tmp = unsafe { ffi::gtk_print_settings_get_media_type(GTK_PRINT_SETTINGS(self.unwrap_widget())) };
-
-        if tmp.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gtk_print_settings_get_media_type(GTK_PRINT_SETTINGS(self.unwrap_widget())))
         }
     }
 
@@ -333,12 +319,9 @@ impl PrintSettings {
     }
 
     pub fn get_dither(&self) -> Option<String> {
-        let tmp = unsafe { ffi::gtk_print_settings_get_dither(GTK_PRINT_SETTINGS(self.unwrap_widget())) };
-
-        if tmp.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gtk_print_settings_get_dither(GTK_PRINT_SETTINGS(self.unwrap_widget())))
         }
     }
 
@@ -350,12 +333,9 @@ impl PrintSettings {
     }
 
     pub fn get_finishings(&self) -> Option<String> {
-        let tmp = unsafe { ffi::gtk_print_settings_get_finishings(GTK_PRINT_SETTINGS(self.unwrap_widget())) };
-
-        if tmp.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gtk_print_settings_get_finishings(GTK_PRINT_SETTINGS(self.unwrap_widget())))
         }
     }
 
@@ -367,12 +347,9 @@ impl PrintSettings {
     }
 
     pub fn get_output_bin(&self) -> Option<String> {
-        let tmp = unsafe { ffi::gtk_print_settings_get_output_bin(GTK_PRINT_SETTINGS(self.unwrap_widget())) };
-
-        if tmp.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gtk_print_settings_get_output_bin(GTK_PRINT_SETTINGS(self.unwrap_widget())))
         }
     }
 

--- a/src/gtk/widgets/print_settings.rs
+++ b/src/gtk/widgets/print_settings.rs
@@ -18,6 +18,7 @@ use glib::{to_bool, to_gboolean};
 use gtk::FFIWidget;
 use gtk::cast::{GTK_PRINT_SETTINGS, GTK_PAPER_SIZE};
 use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 
 struct_Widget!(PrintSettings);
 
@@ -52,9 +53,8 @@ impl PrintSettings {
 
     pub fn get(&self, key: &str) -> Option<String> {
         unsafe {
-            let c_str = CString::from_slice(key.as_bytes());
-
-            let tmp = ffi::gtk_print_settings_get(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr());
+            let mut tmp_key = key.to_tmp_for_borrow();
+            let tmp = ffi::gtk_print_settings_get(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_key.to_glib_ptr());
 
             if tmp.is_null() {
                 None
@@ -67,97 +67,85 @@ impl PrintSettings {
     pub fn set(&self, key: &str, value: &str) {
         unsafe {
             let c_str = CString::from_slice(key.as_bytes());
-            let c_str2 = CString::from_slice(value.as_bytes());
-
-            ffi::gtk_print_settings_set(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr(), c_str2.as_ptr())
+            let mut tmp_value = value.to_tmp_for_borrow();
+            ffi::gtk_print_settings_set(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr(), tmp_value.to_glib_ptr())
         }
     }
 
     pub fn unset(&self, key: &str) {
         unsafe {
-            let c_str = CString::from_slice(key.as_bytes());
-
-            ffi::gtk_print_settings_unset(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_key = key.to_tmp_for_borrow();
+            ffi::gtk_print_settings_unset(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_key.to_glib_ptr())
         }
     }
 
     pub fn get_bool(&self, key: &str) -> bool {
         unsafe {
-            let c_str = CString::from_slice(key.as_bytes());
-
-            to_bool(ffi::gtk_print_settings_get_bool(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr()))
+            let mut tmp_key = key.to_tmp_for_borrow();
+            to_bool(ffi::gtk_print_settings_get_bool(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_key.to_glib_ptr()))
         }
     }
 
     pub fn set_bool(&self, key: &str, value: bool) {
         unsafe {
-            let c_str = CString::from_slice(key.as_bytes());
-
-            ffi::gtk_print_settings_set_bool(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr(), to_gboolean(value))
+            let mut tmp_key = key.to_tmp_for_borrow();
+            ffi::gtk_print_settings_set_bool(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_key.to_glib_ptr(), to_gboolean(value))
         }
     }
 
     pub fn get_double(&self, key: &str) -> f64 {
         unsafe {
-            let c_str = CString::from_slice(key.as_bytes());
-
-            ffi::gtk_print_settings_get_double(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_key = key.to_tmp_for_borrow();
+            ffi::gtk_print_settings_get_double(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_key.to_glib_ptr())
         }
     }
 
     pub fn set_double(&self, key: &str, value: f64) {
         unsafe {
-            let c_str = CString::from_slice(key.as_bytes());
-
-            ffi::gtk_print_settings_set_double(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr(), value)
+            let mut tmp_key = key.to_tmp_for_borrow();
+            ffi::gtk_print_settings_set_double(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_key.to_glib_ptr(), value)
         }
     }
 
     pub fn get_double_with_default(&self, key: &str, def: f64) -> f64 {
         unsafe {
-            let c_str = CString::from_slice(key.as_bytes());
-
-            ffi::gtk_print_settings_get_double_with_default(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr(), def)
+            let mut tmp_key = key.to_tmp_for_borrow();
+            ffi::gtk_print_settings_get_double_with_default(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_key.to_glib_ptr(), def)
         }
     }
 
     pub fn get_length(&self, key: &str, unit: gtk::Unit) -> f64 {
         unsafe {
-            let c_str = CString::from_slice(key.as_bytes());
-
-            ffi::gtk_print_settings_get_length(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr(), unit)
+            let mut tmp_key = key.to_tmp_for_borrow();
+            ffi::gtk_print_settings_get_length(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_key.to_glib_ptr(), unit)
         }
     }
 
     pub fn set_length(&self, key: &str, value: f64, unit: gtk::Unit) {
         unsafe {
-            let c_str = CString::from_slice(key.as_bytes());
-
-            ffi::gtk_print_settings_set_length(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr(), value, unit)
+            let mut tmp_key = key.to_tmp_for_borrow();
+            ffi::gtk_print_settings_set_length(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_key.to_glib_ptr(), value, unit)
         }
     }
 
     pub fn get_int(&self, key: &str) -> i32 {
         unsafe {
-            let c_str = CString::from_slice(key.as_bytes());
-
-            ffi::gtk_print_settings_get_int(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_key = key.to_tmp_for_borrow();
+            ffi::gtk_print_settings_get_int(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_key.to_glib_ptr())
         }
     }
 
     pub fn set_int(&self, key: &str, value: i32) {
         unsafe {
-            let c_str = CString::from_slice(key.as_bytes());
-
-            ffi::gtk_print_settings_set_int(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr(), value)
+            let mut tmp_key = key.to_tmp_for_borrow();
+            ffi::gtk_print_settings_set_int(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_key.to_glib_ptr(), value)
         }
     }
 
     pub fn get_int_with_default(&self, key: &str, def: i32) -> i32 {
         unsafe {
-            let c_str = CString::from_slice(key.as_bytes());
-
-            ffi::gtk_print_settings_get_int_with_default(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr(), def)
+            let mut tmp_key = key.to_tmp_for_borrow();
+            ffi::gtk_print_settings_get_int_with_default(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_key.to_glib_ptr(), def)
         }
     }
 
@@ -173,9 +161,8 @@ impl PrintSettings {
 
     pub fn set_printer(&self, printer: &str) {
         unsafe {
-            let c_str = CString::from_slice(printer.as_bytes());
-
-            ffi::gtk_print_settings_set_printer(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_printer = printer.to_tmp_for_borrow();
+            ffi::gtk_print_settings_set_printer(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_printer.to_glib_ptr())
         }
     }
 
@@ -323,9 +310,8 @@ impl PrintSettings {
 
     pub fn set_default_source(&self, default_source: &str) {
         unsafe {
-            let c_str = CString::from_slice(default_source.as_bytes());
-
-            ffi::gtk_print_settings_set_default_source(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_default_source = default_source.to_tmp_for_borrow();
+            ffi::gtk_print_settings_set_default_source(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_default_source.to_glib_ptr())
         }
     }
 
@@ -341,9 +327,8 @@ impl PrintSettings {
 
     pub fn set_media_type(&self, media_type: &str) {
         unsafe {
-            let c_str = CString::from_slice(media_type.as_bytes());
-
-            ffi::gtk_print_settings_set_media_type(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_media_type = media_type.to_tmp_for_borrow();
+            ffi::gtk_print_settings_set_media_type(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_media_type.to_glib_ptr())
         }
     }
 
@@ -359,9 +344,8 @@ impl PrintSettings {
 
     pub fn set_dither(&self, dither: &str) {
         unsafe {
-            let c_str = CString::from_slice(dither.as_bytes());
-
-            ffi::gtk_print_settings_set_dither(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_dither = dither.to_tmp_for_borrow();
+            ffi::gtk_print_settings_set_dither(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_dither.to_glib_ptr())
         }
     }
 
@@ -377,9 +361,8 @@ impl PrintSettings {
 
     pub fn set_finishings(&self, finishings: &str) {
         unsafe {
-            let c_str = CString::from_slice(finishings.as_bytes());
-
-            ffi::gtk_print_settings_set_finishings(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_finishings = finishings.to_tmp_for_borrow();
+            ffi::gtk_print_settings_set_finishings(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_finishings.to_glib_ptr())
         }
     }
 
@@ -395,9 +378,8 @@ impl PrintSettings {
 
     pub fn set_output_bin(&self, output_bin: &str) {
         unsafe {
-            let c_str = CString::from_slice(output_bin.as_bytes());
-
-            ffi::gtk_print_settings_set_output_bin(GTK_PRINT_SETTINGS(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_output_bin = output_bin.to_tmp_for_borrow();
+            ffi::gtk_print_settings_set_output_bin(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_output_bin.to_glib_ptr())
         }
     }
 }

--- a/src/gtk/widgets/progress_bar.rs
+++ b/src/gtk/widgets/progress_bar.rs
@@ -16,7 +16,7 @@
 //! A widget which indicates progress visually
 
 use libc::c_double;
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
@@ -58,13 +58,8 @@ impl ProgressBar {
 
     pub fn get_text(&self) -> Option<String> {
         unsafe {
-            let c_str = ffi::gtk_progress_bar_get_text(GTK_PROGRESSBAR(self.pointer));
-
-            if c_str.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&c_str)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_progress_bar_get_text(GTK_PROGRESSBAR(self.pointer)))
         }
     }
 

--- a/src/gtk/widgets/progress_bar.rs
+++ b/src/gtk/widgets/progress_bar.rs
@@ -16,7 +16,7 @@
 //! A widget which indicates progress visually
 
 use libc::c_double;
-use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
@@ -51,9 +51,8 @@ impl ProgressBar {
 
     pub fn set_text(&mut self, text: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(text.as_bytes());
-
-            ffi::gtk_progress_bar_set_text(GTK_PROGRESSBAR(self.pointer), c_str.as_ptr());
+            let mut tmp_text = text.to_tmp_for_borrow();
+            ffi::gtk_progress_bar_set_text(GTK_PROGRESSBAR(self.pointer), tmp_text.to_glib_ptr());
         }
     }
 

--- a/src/gtk/widgets/radio_button.rs
+++ b/src/gtk/widgets/radio_button.rs
@@ -16,8 +16,8 @@
 //! A choice from multiple check buttons
 
 use std::ptr;
-use std::ffi::CString;
 
+use glib::translate::{ToGlibPtr, ToTmp};
 use gtk::{self, ffi};
 use gtk::cast::GTK_RADIOBUTTON;
 
@@ -31,17 +31,19 @@ impl RadioButton {
     }
 
     pub fn new_with_label(label: &str) -> Option<RadioButton> {
-        let c_str = CString::from_slice(label.as_bytes());
         let tmp_pointer = unsafe {
-            ffi::gtk_radio_button_new_with_label(ptr::null_mut(), c_str.as_ptr())
+            let mut tmp_label = label.to_tmp_for_borrow();
+            ffi::gtk_radio_button_new_with_label(ptr::null_mut(),
+                                                 tmp_label.to_glib_ptr())
         };
         check_pointer!(tmp_pointer, RadioButton)
     }
 
     pub fn new_with_mnemonic(mnemonic: &str) -> Option<RadioButton> {
-        let c_str = CString::from_slice(mnemonic.as_bytes());
         let tmp_pointer = unsafe {
-            ffi::gtk_radio_button_new_with_mnemonic(ptr::null_mut(), c_str.as_ptr())
+            let mut tmp_mnemonic = mnemonic.to_tmp_for_borrow();
+            ffi::gtk_radio_button_new_with_mnemonic(ptr::null_mut(),
+                                                    tmp_mnemonic.to_glib_ptr())
         };
         check_pointer!(tmp_pointer, RadioButton)
     }

--- a/src/gtk/widgets/recent_chooser_dialog.rs
+++ b/src/gtk/widgets/recent_chooser_dialog.rs
@@ -13,26 +13,31 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::ptr;
+use glib::translate::{ToGlibPtr, ToTmp};
 use gtk::{self, ffi};
 use gtk::FFIWidget;
 use gtk::ResponseType;
 use gtk::cast::{GTK_WINDOW, GTK_RECENT_MANAGER};
-use std::ffi::CString;
 
 struct_Widget!(RecentChooserDialog);
 
 impl RecentChooserDialog {
     pub fn new(title: &str, parent: Option<gtk::Window>) -> Option<RecentChooserDialog> {
-        let c_str = CString::from_slice(title.as_bytes());
-        let ok_str = CString::from_slice("Ok".as_bytes());
-        let cancel_str = CString::from_slice("Cancel".as_bytes());
+        let mut tmp_title = title.to_tmp_for_borrow();
+        let mut tmp_ok = "Ok".to_tmp_for_borrow();
+        let mut tmp_cancel = "Cancel".to_tmp_for_borrow();
+        let parent = match parent {
+            Some(ref p) => GTK_WINDOW(p.unwrap_widget()),
+            None => ptr::null_mut()
+        };
+
         let tmp_pointer = unsafe {
-            ffi::gtk_recent_chooser_dialog_new(c_str.as_ptr(), match parent {
-                Some(ref p) => GTK_WINDOW(p.unwrap_widget()),
-                None => ::std::ptr::null_mut()
-            }, ok_str.as_ptr(), ResponseType::Ok,
-               cancel_str.as_ptr(), ResponseType::Cancel,
-               ::std::ptr::null::<::libc::c_void>())
+            ffi::gtk_recent_chooser_dialog_new(
+                tmp_title.to_glib_ptr(), parent,
+                tmp_ok.to_glib_ptr(), ResponseType::Ok,
+                tmp_cancel.to_glib_ptr(), ResponseType::Cancel,
+                ptr::null::<()>())
         };
 
         if tmp_pointer.is_null() {
@@ -43,18 +48,21 @@ impl RecentChooserDialog {
     }
 
     pub fn new_for_manager(title: &str, parent: Option<gtk::Window>, manager: &gtk::RecentManager) -> Option<RecentChooserDialog> {
-        let c_str = CString::from_slice(title.as_bytes());
-        let ok_str = CString::from_slice("Ok".as_bytes());
-        let cancel_str = CString::from_slice("Cancel".as_bytes());
+        let mut tmp_title = title.to_tmp_for_borrow();
+        let mut tmp_ok = "Ok".to_tmp_for_borrow();
+        let mut tmp_cancel = "Cancel".to_tmp_for_borrow();
+        let parent = match parent {
+            Some(ref p) => GTK_WINDOW(p.unwrap_widget()),
+            None => ptr::null_mut()
+        };
 
         let tmp_pointer = unsafe {
-            ffi::gtk_recent_chooser_dialog_new_for_manager(c_str.as_ptr(), match parent {
-                Some(ref p) => GTK_WINDOW(p.unwrap_widget()),
-                None => ::std::ptr::null_mut()
-            }, GTK_RECENT_MANAGER(manager.unwrap_widget()),
-               ok_str.as_ptr(), ResponseType::Ok,
-               cancel_str.as_ptr(), ResponseType::Cancel,
-               ::std::ptr::null::<::libc::c_void>())
+            ffi::gtk_recent_chooser_dialog_new_for_manager(
+                tmp_title.to_glib_ptr(), parent,
+                GTK_RECENT_MANAGER(manager.unwrap_widget()),
+                tmp_ok.to_glib_ptr(), ResponseType::Ok,
+                tmp_cancel.to_glib_ptr(), ResponseType::Cancel,
+                ptr::null::<()>())
         };
 
         if tmp_pointer.is_null() {

--- a/src/gtk/widgets/recent_filter.rs
+++ b/src/gtk/widgets/recent_filter.rs
@@ -15,7 +15,7 @@
 
 use gtk::{self, ffi};
 use glib::to_bool;
-use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 
 #[derive(Copy)]
 pub struct RecentFilter {
@@ -35,17 +35,15 @@ impl RecentFilter {
 
     pub fn add_application(&self, application: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(application.as_bytes());
-
-            ffi::gtk_recent_filter_add_application(self.pointer, c_str.as_ptr())
+            let mut tmp_application = application.to_tmp_for_borrow();
+            ffi::gtk_recent_filter_add_application(self.pointer, tmp_application.to_glib_ptr())
         }
     }
 
     pub fn add_group(&self, group: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(group.as_bytes());
-
-            ffi::gtk_recent_filter_add_group(self.pointer, c_str.as_ptr())
+            let mut tmp_group = group.to_tmp_for_borrow();
+            ffi::gtk_recent_filter_add_group(self.pointer, tmp_group.to_glib_ptr())
         }
     }
 

--- a/src/gtk/widgets/recent_info.rs
+++ b/src/gtk/widgets/recent_info.rs
@@ -18,7 +18,6 @@ use glib::to_bool;
 use gtk::FFIWidget;
 use gtk::cast::GTK_RECENT_INFO;
 use std::ptr;
-use std::ffi::CString;
 use glib::translate::{FromGlibPtr, FromGlibPtrNotNull, ToGlibPtr, ToTmp};
 use libc::c_char;
 
@@ -155,10 +154,11 @@ impl RecentInfo {
     }
 
     pub fn has_group(&self, group_name: &str) -> bool {
-        let c_str = CString::from_slice(group_name.as_bytes());
-
         unsafe {
-            to_bool(ffi::gtk_recent_info_has_group(GTK_RECENT_INFO(self.unwrap_widget()), c_str.as_ptr()))
+            let mut tmp_group_name = group_name.to_tmp_for_borrow();
+            to_bool(
+                ffi::gtk_recent_info_has_group(GTK_RECENT_INFO(self.unwrap_widget()),
+                                               tmp_group_name.to_glib_ptr()))
         }
     }
 

--- a/src/gtk/widgets/recent_info.rs
+++ b/src/gtk/widgets/recent_info.rs
@@ -18,7 +18,7 @@ use glib::to_bool;
 use gtk::FFIWidget;
 use gtk::cast::GTK_RECENT_INFO;
 use std::ffi::CString;
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 use libc::c_char;
 
 struct_Widget!(RecentInfo);
@@ -39,42 +39,30 @@ impl RecentInfo {
     }
 
     pub fn get_uri(&self) -> Option<String> {
-        let uri = unsafe { ffi::gtk_recent_info_get_uri(GTK_RECENT_INFO(self.unwrap_widget())) };
-
-        if uri.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&uri)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gtk_recent_info_get_uri(GTK_RECENT_INFO(self.unwrap_widget())))
         }
     }
 
     pub fn get_display_name(&self) -> Option<String> {
-        let display_name = unsafe { ffi::gtk_recent_info_get_display_name(GTK_RECENT_INFO(self.unwrap_widget())) };
-
-        if display_name.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&display_name)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gtk_recent_info_get_display_name(GTK_RECENT_INFO(self.unwrap_widget())))
         }
     }
 
     pub fn get_description(&self) -> Option<String> {
-        let description = unsafe { ffi::gtk_recent_info_get_description(GTK_RECENT_INFO(self.unwrap_widget())) };
-
-        if description.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&description)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gtk_recent_info_get_description(GTK_RECENT_INFO(self.unwrap_widget())))
         }
     }
 
     pub fn get_mime_type(&self) -> Option<String> {
-        let mime_type = unsafe { ffi::gtk_recent_info_get_mime_type(GTK_RECENT_INFO(self.unwrap_widget())) };
-
-        if mime_type.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&mime_type)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gtk_recent_info_get_mime_type(GTK_RECENT_INFO(self.unwrap_widget())))
         }
     }
 
@@ -128,12 +116,9 @@ impl RecentInfo {
     }
 
     pub fn last_application(&self) -> Option<String> {
-        let tmp = unsafe { ffi::gtk_recent_info_last_application(GTK_RECENT_INFO(self.unwrap_widget())) as *const c_char};
-
-        if tmp.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gtk_recent_info_last_application(GTK_RECENT_INFO(self.unwrap_widget())) as *const c_char)
         }
     }
 
@@ -169,22 +154,16 @@ impl RecentInfo {
     }
 
     pub fn get_short_name(&self) -> Option<String> {
-        let tmp = unsafe { ffi::gtk_recent_info_get_short_name(GTK_RECENT_INFO(self.unwrap_widget())) as *const c_char };
-
-        if tmp.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gtk_recent_info_get_short_name(GTK_RECENT_INFO(self.unwrap_widget())) as *const c_char)
         }
     }
 
     pub fn get_uri_display(&self) -> Option<String> {
-        let tmp = unsafe { ffi::gtk_recent_info_get_uri_display(GTK_RECENT_INFO(self.unwrap_widget())) as *const c_char };
-
-        if tmp.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gtk_recent_info_get_uri_display(GTK_RECENT_INFO(self.unwrap_widget())) as *const c_char)
         }
     }
 

--- a/src/gtk/widgets/recent_info.rs
+++ b/src/gtk/widgets/recent_info.rs
@@ -18,6 +18,7 @@ use glib::to_bool;
 use gtk::FFIWidget;
 use gtk::cast::GTK_RECENT_INFO;
 use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 use libc::c_char;
 
 struct_Widget!(RecentInfo);
@@ -138,9 +139,8 @@ impl RecentInfo {
 
     pub fn has_application(&self, app_name: &str) -> bool {
         unsafe {
-            let c_str = CString::from_slice(app_name.as_bytes());
-
-            to_bool(ffi::gtk_recent_info_has_application(GTK_RECENT_INFO(self.unwrap_widget()), c_str.as_ptr()))
+            let mut tmp_app_name = app_name.to_tmp_for_borrow();
+            to_bool(ffi::gtk_recent_info_has_application(GTK_RECENT_INFO(self.unwrap_widget()), tmp_app_name.to_glib_ptr()))
         }
     }
 

--- a/src/gtk/widgets/recent_manager.rs
+++ b/src/gtk/widgets/recent_manager.rs
@@ -18,7 +18,6 @@ use glib::to_bool;
 use gtk::FFIWidget;
 use gtk::cast::GTK_RECENT_MANAGER;
 use glib;
-use std::ffi::CString;
 use glib::translate::{ToGlibPtr, ToTmp};
 
 struct_Widget!(RecentManager);
@@ -45,10 +44,12 @@ impl RecentManager {
     }
 
     pub fn add_item(&self, uri: &str) -> bool {
-        let c_str = CString::from_slice(uri.as_bytes());
-
         unsafe {
-            to_bool(ffi::gtk_recent_manager_add_item(GTK_RECENT_MANAGER(self.unwrap_widget()), c_str.as_ptr()))
+            let mut tmp_uri = uri.to_tmp_for_borrow();
+            to_bool(
+                ffi::gtk_recent_manager_add_item(
+                    GTK_RECENT_MANAGER(self.unwrap_widget()),
+                    tmp_uri.to_glib_ptr()))
         }
     }
 
@@ -60,10 +61,12 @@ impl RecentManager {
     }
 
     pub fn has_item(&self, uri: &str) -> bool {
-        let c_str = CString::from_slice(uri.as_bytes());
-
         unsafe {
-            to_bool(ffi::gtk_recent_manager_has_item(GTK_RECENT_MANAGER(self.unwrap_widget()), c_str.as_ptr()))
+            let mut tmp_uri = uri.to_tmp_for_borrow();
+            to_bool(
+                ffi::gtk_recent_manager_has_item(
+                    GTK_RECENT_MANAGER(self.unwrap_widget()),
+                    tmp_uri.to_glib_ptr()))
         }
     }
 

--- a/src/gtk/widgets/recent_manager.rs
+++ b/src/gtk/widgets/recent_manager.rs
@@ -19,6 +19,7 @@ use gtk::FFIWidget;
 use gtk::cast::GTK_RECENT_MANAGER;
 use glib;
 use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 
 struct_Widget!(RecentManager);
 
@@ -53,9 +54,8 @@ impl RecentManager {
 
     pub fn add_full(&self, uri: &str, recent_data: &gtk::RecentData) -> bool {
         unsafe {
-            let c_str = CString::from_slice(uri.as_bytes());
-
-            to_bool(ffi::gtk_recent_manager_add_full(GTK_RECENT_MANAGER(self.unwrap_widget()), c_str.as_ptr(), &recent_data.get_ffi()))
+            let mut tmp_uri = uri.to_tmp_for_borrow();
+            to_bool(ffi::gtk_recent_manager_add_full(GTK_RECENT_MANAGER(self.unwrap_widget()), tmp_uri.to_glib_ptr(), &recent_data.get_ffi()))
         }
     }
 

--- a/src/gtk/widgets/scale.rs
+++ b/src/gtk/widgets/scale.rs
@@ -16,7 +16,7 @@
 //! A slider widget for selecting a value from a range
 
 use libc::{c_double, c_int};
-use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 
 use gtk::{Orientation, PositionType};
 use gtk::cast::GTK_SCALE;
@@ -97,9 +97,8 @@ impl Scale {
 
     pub fn add_mark(&mut self, value: f64, position: PositionType, markup: &str) -> () {
         unsafe {
-            let c_str = CString::from_slice(markup.as_bytes());
-
-            ffi::gtk_scale_add_mark(GTK_SCALE(self.pointer), value as c_double, position, c_str.as_ptr());
+            let mut tmp_markup = markup.to_tmp_for_borrow();
+            ffi::gtk_scale_add_mark(GTK_SCALE(self.pointer), value as c_double, position, tmp_markup.to_glib_ptr());
         }
     }
 

--- a/src/gtk/widgets/stack.rs
+++ b/src/gtk/widgets/stack.rs
@@ -19,8 +19,7 @@
 
 use gtk::{self, ffi};
 use gtk::cast::GTK_STACK;
-use std::ffi::CString;
-use glib::translate::{FromGlibPtr};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 use glib::{to_bool, to_gboolean};
 
 /// GtkStack — A stacking container
@@ -33,24 +32,22 @@ impl Stack {
     }
 
     pub fn add_named<T: gtk::WidgetTrait>(&mut self, child: &T, name: &str) {
-        let c_str = CString::from_slice(name.as_bytes());
-
         unsafe {
+            let mut tmp_name = name.to_tmp_for_borrow();
             ffi::gtk_stack_add_named(GTK_STACK(self.pointer),
                                      child.unwrap_widget(),
-                                     c_str.as_ptr())
+                                     tmp_name.to_glib_ptr())
         }
     }
 
     pub fn add_titled<T: gtk::WidgetTrait>(&mut self, child: &T, name: &str, title: &str) {
-        let c_name = CString::from_slice(name.as_bytes());
-        let c_title = CString::from_slice(title.as_bytes());
-
         unsafe {
+            let mut tmp_name = name.to_tmp_for_borrow();
+            let mut tmp_title = title.to_tmp_for_borrow();
             ffi::gtk_stack_add_titled(GTK_STACK(self.pointer),
                                       child.unwrap_widget(),
-                                      c_name.as_ptr(),
-                                      c_title.as_ptr())
+                                      tmp_name.to_glib_ptr(),
+                                      tmp_title.to_glib_ptr())
         }
     }
 
@@ -71,10 +68,10 @@ impl Stack {
     }
 
     pub fn set_visible_child_name(&mut self, name: &str) {
-        let c_str = CString::from_slice(name.as_bytes());
-
         unsafe {
-            ffi::gtk_stack_set_visible_child_name(GTK_STACK(self.pointer), c_str.as_ptr())
+            let mut tmp_name = name.to_tmp_for_borrow();
+            ffi::gtk_stack_set_visible_child_name(GTK_STACK(self.pointer),
+                                                  tmp_name.to_glib_ptr())
         }
     }
 
@@ -86,11 +83,10 @@ impl Stack {
     }
 
     pub fn set_visible_child_full(&mut self, name: &str, transition: gtk::StackTransitionType) {
-        let c_str = CString::from_slice(name.as_bytes());
-
         unsafe {
+            let mut tmp_name = name.to_tmp_for_borrow();
             ffi::gtk_stack_set_visible_child_full(GTK_STACK(self.pointer),
-                                                  c_str.as_ptr(),
+                                                  tmp_name.to_glib_ptr(),
                                                   transition)
         }
     }

--- a/src/gtk/widgets/stack.rs
+++ b/src/gtk/widgets/stack.rs
@@ -20,6 +20,7 @@
 use gtk::{self, ffi};
 use gtk::cast::GTK_STACK;
 use std::ffi::CString;
+use glib::translate::{FromGlibPtr};
 use glib::{to_bool, to_gboolean};
 
 /// GtkStack — A stacking container
@@ -78,12 +79,9 @@ impl Stack {
     }
 
     pub fn get_visible_child_name(&self) -> Option<String> {
-        let c_name = unsafe { ffi::gtk_stack_get_visible_child_name(GTK_STACK(self.pointer)) };
-
-        if c_name.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&c_name)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gtk_stack_get_visible_child_name(GTK_STACK(self.pointer)))
         }
     }
 

--- a/src/gtk/widgets/status_bar.rs
+++ b/src/gtk/widgets/status_bar.rs
@@ -15,9 +15,9 @@
 
 //! An adapter which makes widgets scrollable
 
+use glib::translate::{ToGlibPtr, ToTmp};
 use gtk::cast::GTK_STATUSBAR;
 use gtk::{self, ffi};
-use std::ffi::CString;
 
 /// GtkViewport — An adapter which makes widgets scrollable
 struct_Widget!(StatusBar);
@@ -31,11 +31,10 @@ impl StatusBar {
 
     pub fn push(&mut self, context_id: u32, text: &str) -> u32 {
         unsafe {
-            let c_str = CString::from_slice(text.as_bytes());
-
+            let mut tmp_text = text.to_tmp_for_borrow();
             ffi::gtk_statusbar_push(GTK_STATUSBAR(self.pointer),
-                                        context_id,
-                                        c_str.as_ptr())
+                                    context_id,
+                                    tmp_text.to_glib_ptr())
         }
     }
 

--- a/src/gtk/widgets/text_iter.rs
+++ b/src/gtk/widgets/text_iter.rs
@@ -18,6 +18,7 @@
 use gtk::{self, ffi};
 use libc::c_char;
 use glib::{to_bool, to_gboolean};
+use glib::translate::{FromGlibPtr};
 
 #[derive(Copy)]
 pub struct TextIter {
@@ -87,46 +88,42 @@ impl TextIter {
     }
 
     pub fn get_slice(&self, end: &TextIter) -> Option<String> {
-        let tmp_pointer = unsafe { ffi::gtk_text_iter_get_slice(self.pointer as *const ffi::C_GtkTextIter,
-            end.pointer as *const ffi::C_GtkTextIter) as *const c_char };
-
-        if tmp_pointer.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp_pointer)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gtk_text_iter_get_slice(
+                    self.pointer as *const ffi::C_GtkTextIter,
+                    end.pointer as *const ffi::C_GtkTextIter)
+                as *const c_char)
         }
     }
 
     pub fn get_text(&self, end: &TextIter) -> Option<String> {
-        let tmp_pointer = unsafe { ffi::gtk_text_iter_get_text(self.pointer as *const ffi::C_GtkTextIter,
-            end.pointer as *const ffi::C_GtkTextIter) as *const c_char };
-
-        if tmp_pointer.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp_pointer)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gtk_text_iter_get_text(
+                    self.pointer as *const ffi::C_GtkTextIter,
+                    end.pointer as *const ffi::C_GtkTextIter)
+                as *const c_char)
         }
     }
 
     pub fn get_visible_slice(&self, end: &TextIter) -> Option<String> {
-        let tmp_pointer = unsafe { ffi::gtk_text_iter_get_visible_slice(self.pointer as *const ffi::C_GtkTextIter,
-            end.pointer as *const ffi::C_GtkTextIter) as *const c_char };
-
-        if tmp_pointer.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp_pointer)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gtk_text_iter_get_visible_slice(
+                    self.pointer as *const ffi::C_GtkTextIter,
+                    end.pointer as *const ffi::C_GtkTextIter)
+                as *const c_char)
         }
     }
 
     pub fn get_visible_text(&self, end: &TextIter) -> Option<String> {
-        let tmp_pointer = unsafe { ffi::gtk_text_iter_get_visible_text(self.pointer as *const ffi::C_GtkTextIter,
-            end.pointer as *const ffi::C_GtkTextIter) as *const c_char };
-
-        if tmp_pointer.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp_pointer)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gtk_text_iter_get_visible_text(
+                    self.pointer as *const ffi::C_GtkTextIter,
+                    end.pointer as *const ffi::C_GtkTextIter)
+                as *const c_char)
         }
     }
 

--- a/src/gtk/widgets/text_mark.rs
+++ b/src/gtk/widgets/text_mark.rs
@@ -16,7 +16,7 @@
 //! GtkTextMark — A position in the buffer preserved across buffer modifications
 
 use gtk::{self, ffi};
-use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 use glib::{to_bool, to_gboolean};
 
 pub struct TextMark {
@@ -26,9 +26,8 @@ pub struct TextMark {
 impl TextMark {
     pub fn new(name: &str, left_gravity: bool) -> Option<TextMark> {
         let tmp_pointer = unsafe {
-            let c_str = CString::from_slice(name.as_bytes());
-
-            ffi::gtk_text_mark_new(c_str.as_ptr(), to_gboolean(left_gravity))
+            let mut tmp_name = name.to_tmp_for_borrow();
+            ffi::gtk_text_mark_new(tmp_name.to_glib_ptr(), to_gboolean(left_gravity))
         };
 
         if tmp_pointer.is_null() {

--- a/src/gtk/widgets/text_mark.rs
+++ b/src/gtk/widgets/text_mark.rs
@@ -16,7 +16,7 @@
 //! GtkTextMark — A position in the buffer preserved across buffer modifications
 
 use gtk::{self, ffi};
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 use glib::{to_bool, to_gboolean};
 
 pub struct TextMark {
@@ -50,12 +50,9 @@ impl TextMark {
     }
 
     pub fn get_name(&self) -> Option<String> {
-        let tmp_pointer = unsafe { ffi::gtk_text_mark_get_name(self.pointer) };
-
-        if tmp_pointer.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp_pointer)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gtk_text_mark_get_name(self.pointer))
         }
     }
 

--- a/src/gtk/widgets/text_tag.rs
+++ b/src/gtk/widgets/text_tag.rs
@@ -16,7 +16,7 @@
 //! GtkTextTag — A tag that can be applied to text in a GtkTextBuffer
 
 use gtk::ffi;
-use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 
 #[derive(Copy)]
 pub struct TextTag {
@@ -26,9 +26,8 @@ pub struct TextTag {
 impl TextTag {
     pub fn new(name: &str) -> Option<TextTag> {
         let tmp_pointer = unsafe {
-            let c_str = CString::from_slice(name.as_bytes());
-
-            ffi::gtk_text_tag_new(c_str.as_ptr())
+            let mut tmp_name = name.to_tmp_for_borrow();
+            ffi::gtk_text_tag_new(tmp_name.to_glib_ptr())
         };
 
         if tmp_pointer.is_null() {

--- a/src/gtk/widgets/toggle_button.rs
+++ b/src/gtk/widgets/toggle_button.rs
@@ -16,6 +16,7 @@
 //! A button to launch a font chooser dialog
 
 use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 use gtk::{self, ffi};
 
 /// ToggleButton — A button to launch a font chooser dialog
@@ -33,9 +34,8 @@ impl ToggleButton {
 
     pub fn new_with_label(label: &str) -> Option<ToggleButton> {
         let tmp_pointer = unsafe {
-            let c_str = CString::from_slice(label.as_bytes());
-
-            ffi::gtk_toggle_button_new_with_label(c_str.as_ptr())
+            let mut tmp_label = label.to_tmp_for_borrow();
+            ffi::gtk_toggle_button_new_with_label(tmp_label.to_glib_ptr())
         };
         check_pointer!(tmp_pointer, ToggleButton)
     }

--- a/src/gtk/widgets/toggle_button.rs
+++ b/src/gtk/widgets/toggle_button.rs
@@ -15,7 +15,6 @@
 
 //! A button to launch a font chooser dialog
 
-use std::ffi::CString;
 use glib::translate::{ToGlibPtr, ToTmp};
 use gtk::{self, ffi};
 
@@ -41,10 +40,9 @@ impl ToggleButton {
     }
 
     pub fn new_with_mnemonic(mnemonic: &str) -> Option<ToggleButton> {
-        let c_str = CString::from_slice(mnemonic.as_bytes());
-
         let tmp_pointer = unsafe {
-            ffi::gtk_toggle_button_new_with_mnemonic(c_str.as_ptr())
+            let mut tmp_mnemonic = mnemonic.to_tmp_for_borrow();
+            ffi::gtk_toggle_button_new_with_mnemonic(tmp_mnemonic.to_glib_ptr())
         };
         check_pointer!(tmp_pointer, ToggleButton)
     }

--- a/src/gtk/widgets/toggle_tool_button.rs
+++ b/src/gtk/widgets/toggle_tool_button.rs
@@ -16,7 +16,7 @@
 //! A ToolItem containing a toggle button
 
 use gtk::{self, ffi};
-use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 
 /// ToggleToolButton — A ToolItem containing a toggle button
 struct_Widget!(ToggleToolButton);
@@ -28,8 +28,8 @@ impl ToggleToolButton {
     }
 
     pub fn new_from_stock(stock_id: &str) -> Option<ToggleToolButton> {
-        let c_str = CString::from_slice(stock_id.as_bytes());
-        let tmp_pointer = unsafe { ffi::gtk_toggle_tool_button_new_from_stock(c_str.as_ptr()) };
+        let mut tmp_stock_id = stock_id.to_tmp_for_borrow();
+        let tmp_pointer = unsafe { ffi::gtk_toggle_tool_button_new_from_stock(tmp_stock_id.to_glib_ptr()) };
         check_pointer!(tmp_pointer, ToggleToolButton)
     }
 }

--- a/src/gtk/widgets/tool_button.rs
+++ b/src/gtk/widgets/tool_button.rs
@@ -16,8 +16,8 @@
 //! A ToolItem subclass that displays buttons
 
 use std::ptr;
-use std::ffi::CString;
 
+use glib::translate::{ToGlibPtr, ToTmp};
 use gtk::{self, ffi};
 
 /// ToolButton — A ToolItem subclass that displays buttons
@@ -26,30 +26,20 @@ struct_Widget!(ToolButton);
 impl ToolButton {
     pub fn new<T: gtk::WidgetTrait>(icon_widget: Option<&T>, label: Option<&str>) -> Option<ToolButton> {
         let tmp_pointer = unsafe {
-            match label {
-                Some(l) => {
-                    let c_str = CString::from_slice(l.as_bytes());
-
-                    match icon_widget {
-                        Some(i) => ffi::gtk_tool_button_new(i.unwrap_widget(), c_str.as_ptr()),
-                        None    => ffi::gtk_tool_button_new(ptr::null_mut(), c_str.as_ptr())
-                    }
-                }
-                None => {
-                    match icon_widget {
-                        Some(i) => ffi::gtk_tool_button_new(i.unwrap_widget(), ptr::null()),
-                        None    => ffi::gtk_tool_button_new(ptr::null_mut(), ptr::null())
-                    }
-                }
-            }
+            let mut tmp_label = label.to_tmp_for_borrow();
+            let icon_widget_ptr = match icon_widget {
+                Some(i) => i.unwrap_widget(),
+                None    => ptr::null_mut(),
+            };
+            ffi::gtk_tool_button_new(icon_widget_ptr, tmp_label.to_glib_ptr())
         };
         check_pointer!(tmp_pointer, ToolButton)
     }
 
     pub fn new_from_stock(stock_id: &str) -> Option<ToolButton> {
-        let c_str = CString::from_slice(stock_id.as_bytes());
         let tmp_pointer = unsafe {
-            ffi::gtk_tool_button_new_from_stock(c_str.as_ptr())
+            let mut tmp_stock_id = stock_id.to_tmp_for_borrow();
+            ffi::gtk_tool_button_new_from_stock(tmp_stock_id.to_glib_ptr())
         };
         check_pointer!(tmp_pointer, ToolButton)
     }

--- a/src/gtk/widgets/tool_item_group.rs
+++ b/src/gtk/widgets/tool_item_group.rs
@@ -18,7 +18,7 @@
 use gtk::{self, ffi, ToolItem};
 use gtk::FFIWidget;
 use gtk::cast::{GTK_TOOL_ITEM_GROUP, GTK_TOOL_ITEM};
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 use glib::{to_bool, to_gboolean};
 
 struct_Widget!(ToolItemGroup);
@@ -65,12 +65,9 @@ impl ToolItemGroup {
     }
 
     pub fn get_label(&self) -> Option<String> {
-        let tmp_pointer = unsafe { ffi::gtk_tool_item_group_get_label(GTK_TOOL_ITEM_GROUP(self.unwrap_widget())) };
-
-        if tmp_pointer.is_null() {
-            None
-        } else {
-            unsafe { Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp_pointer)).to_string()) }
+        unsafe {
+            FromGlibPtr::borrow(
+                ffi::gtk_tool_item_group_get_label(GTK_TOOL_ITEM_GROUP(self.unwrap_widget())))
         }
     }
 

--- a/src/gtk/widgets/tool_item_group.rs
+++ b/src/gtk/widgets/tool_item_group.rs
@@ -18,7 +18,7 @@
 use gtk::{self, ffi, ToolItem};
 use gtk::FFIWidget;
 use gtk::cast::{GTK_TOOL_ITEM_GROUP, GTK_TOOL_ITEM};
-use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 use glib::{to_bool, to_gboolean};
 
 struct_Widget!(ToolItemGroup);
@@ -26,9 +26,8 @@ struct_Widget!(ToolItemGroup);
 impl ToolItemGroup {
     pub fn new(label: &str) -> Option<ToolItemGroup> {
         let tmp_pointer = unsafe {
-            let c_str = CString::from_slice(label.as_bytes());
-
-            ffi::gtk_tool_item_group_new(c_str.as_ptr())
+            let mut tmp_label = label.to_tmp_for_borrow();
+            ffi::gtk_tool_item_group_new(tmp_label.to_glib_ptr())
         };
         check_pointer!(tmp_pointer, ToolItemGroup)
     }
@@ -77,9 +76,8 @@ impl ToolItemGroup {
 
     pub fn set_label(&self, label: &str) {
         unsafe {
-            let c_str = CString::from_slice(label.as_bytes());
-
-            ffi::gtk_tool_item_group_set_label(GTK_TOOL_ITEM_GROUP(self.unwrap_widget()), c_str.as_ptr())
+            let mut tmp_label = label.to_tmp_for_borrow();
+            ffi::gtk_tool_item_group_set_label(GTK_TOOL_ITEM_GROUP(self.unwrap_widget()), tmp_label.to_glib_ptr())
         }
     }
 

--- a/src/gtk/widgets/tree_model.rs
+++ b/src/gtk/widgets/tree_model.rs
@@ -14,7 +14,7 @@
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
 use glib::{Value, Type};
-use glib::translate::from_glib;
+use glib::translate::{ToGlibPtr, ToTmp, from_glib};
 use gtk::{self, ffi, TreeIter, TreePath};
 use libc::{self, c_char};
 use std::ffi::CString;
@@ -44,9 +44,8 @@ impl TreeModel {
     }
 
     pub fn get_iter_from_string(&self, iter: &mut TreeIter, path_string: &str) -> bool {
-        let c_str = CString::from_slice(path_string.as_bytes());
-
-        match unsafe { ffi::gtk_tree_model_get_iter_from_string(self.pointer, iter.unwrap_pointer(), c_str.as_ptr()) } {
+        let mut tmp_path_string = path_string.to_tmp_for_borrow();
+        match unsafe { ffi::gtk_tree_model_get_iter_from_string(self.pointer, iter.unwrap_pointer(), tmp_path_string.to_glib_ptr()) } {
                 0 => false,
                 _ => true
             }

--- a/src/gtk/widgets/tree_model.rs
+++ b/src/gtk/widgets/tree_model.rs
@@ -13,11 +13,10 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
+use libc::c_char;
 use glib::{Value, Type};
-use glib::translate::{ToGlibPtr, ToTmp, from_glib};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp, from_glib};
 use gtk::{self, ffi, TreeIter, TreePath};
-use libc::{self, c_char};
-use std::ffi::CString;
 
 pub struct TreeModel {
     pointer: *mut ffi::C_GtkTreeModel
@@ -130,19 +129,12 @@ impl TreeModel {
         }
     }
 
-    #[allow(unused_variables)]
     pub fn get_string_from_iter(&self, iter: &TreeIter) -> Option<String> {
-        let string = unsafe { ffi::gtk_tree_model_get_string_from_iter(self.pointer, iter.unwrap_pointer()) as *const c_char };
-
-        if string.is_null() {
-            None
-        } else {
-            unsafe {
-                let res = String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&string)).to_string();
-
-                libc::free(string as *mut libc::c_void);
-                Some(res)
-            }
+        unsafe {
+            FromGlibPtr::take(
+                ffi::gtk_tree_model_get_string_from_iter(self.pointer,
+                                                         iter.unwrap_pointer())
+                    as *const c_char)
         }
     }
 

--- a/src/gtk/widgets/tree_path.rs
+++ b/src/gtk/widgets/tree_path.rs
@@ -16,9 +16,8 @@
 extern crate libc;
 
 use gtk::ffi;
-use std::ffi::CString;
-use libc::free;
-use libc::{c_void, c_char};
+use libc::{c_char};
+use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
 
 #[derive(Copy)]
 pub struct TreePath {
@@ -39,9 +38,9 @@ impl TreePath {
     }
 
     pub fn new_from_string(path: &str) -> Option<TreePath> {
-        let c_str = CString::from_slice(path.as_bytes());
+        let mut tmp_path = path.to_tmp_for_borrow();
         let tmp = unsafe {
-            ffi::gtk_tree_path_new_from_string(c_str.as_ptr())
+            ffi::gtk_tree_path_new_from_string(tmp_path.to_glib_ptr())
         };
 
         if tmp.is_null() {
@@ -79,17 +78,10 @@ impl TreePath {
 
     #[allow(unused_variables)]
     pub fn to_string(&self) -> Option<String> {
-        let string = unsafe { ffi::gtk_tree_path_to_string(self.pointer) as *const c_char };
-
-        if string.is_null() {
-            None
-        } else {
-            unsafe {
-                let res = String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&string)).to_string();
-
-                libc::free(string as *mut c_void);
-                Some(res)
-            }
+        unsafe {
+            FromGlibPtr::take(
+                ffi::gtk_tree_path_to_string(self.pointer)
+                    as *const c_char)
         }
     }
 

--- a/src/gtk/widgets/tree_store.rs
+++ b/src/gtk/widgets/tree_store.rs
@@ -17,7 +17,7 @@ use glib::{to_bool, Value, Type};
 use glib::translate::ToGlib;
 use gtk::{self, ffi};
 use gtk::TreeIter;
-use std::ffi::CString;
+use glib::translate::{ToGlibPtr, ToTmp};
 use std::num::ToPrimitive;
 
 pub struct TreeStore {
@@ -37,9 +37,8 @@ impl TreeStore {
     }
 
     pub fn set_string(&self, iter: &TreeIter, column: i32, text: &str) {
-        let text_c = CString::from_slice(text.as_bytes());
-
-        unsafe { ffi::gtk_tree_store_set(self.pointer, iter.unwrap_pointer(), column, text_c.as_ptr(), -1) }
+        let mut tmp_text = text.to_tmp_for_borrow();
+        unsafe { ffi::gtk_tree_store_set(self.pointer, iter.unwrap_pointer(), column, tmp_text.to_glib_ptr(), -1) }
     }
 
     pub fn remove(&self, iter: &TreeIter) -> bool {

--- a/src/gtk/widgets/tree_view_column.rs
+++ b/src/gtk/widgets/tree_view_column.rs
@@ -18,6 +18,7 @@
 use glib;
 use gtk::{self, ffi, cast};
 use std::ffi::CString;
+use glib::translate::{FromGlibPtr};
 use glib::{to_bool, to_gboolean};
 
 pub struct TreeViewColumn {
@@ -148,13 +149,8 @@ impl TreeViewColumn {
 
     pub fn get_title(&self) -> Option<String> {
         unsafe {
-            let tmp = ffi::gtk_tree_view_column_get_title(self.pointer);
-
-            if tmp.is_null() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&tmp)).to_string())
-            }
+            FromGlibPtr::borrow(
+                ffi::gtk_tree_view_column_get_title(self.pointer))
         }
     }
 


### PR DESCRIPTION
Refactor most `CString` conversions utilizing `glib::translate`.
Fix some badness in the process.
This removes 500 lines of repeated code and a lot of deprecation warnings.