### PR TITLE
Use glib::GType enum instead of FFI constants

### DIFF
--- a/examples/src/treeview.rs
+++ b/examples/src/treeview.rs
@@ -38,14 +38,14 @@ fn main() {
     let hello = String::from_str("Hello world !");
     let value = gtk::GValue::new().unwrap();
 
-    value.init(ffi::glib::g_type_string);
+    value.init(GType::String);
     value.set(&hello);
     println!("gvalue.get example : {}", value.get::<String>());
 
     // left pane
 
     let mut left_tree = gtk::TreeView::new().unwrap();
-    let column_types = [ffi::glib::g_type_string];
+    let column_types = [GType::String];
     let left_store = gtk::ListStore::new(&column_types).unwrap();
     let left_model = left_store.get_model().unwrap();
 
@@ -62,7 +62,7 @@ fn main() {
     // right pane
 
     let mut right_tree = gtk::TreeView::new().unwrap();
-    let column_types = [ffi::glib::g_type_string];
+    let column_types = [GType::String];
     let right_store = gtk::TreeStore::new(&column_types).unwrap();
     let right_model = right_store.get_model().unwrap();
 

--- a/glib-sys/src/lib.rs
+++ b/glib-sys/src/lib.rs
@@ -168,35 +168,4 @@ extern "C" {
                                signal: *const c_char,
                                func: Option<extern "C" fn()>,
                                user_data: *const c_void);
-
-    //=========================================================================
-    // GType constants
-    //=========================================================================
-    pub static g_type_invalid: GType;
-    pub static g_type_none: GType;
-    pub static g_type_interface: GType;
-    pub static g_type_char: GType;
-    pub static g_type_uchar: GType;
-    pub static g_type_boolean: GType;
-    pub static g_type_int: GType;
-    pub static g_type_uint: GType;
-    pub static g_type_long: GType;
-    pub static g_type_ulong: GType;
-    pub static g_type_int64: GType;
-    pub static g_type_uint64: GType;
-    pub static g_type_enum: GType;
-    pub static g_type_flags: GType;
-    pub static g_type_float: GType;
-    pub static g_type_double: GType;
-    pub static g_type_string: GType;
-    pub static g_type_pointer: GType;
-    pub static g_type_boxed: GType;
-    pub static g_type_param: GType;
-    pub static g_type_object: GType;
-    pub static g_type_variant: GType;
-    pub static g_type_reserved_glib_first: GType;
-    pub static g_type_reserved_glib_last: GType;
-    pub static g_type_reserved_bse_first: GType;
-    pub static g_type_reserved_bse_last: GType;
-    pub static g_type_reserved_user_first: GType;
 }

--- a/glib/src/lib.rs
+++ b/glib/src/lib.rs
@@ -34,7 +34,6 @@ pub use self::glib_container::GlibContainer;
 pub use self::error::{Error};
 pub use self::permission::Permission;
 pub use self::traits::{FFIGObject, Connect};
-pub use ffi::GType;
 
 mod list;
 mod slist;
@@ -89,6 +88,71 @@ pub struct ParamSpec {
     g_type_instance: TypeInstance,
     name: *mut c_char,
     flags: ParamFlags,
-    value_type: GType,
-    owner_type: GType
+    value_type: ffi::GType,
+    owner_type: ffi::GType
+}
+
+#[repr(C)]
+#[derive(Clone, PartialEq, PartialOrd, Debug, FromPrimitive, Copy)]
+pub enum GType {
+    /// An invalid GType used as error return value in some functions which return a GType.
+    Invalid = 0 << 2,
+    /// A fundamental type which is used as a replacement for the C void return type.
+    None = 1 << 2,
+    /// The fundamental type from which all interfaces are derived.
+    Interface = 2 << 2,
+    /// The fundamental type corresponding to gchar. The type designated by G_TYPE_CHAR is unconditionally
+    /// an 8-bit signed integer. This may or may not be the same type a the C type "gchar".
+    Char = 3 << 2,
+    /// The fundamental type corresponding to guchar.
+    UChar = 4 << 2,
+    /// The fundamental type corresponding to gboolean.
+    Boolean = 5 << 2,
+    /// The fundamental type corresponding to gint.
+    Int = 6 << 2,
+    /// The fundamental type corresponding to guint.
+    UInt = 7 << 2,
+    /// The fundamental type corresponding to glong.
+    Long = 8 << 2,
+    /// The fundamental type corresponding to gulong.
+    ULong = 9 << 2,
+    /// The fundamental type corresponding to gint64.
+    Int64 = 10 << 2,
+    /// The fundamental type corresponding to guint64.
+    UInt64 = 11 << 2,
+    /// The fundamental type from which all enumeration types are derived.
+    Enum = 12 << 2,
+    /// The fundamental type from which all flags types are derived.
+    Flags = 13 << 2,
+    /// The fundamental type corresponding to gfloat.
+    Float = 14 << 2,
+    /// The fundamental type corresponding to gdouble.
+    Double = 15 << 2,
+    /// The fundamental type corresponding to nul-terminated C strings.
+    String = 16 << 2,
+    /// The fundamental type corresponding to gpointer.
+    Pointer = 17 << 2,
+    /// The fundamental type from which all boxed types are derived.
+    Boxed = 18 << 2,
+    /// The fundamental type from which all GParamSpec types are derived.
+    Param = 19 << 2,
+    /// The fundamental type for GObject.
+    Object = 20 << 2,
+    /// The fundamental type corresponding to GVariant.
+    /// All floating GVariant instances passed through the GType system are consumed.
+    /// Note that callbacks in closures, and signal handlers for signals of return type G_TYPE_VARIANT, must never return floating variants.
+    /// Note: GLib 2.24 did include a boxed type with this name. It was replaced with this fundamental type in 2.26.
+    Variant = 21 << 2,
+/*
+    /// First fundamental type number to create a new fundamental type id with G_TYPE_MAKE_FUNDAMENTAL() reserved for GLib.
+    ReservedGLibFirst = 22,
+    /// Last fundamental type number reserved for GLib.
+    ReservedGLibLast = 31,
+    /// First fundamental type number to create a new fundamental type id with G_TYPE_MAKE_FUNDAMENTAL() reserved for BSE.
+    ReservedGLibBSEFirst = 32,
+    /// Last fundamental type number reserved for BSE.
+    ReservedGLibBSELast = 48,
+    /// First available fundamental type number to create new fundamental type id with G_TYPE_MAKE_FUNDAMENTAL().
+    ReservedUserFirst = 49
+*/
 }

--- a/gtk3-sys/src/enums.rs
+++ b/gtk3-sys/src/enums.rs
@@ -1266,69 +1266,6 @@ pub enum SensitivityType {
     Off
 }
 
-#[repr(C)]
-#[derive(Clone, PartialEq, PartialOrd, Debug, Copy)]
-pub enum GType {
-    /// An invalid GType used as error return value in some functions which return a GType.
-    Invalid,
-    /// A fundamental type which is used as a replacement for the C void return type.
-    None,
-    /// The fundamental type from which all interfaces are derived.
-    Interface,
-    /// The fundamental type corresponding to gchar. The type designated by G_TYPE_CHAR is unconditionally
-    /// an 8-bit signed integer. This may or may not be the same type a the C type "gchar".
-    Char,
-    /// The fundamental type corresponding to guchar.
-    UChar,
-    /// The fundamental type corresponding to gboolean.
-    Boolean,
-    /// The fundamental type corresponding to gint.
-    Int,
-    /// The fundamental type corresponding to guint.
-    UInt,
-    /// The fundamental type corresponding to glong.
-    Long,
-    /// The fundamental type corresponding to gulong.
-    ULong,
-    /// The fundamental type corresponding to gint64.
-    Int64,
-    /// The fundamental type corresponding to guint64.
-    UInt64,
-    /// The fundamental type from which all enumeration types are derived.
-    Enum,
-    /// The fundamental type from which all flags types are derived.
-    Flags,
-    /// The fundamental type corresponding to gfloat.
-    Float,
-    /// The fundamental type corresponding to gdouble.
-    Double,
-    /// The fundamental type corresponding to nul-terminated C strings.
-    String,
-    /// The fundamental type corresponding to gpointer.
-    Pointer,
-    /// The fundamental type from which all boxed types are derived.
-    Boxed,
-    /// The fundamental type from which all GParamSpec types are derived.
-    Param,
-    /// The fundamental type for GObject.
-    Object,
-    /// The fundamental type corresponding to GVariant.
-    /// All floating GVariant instances passed through the GType system are consumed.
-    /// Note that callbacks in closures, and signal handlers for signals of return type G_TYPE_VARIANT, must never return floating variants.
-    /// Note: GLib 2.24 did include a boxed type with this name. It was replaced with this fundamental type in 2.26.
-    Variant,
-    /// First fundamental type number to create a new fundamental type id with G_TYPE_MAKE_FUNDAMENTAL() reserved for GLib.
-    ReservedGLibFirst,
-    /// Last fundamental type number reserved for GLib.
-    ReservedGLibLast = 31,
-    /// First fundamental type number to create a new fundamental type id with G_TYPE_MAKE_FUNDAMENTAL() reserved for BSE.
-    ReservedGLibBSEFirst = 32,
-    /// Last fundamental type number reserved for BSE.
-    ReservedGLibBSELast = 48,
-    /// First available fundamental type number to create new fundamental type id with G_TYPE_MAKE_FUNDAMENTAL().
-    ReservedUserFirst = 49
-}
-
 /// Flags affecting how a search is done.
 #[repr(C)]
 #[derive(Clone, PartialEq, PartialOrd, Debug, Copy)]

--- a/gtk3-sys/src/gtk_glue.c
+++ b/gtk3-sys/src/gtk_glue.c
@@ -610,36 +610,6 @@ GtkEventBox* cast_GtkEventBox(GtkWidget* widget) {
     return GTK_EVENT_BOX(widget);
 }
 
-// GType constants
-
-const GType g_type_invalid = G_TYPE_INVALID;
-const GType g_type_none = G_TYPE_NONE;
-const GType g_type_interface = G_TYPE_INTERFACE;
-const GType g_type_char = G_TYPE_CHAR;
-const GType g_type_uchar = G_TYPE_UCHAR;
-const GType g_type_boolean = G_TYPE_BOOLEAN;
-const GType g_type_int = G_TYPE_INT;
-const GType g_type_uint = G_TYPE_UINT;
-const GType g_type_long = G_TYPE_LONG;
-const GType g_type_ulong = G_TYPE_ULONG;
-const GType g_type_int64 = G_TYPE_INT64;
-const GType g_type_uint64 = G_TYPE_UINT64;
-const GType g_type_enum = G_TYPE_ENUM;
-const GType g_type_flags = G_TYPE_FLAGS;
-const GType g_type_float = G_TYPE_FLOAT;
-const GType g_type_double = G_TYPE_DOUBLE;
-const GType g_type_string = G_TYPE_STRING;
-const GType g_type_pointer = G_TYPE_POINTER;
-const GType g_type_boxed = G_TYPE_BOXED;
-const GType g_type_param = G_TYPE_PARAM;
-const GType g_type_object = G_TYPE_OBJECT;
-const GType g_type_variant = G_TYPE_VARIANT;
-const GType g_type_reserved_glib_first = G_TYPE_RESERVED_GLIB_FIRST;
-const GType g_type_reserved_glib_last = G_TYPE_RESERVED_GLIB_LAST;
-const GType g_type_reserved_bse_first = G_TYPE_RESERVED_BSE_FIRST;
-const GType g_type_reserved_bse_last = G_TYPE_RESERVED_BSE_LAST;
-const GType g_type_reserved_user_first = G_TYPE_RESERVED_USER_FIRST;
-
 /* MAC OS dylib
 gcc -I/usr/local/include/gtk-3.0 -I/usr/local/include/glib-2.0 -I/usr/local/include/gobject-introspection-1.0 -I/usr/local/Cellar/glib/2.38.1/lib/glib-2.0/include/ -I/usr/local/Cellar/pango/1.36.0/include/pango-1.0/ -I/usr/local/Cellar/cairo/1.12.16/include/cairo/ -I/usr/local/Cellar/gdk-pixbuf/2.30.0/include/gdk-pixbuf-2.0/ -I/usr/local/Cellar/atk/2.10.0/include/atk-1.0/ -lglib-2.0 -lgtk-3.0 -lgobject-2.0 -dynamiclib -o libgtk_glue.dylib -dy gtk_glue.c
 */

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -289,7 +289,6 @@ pub use gtk_ffi::enums::CellRendererState;
 pub use gtk_ffi::enums::TreeModelFlags;
 pub use gtk_ffi::enums::IconViewDropPosition;
 pub use gtk_ffi::enums::SensitivityType;
-pub use gtk_ffi::enums::GType;
 pub use gtk_ffi::enums::TextSearchFlags;
 pub use gtk_ffi::enums::PlacesOpenFlags;
 pub use gtk_ffi::enums::ToolPaletteDragTargets;

--- a/src/gtk/widgets/list_store.rs
+++ b/src/gtk/widgets/list_store.rs
@@ -13,12 +13,11 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use glib::ffi::GType;
+use glib::{to_bool, GType};
 use gtk::{self, ffi};
 use gtk::TreeIter;
 use std::ffi::CString;
 use std::num::ToPrimitive;
-use glib::to_bool;
 
 pub struct ListStore {
     pointer: *mut ffi::C_GtkListStore
@@ -26,12 +25,18 @@ pub struct ListStore {
 
 impl ListStore {
     pub fn new(column_types: &[GType]) -> Option<ListStore> {
-        let tmp_pointer = unsafe { ffi::gtk_list_store_newv(column_types.len().to_i32().unwrap(), column_types) };
+        let column_types_ffi : Vec<::glib_ffi::GType> = column_types.iter().map(|n| *n as ::glib_ffi::GType).collect();
+        let tmp_pointer = unsafe {
+            ffi::gtk_list_store_newv(column_types.len().to_i32().unwrap(), column_types_ffi.as_slice())
+        };
         check_pointer!(tmp_pointer, ListStore, G_OBJECT_FROM_LIST_STORE)
     }
 
     pub fn set_column_types(&self, column_types: &[GType]) {
-        unsafe { ffi::gtk_list_store_set_column_types(self.pointer, column_types.len().to_i32().unwrap(), column_types) }
+        let column_types_ffi : Vec<::glib_ffi::GType> = column_types.iter().map(|n| *n as ::glib_ffi::GType).collect();
+        unsafe {
+            ffi::gtk_list_store_set_column_types(self.pointer, column_types.len().to_i32().unwrap(), column_types_ffi.as_slice())
+        }
     }
 
     pub fn set_string(&self, iter: &TreeIter, column: i32, text: &str) {

--- a/src/gtk/widgets/tree_store.rs
+++ b/src/gtk/widgets/tree_store.rs
@@ -13,12 +13,11 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
+use glib::{to_bool, GType};
 use gtk::{self, ffi};
-use glib::ffi::GType;
 use gtk::TreeIter;
 use std::ffi::CString;
 use std::num::ToPrimitive;
-use glib::to_bool;
 
 pub struct TreeStore {
     pointer: *mut ffi::C_GtkTreeStore
@@ -26,12 +25,18 @@ pub struct TreeStore {
 
 impl TreeStore {
     pub fn new(column_types: &[GType]) -> Option<TreeStore> {
-        let tmp_pointer = unsafe { ffi::gtk_tree_store_newv(column_types.len().to_i32().unwrap(), column_types) };
+        let column_types_ffi : Vec<::glib_ffi::GType> = column_types.iter().map(|n| *n as ::glib_ffi::GType).collect();
+        let tmp_pointer = unsafe {
+            ffi::gtk_tree_store_newv(column_types.len().to_i32().unwrap(), column_types_ffi.as_slice())
+        };
         check_pointer!(tmp_pointer, TreeStore, G_OBJECT_FROM_TREE_STORE)
     }
 
     pub fn set_column_types(&self, column_types: &[GType]) {
-        unsafe { ffi::gtk_tree_store_set_column_types(self.pointer, column_types.len().to_i32().unwrap(), column_types) }
+        let column_types_ffi : Vec<::glib_ffi::GType> = column_types.iter().map(|n| *n as ::glib_ffi::GType).collect();
+        unsafe {
+            ffi::gtk_tree_store_set_column_types(self.pointer, column_types.len().to_i32().unwrap(), column_types_ffi.as_slice())
+        }
     }
 
     pub fn set_string(&self, iter: &TreeIter, column: i32, text: &str) {

--- a/src/gtk/widgets/value.rs
+++ b/src/gtk/widgets/value.rs
@@ -15,11 +15,11 @@
 
 //! Generic values — A polymorphic type that can hold values of any other type
 
+use libc::{self, c_char, c_void};
+use glib::{to_bool, to_gboolean, GType};
 use gtk::ffi;
 use std::ffi::CString;
-use libc::{self, c_char, c_void};
-use glib::{to_bool, to_gboolean};
-use glib_ffi::{self};
+use std::num::FromPrimitive;
 
 trait GValuePrivate {
     fn get(gvalue: &GValue) -> Self;
@@ -46,8 +46,8 @@ impl GValue {
         }
     }
 
-    pub fn init(&self, _type: glib_ffi::GType) {
-        unsafe { ffi::g_value_init(self.pointer, _type) }
+    pub fn init(&self, _type: GType) {
+        unsafe { ffi::g_value_init(self.pointer, _type as ::glib_ffi::GType) }
     }
 
     pub fn reset(&self) {
@@ -158,23 +158,23 @@ impl GValue {
     }
 
     // FIXME shouldn't be like that
-    pub fn set_enum(&self, v_enum: glib_ffi::GType) {
-        unsafe { ffi::g_value_set_enum(self.pointer, v_enum) }
+    pub fn set_enum(&self, v_enum: GType) {
+        unsafe { ffi::g_value_set_enum(self.pointer, v_enum as ::glib_ffi::GType) }
     }
 
     // FIXME shouldn't be like that
-    pub fn get_enum(&self) -> glib_ffi::GType {
-        unsafe { ffi::g_value_get_enum(self.pointer) }
+    pub fn get_enum(&self) -> GType {
+        unsafe { FromPrimitive::from_u64(ffi::g_value_get_enum(self.pointer)).unwrap() }
     }
 
     // FIXME shouldn't be like that
-    pub fn set_flags(&self, v_flags: glib_ffi::GType) {
-        unsafe { ffi::g_value_set_flags(self.pointer, v_flags) }
+    pub fn set_flags(&self, v_flags: GType) {
+        unsafe { ffi::g_value_set_flags(self.pointer, v_flags as ::glib_ffi::GType) }
     }
 
     // FIXME shouldn't be like that
-    pub fn get_flags(&self) -> glib_ffi::GType {
-        unsafe { ffi::g_value_get_flags(self.pointer) }
+    pub fn get_flags(&self) -> GType {
+        unsafe { FromPrimitive::from_u64(ffi::g_value_get_flags(self.pointer)).unwrap() }
     }
 
     fn set_string(&self, v_string: &str) {
@@ -276,13 +276,13 @@ impl GValue {
     }*/
 
     // FIXME shouldn't be like that
-    fn set_gtype(&self, v_gtype: glib_ffi::GType) {
-        unsafe { ffi::g_value_set_gtype(self.pointer, v_gtype) }
+    fn set_gtype(&self, v_gtype: GType) {
+        unsafe { ffi::g_value_set_gtype(self.pointer, v_gtype as ::glib_ffi::GType) }
     }
 
     // FIXME shouldn't be like that
-    fn get_gtype(&self) -> glib_ffi::GType {
-        unsafe { ffi::g_value_get_gtype(self.pointer) }
+    fn get_gtype(&self) -> GType {
+        unsafe { FromPrimitive::from_u64(ffi::g_value_get_gtype(self.pointer)).unwrap() }
     }
 
     pub fn set<T: GValuePublic>(&self, val: &T) {
@@ -293,12 +293,12 @@ impl GValue {
         GValuePrivate::get(self)
     }
 
-    pub fn compatible(src_type: glib_ffi::GType, dest_type: glib_ffi::GType) -> bool {
-        unsafe { to_bool(ffi::g_value_type_compatible(src_type, dest_type)) }
+    pub fn compatible(src_type: GType, dest_type: GType) -> bool {
+        unsafe { to_bool(ffi::g_value_type_compatible(src_type as ::glib_ffi::GType, dest_type as ::glib_ffi::GType)) }
     }
 
-    pub fn transformable(src_type: glib_ffi::GType, dest_type: glib_ffi::GType) -> bool {
-        unsafe { to_bool(ffi::g_value_type_transformable(src_type, dest_type)) }
+    pub fn transformable(src_type: GType, dest_type: GType) -> bool {
+        unsafe { to_bool(ffi::g_value_type_transformable(src_type as ::glib_ffi::GType, dest_type as ::glib_ffi::GType)) }
     }
 
     #[doc(hidden)]
@@ -353,7 +353,6 @@ impl GValuePrivate for i64 {
     }
 }
 
-/*
 impl GValuePrivate for u64 {
     fn get(gvalue: &GValue) -> u64 {
         gvalue.get_uint64()
@@ -363,7 +362,6 @@ impl GValuePrivate for u64 {
         gvalue.set_uint64(*self)
     }
 }
-*/
 
 impl GValuePrivate for bool {
     fn get(gvalue: &GValue) -> bool {
@@ -415,8 +413,8 @@ impl GValuePrivate for f64 {
     }
 }
 
-impl GValuePrivate for glib_ffi::GType {
-    fn get(gvalue: &GValue) -> glib_ffi::GType {
+impl GValuePrivate for GType {
+    fn get(gvalue: &GValue) -> GType {
         gvalue.get_gtype()
     }
 
@@ -441,10 +439,10 @@ impl GValuePrivate for String {
 impl GValuePublic for i32 {}
 impl GValuePublic for u32 {}
 impl GValuePublic for i64 {}
-//impl GValuePublic for u64 {}
+impl GValuePublic for u64 {}
 impl GValuePublic for i8 {}
 impl GValuePublic for u8 {}
-impl GValuePublic for glib_ffi::GType {}
+impl GValuePublic for GType {}
 impl GValuePublic for String {}
 impl GValuePublic for f32 {}
 impl GValuePublic for f64 {}

--- a/src/rgtk.rs
+++ b/src/rgtk.rs
@@ -61,6 +61,7 @@ extern crate "cairo-sys" as cairo_ffi;
 extern crate glib;
 
 pub use glib::traits::Connect;
+pub use glib::GType;
 pub use gtk::widgets::GValuePublic;
 
 pub use gtk::BoxTrait as GtkBoxTrait;
@@ -104,9 +105,3 @@ pub use gtk::WindowTrait as GtkWindowTrait;
 pub mod gtk;
 pub mod cairo;
 pub mod gdk;
-
-pub mod ffi {
-    pub mod glib {
-        pub use glib_ffi::*;
-    }
-}


### PR DESCRIPTION
This is the same as #221 but moves GType to the glib crate and replaces `as u64` with `as ::glib_ffi::GType` for better maintainability. I don't know how to get the variant working as @gkoz mentioned.