### PR TITLE
Add glib::type_::Type that corresponds to GType

### DIFF
--- a/examples/src/treeview.rs
+++ b/examples/src/treeview.rs
@@ -38,14 +38,14 @@ fn main() {
     let hello = String::from_str("Hello world !");
     let value = gtk::GValue::new().unwrap();
 
-    value.init(ffi::glib::g_type_string);
+    value.init(ffi::glib::G_TYPE_STRING);
     value.set(&hello);
     println!("gvalue.get example : {}", value.get::<String>());
 
     // left pane
 
     let mut left_tree = gtk::TreeView::new().unwrap();
-    let column_types = [ffi::glib::g_type_string];
+    let column_types = [ffi::glib::G_TYPE_STRING];
     let left_store = gtk::ListStore::new(&column_types).unwrap();
     let left_model = left_store.get_model().unwrap();
 
@@ -62,7 +62,7 @@ fn main() {
     // right pane
 
     let mut right_tree = gtk::TreeView::new().unwrap();
-    let column_types = [ffi::glib::g_type_string];
+    let column_types = [ffi::glib::G_TYPE_STRING];
     let right_store = gtk::TreeStore::new(&column_types).unwrap();
     let right_model = right_store.get_model().unwrap();
 

--- a/glib-sys/src/lib.rs
+++ b/glib-sys/src/lib.rs
@@ -60,6 +60,34 @@ pub struct C_GPermission;
 #[derive(Copy)]
 pub struct C_GObject;
 
+//=========================================================================
+// GType constants
+//=========================================================================
+
+pub const G_TYPE_FUNDAMENTAL_SHIFT: u8 = 2;
+pub const G_TYPE_INVALID: GType = 0 << G_TYPE_FUNDAMENTAL_SHIFT;
+pub const G_TYPE_NONE: GType = 1 << G_TYPE_FUNDAMENTAL_SHIFT;
+pub const G_TYPE_INTERFACE: GType = 2 << G_TYPE_FUNDAMENTAL_SHIFT;
+pub const G_TYPE_CHAR: GType = 3 << G_TYPE_FUNDAMENTAL_SHIFT;
+pub const G_TYPE_UCHAR: GType = 4 << G_TYPE_FUNDAMENTAL_SHIFT;
+pub const G_TYPE_BOOLEAN: GType = 5 << G_TYPE_FUNDAMENTAL_SHIFT;
+pub const G_TYPE_INT: GType = 6 << G_TYPE_FUNDAMENTAL_SHIFT;
+pub const G_TYPE_UINT: GType = 7 << G_TYPE_FUNDAMENTAL_SHIFT;
+pub const G_TYPE_LONG: GType = 8 << G_TYPE_FUNDAMENTAL_SHIFT;
+pub const G_TYPE_ULONG: GType = 9 << G_TYPE_FUNDAMENTAL_SHIFT;
+pub const G_TYPE_INT64: GType = 10 << G_TYPE_FUNDAMENTAL_SHIFT;
+pub const G_TYPE_UINT64: GType = 11 << G_TYPE_FUNDAMENTAL_SHIFT;
+pub const G_TYPE_ENUM: GType = 12 << G_TYPE_FUNDAMENTAL_SHIFT;
+pub const G_TYPE_FLAGS: GType = 13 << G_TYPE_FUNDAMENTAL_SHIFT;
+pub const G_TYPE_FLOAT: GType = 14 << G_TYPE_FUNDAMENTAL_SHIFT;
+pub const G_TYPE_DOUBLE: GType = 15 << G_TYPE_FUNDAMENTAL_SHIFT;
+pub const G_TYPE_STRING: GType = 16 << G_TYPE_FUNDAMENTAL_SHIFT;
+pub const G_TYPE_POINTER: GType = 17 << G_TYPE_FUNDAMENTAL_SHIFT;
+pub const G_TYPE_BOXED: GType = 18 << G_TYPE_FUNDAMENTAL_SHIFT;
+pub const G_TYPE_PARAM: GType = 19 << G_TYPE_FUNDAMENTAL_SHIFT;
+pub const G_TYPE_OBJECT: GType = 20 << G_TYPE_FUNDAMENTAL_SHIFT;
+pub const G_TYPE_VARIANT: GType = 21 << G_TYPE_FUNDAMENTAL_SHIFT;
+
 extern "C" {
 
     pub fn g_free                          (ptr: gpointer);

--- a/glib-sys/src/lib.rs
+++ b/glib-sys/src/lib.rs
@@ -196,35 +196,4 @@ extern "C" {
                                signal: *const c_char,
                                func: Option<extern "C" fn()>,
                                user_data: *const c_void);
-
-    //=========================================================================
-    // GType constants
-    //=========================================================================
-    pub static g_type_invalid: GType;
-    pub static g_type_none: GType;
-    pub static g_type_interface: GType;
-    pub static g_type_char: GType;
-    pub static g_type_uchar: GType;
-    pub static g_type_boolean: GType;
-    pub static g_type_int: GType;
-    pub static g_type_uint: GType;
-    pub static g_type_long: GType;
-    pub static g_type_ulong: GType;
-    pub static g_type_int64: GType;
-    pub static g_type_uint64: GType;
-    pub static g_type_enum: GType;
-    pub static g_type_flags: GType;
-    pub static g_type_float: GType;
-    pub static g_type_double: GType;
-    pub static g_type_string: GType;
-    pub static g_type_pointer: GType;
-    pub static g_type_boxed: GType;
-    pub static g_type_param: GType;
-    pub static g_type_object: GType;
-    pub static g_type_variant: GType;
-    pub static g_type_reserved_glib_first: GType;
-    pub static g_type_reserved_glib_last: GType;
-    pub static g_type_reserved_bse_first: GType;
-    pub static g_type_reserved_bse_last: GType;
-    pub static g_type_reserved_user_first: GType;
 }

--- a/glib/src/lib.rs
+++ b/glib/src/lib.rs
@@ -34,7 +34,7 @@ pub use self::glib_container::GlibContainer;
 pub use self::error::{Error};
 pub use self::permission::Permission;
 pub use self::traits::{FFIGObject, Connect};
-pub use ffi::GType;
+pub use type_::Type;
 
 mod list;
 mod slist;
@@ -43,6 +43,7 @@ mod error;
 mod permission;
 pub mod traits;
 pub mod translate;
+pub mod type_;
 
 pub fn to_gboolean(b: bool) -> ffi::Gboolean {
     match b {
@@ -89,6 +90,6 @@ pub struct ParamSpec {
     g_type_instance: TypeInstance,
     name: *mut c_char,
     flags: ParamFlags,
-    value_type: GType,
-    owner_type: GType
+    value_type: ffi::GType,
+    owner_type: ffi::GType,
 }

--- a/glib/src/type_.rs
+++ b/glib/src/type_.rs
@@ -1,0 +1,124 @@
+use std::marker::PhantomFn;
+use translate::{FromGlib, ToGlib};
+use ffi;
+
+/// A GLib or GLib-based library type
+#[derive(Copy, Debug, PartialEq, Eq)]
+pub enum Type {
+    /// An invalid `Type` used as error return value in some functions
+    Invalid,
+    /// The fundamental type corresponding to the unit type `()`
+    Unit,
+    /// The fundamental type corresponding to `i8`
+    I8,
+    /// The fundamental type corresponding to `u8`
+    U8,
+    /// The fundamental type corresponding to `bool`
+    Bool,
+    /// The fundamental type corresponding to `i32`
+    I32,
+    /// The fundamental type corresponding to `u32`
+    U32,
+    /// The fundamental type corresponding to `isize`
+    ISize,
+    /// The fundamental type corresponding to `usize`
+    USize,
+    /// The fundamental type corresponding to `i64`
+    I64,
+    /// The fundamental type corresponding to `u64`
+    U64,
+    /// The fundamental type corresponding to `f32`
+    F32,
+    /// The fundamental type corresponding to `f64`
+    F64,
+    /// The fundamental type corresponding to `String`
+    String,
+    /// The fundamental type corresponding to a pointer
+    Pointer,
+    /// The fundamental type of GVariant
+    Variant,
+    /// The fundamental type from which all interfaces are derived
+    BaseInterface,
+    /// The fundamental type from which all enumeration types are derived
+    BaseEnum,
+    /// The fundamental type from which all flags types are derived
+    BaseFlags,
+    /// The fundamental type from which all boxed types are derived
+    BaseBoxed,
+    /// The fundamental type from which all `GParamSpec` types are derived
+    BaseParamSpec,
+    /// The fundamental type from which all objects are derived
+    BaseObject,
+    /// A non-fundamental type identified by value of type `usize`
+    Other(usize),
+}
+
+pub trait GetType: PhantomFn<Self> {
+    fn get_type() -> Type;
+}
+
+impl FromGlib for Type {
+    type GlibType = ffi::GType;
+
+    fn conv(val: ffi::GType) -> Type {
+        use self::Type::*;
+        match val {
+            ffi::G_TYPE_INVALID => Invalid,
+            ffi::G_TYPE_NONE => Unit,
+            ffi::G_TYPE_INTERFACE => BaseInterface,
+            ffi::G_TYPE_CHAR => I8,
+            ffi::G_TYPE_UCHAR => U8,
+            ffi::G_TYPE_BOOLEAN => Bool,
+            ffi::G_TYPE_INT => I32,
+            ffi::G_TYPE_UINT => U32,
+            ffi::G_TYPE_LONG => ISize,
+            ffi::G_TYPE_ULONG => USize,
+            ffi::G_TYPE_INT64 => I64,
+            ffi::G_TYPE_UINT64 => U64,
+            ffi::G_TYPE_ENUM => BaseEnum,
+            ffi::G_TYPE_FLAGS => BaseFlags,
+            ffi::G_TYPE_FLOAT => F32,
+            ffi::G_TYPE_DOUBLE => F64,
+            ffi::G_TYPE_STRING => String,
+            ffi::G_TYPE_POINTER => Pointer,
+            ffi::G_TYPE_BOXED => BaseBoxed,
+            ffi::G_TYPE_PARAM => BaseParamSpec,
+            ffi::G_TYPE_OBJECT => BaseObject,
+            ffi::G_TYPE_VARIANT => Variant,
+            x => Other(x as usize),
+        }
+    }
+}
+
+impl ToGlib for Type {
+    type GlibType = ffi::GType;
+
+    fn to_glib(&self) -> ffi::GType {
+        use self::Type::*;
+        match *self {
+            Invalid => ffi::G_TYPE_INVALID,
+            Unit => ffi::G_TYPE_NONE,
+            BaseInterface => ffi::G_TYPE_INTERFACE,
+            I8 => ffi::G_TYPE_CHAR,
+            U8 => ffi::G_TYPE_UCHAR,
+            Bool => ffi::G_TYPE_BOOLEAN,
+            I32 => ffi::G_TYPE_INT,
+            U32 => ffi::G_TYPE_UINT,
+            ISize => ffi::G_TYPE_LONG,
+            USize => ffi::G_TYPE_ULONG,
+            I64 => ffi::G_TYPE_INT64,
+            U64 => ffi::G_TYPE_UINT64,
+            BaseEnum => ffi::G_TYPE_ENUM,
+            BaseFlags => ffi::G_TYPE_FLAGS,
+            F32 => ffi::G_TYPE_FLOAT,
+            F64 => ffi::G_TYPE_DOUBLE,
+            String => ffi::G_TYPE_STRING,
+            Pointer => ffi::G_TYPE_POINTER,
+            BaseBoxed => ffi::G_TYPE_BOXED,
+            BaseParamSpec => ffi::G_TYPE_PARAM,
+            BaseObject => ffi::G_TYPE_OBJECT,
+            Variant => ffi::G_TYPE_VARIANT,
+            Other(x) => x as ffi::GType,
+        }
+    }
+}

--- a/gtk3-sys/src/gtk_glue.c
+++ b/gtk3-sys/src/gtk_glue.c
@@ -610,36 +610,6 @@ GtkEventBox* cast_GtkEventBox(GtkWidget* widget) {
     return GTK_EVENT_BOX(widget);
 }
 
-// GType constants
-
-const GType g_type_invalid = G_TYPE_INVALID;
-const GType g_type_none = G_TYPE_NONE;
-const GType g_type_interface = G_TYPE_INTERFACE;
-const GType g_type_char = G_TYPE_CHAR;
-const GType g_type_uchar = G_TYPE_UCHAR;
-const GType g_type_boolean = G_TYPE_BOOLEAN;
-const GType g_type_int = G_TYPE_INT;
-const GType g_type_uint = G_TYPE_UINT;
-const GType g_type_long = G_TYPE_LONG;
-const GType g_type_ulong = G_TYPE_ULONG;
-const GType g_type_int64 = G_TYPE_INT64;
-const GType g_type_uint64 = G_TYPE_UINT64;
-const GType g_type_enum = G_TYPE_ENUM;
-const GType g_type_flags = G_TYPE_FLAGS;
-const GType g_type_float = G_TYPE_FLOAT;
-const GType g_type_double = G_TYPE_DOUBLE;
-const GType g_type_string = G_TYPE_STRING;
-const GType g_type_pointer = G_TYPE_POINTER;
-const GType g_type_boxed = G_TYPE_BOXED;
-const GType g_type_param = G_TYPE_PARAM;
-const GType g_type_object = G_TYPE_OBJECT;
-const GType g_type_variant = G_TYPE_VARIANT;
-const GType g_type_reserved_glib_first = G_TYPE_RESERVED_GLIB_FIRST;
-const GType g_type_reserved_glib_last = G_TYPE_RESERVED_GLIB_LAST;
-const GType g_type_reserved_bse_first = G_TYPE_RESERVED_BSE_FIRST;
-const GType g_type_reserved_bse_last = G_TYPE_RESERVED_BSE_LAST;
-const GType g_type_reserved_user_first = G_TYPE_RESERVED_USER_FIRST;
-
 /* MAC OS dylib
 gcc -I/usr/local/include/gtk-3.0 -I/usr/local/include/glib-2.0 -I/usr/local/include/gobject-introspection-1.0 -I/usr/local/Cellar/glib/2.38.1/lib/glib-2.0/include/ -I/usr/local/Cellar/pango/1.36.0/include/pango-1.0/ -I/usr/local/Cellar/cairo/1.12.16/include/cairo/ -I/usr/local/Cellar/gdk-pixbuf/2.30.0/include/gdk-pixbuf-2.0/ -I/usr/local/Cellar/atk/2.10.0/include/atk-1.0/ -lglib-2.0 -lgtk-3.0 -lgobject-2.0 -dynamiclib -o libgtk_glue.dylib -dy gtk_glue.c
 */


### PR DESCRIPTION
Add an enum `Type` that represents `GType` in a Rust-y way and implements translation between them.

Example usage would be
```rust
use glib::Type;
use glib::translate::{ToGlib, from_glib};
// ...
    pub fn init(&self, _type: Type) {
        unsafe { ffi::g_value_init(self.pointer, _type.to_glib()) }
    }
    pub fn foo() -> Type {
        unsafe { from_glib(ffi::g_foo_that_returns_g_type()) }
    }
```