### PR TITLE
Use the new Type enum and move GValue to the glib crate

### DIFF
--- a/examples/src/treeview.rs
+++ b/examples/src/treeview.rs
@@ -33,10 +33,10 @@ fn main() {
         true
     }));
 
-    // test GValue
+    // test Value
 
     let hello = String::from_str("Hello world !");
-    let value = glib::GValue::new().unwrap();
+    let value = glib::Value::new().unwrap();
 
     value.init(glib::Type::String);
     value.set(&hello);

--- a/examples/src/treeview.rs
+++ b/examples/src/treeview.rs
@@ -36,16 +36,16 @@ fn main() {
     // test GValue
 
     let hello = String::from_str("Hello world !");
-    let value = gtk::GValue::new().unwrap();
+    let value = glib::GValue::new().unwrap();
 
-    value.init(ffi::glib::G_TYPE_STRING);
+    value.init(glib::Type::String);
     value.set(&hello);
     println!("gvalue.get example : {}", value.get::<String>());
 
     // left pane
 
     let mut left_tree = gtk::TreeView::new().unwrap();
-    let column_types = [ffi::glib::G_TYPE_STRING];
+    let column_types = [glib::Type::String];
     let left_store = gtk::ListStore::new(&column_types).unwrap();
     let left_model = left_store.get_model().unwrap();
 
@@ -62,7 +62,7 @@ fn main() {
     // right pane
 
     let mut right_tree = gtk::TreeView::new().unwrap();
-    let column_types = [ffi::glib::G_TYPE_STRING];
+    let column_types = [glib::Type::String];
     let right_store = gtk::TreeStore::new(&column_types).unwrap();
     let right_model = right_store.get_model().unwrap();
 

--- a/glib-sys/src/lib.rs
+++ b/glib-sys/src/lib.rs
@@ -17,7 +17,7 @@
 
 extern crate libc;
 
-use libc::{c_int, c_void, c_uint, c_char, c_ulong};
+use libc::{c_void, c_int, c_uint, c_float, c_double, c_char, c_uchar, c_long, c_ulong};
 
 pub type GQuark = u32;
 
@@ -59,6 +59,10 @@ pub struct C_GPermission;
 #[repr(C)]
 #[derive(Copy)]
 pub struct C_GObject;
+
+#[repr(C)]
+#[derive(Copy)]
+pub struct C_GValue;
 
 //=========================================================================
 // GType constants
@@ -196,4 +200,56 @@ extern "C" {
                                signal: *const c_char,
                                func: Option<extern "C" fn()>,
                                user_data: *const c_void);
+
+    //=========================================================================
+    // GValue
+    //=========================================================================
+    pub fn create_gvalue                       () -> *mut C_GValue;
+    pub fn get_gtype                           (_type: GType) -> GType;
+    pub fn g_value_init                        (value: *mut C_GValue, _type: GType);
+    pub fn g_value_reset                       (value: *mut C_GValue);
+    pub fn g_value_unset                       (value: *mut C_GValue);
+    pub fn g_strdup_value_contents             (value: *mut C_GValue) -> *mut c_char;
+    pub fn g_value_set_boolean                 (value: *mut C_GValue, b: Gboolean);
+    pub fn g_value_get_boolean                 (value: *mut C_GValue) -> Gboolean;
+    pub fn g_value_set_schar                   (value: *mut C_GValue, b: c_char);
+    pub fn g_value_get_schar                   (value: *mut C_GValue) -> c_char;
+    pub fn g_value_set_uchar                   (value: *mut C_GValue, b: c_uchar);
+    pub fn g_value_get_uchar                   (value: *mut C_GValue) -> c_uchar;
+    pub fn g_value_set_int                     (value: *mut C_GValue, b: c_int);
+    pub fn g_value_get_int                     (value: *mut C_GValue) -> c_int;
+    pub fn g_value_set_uint                    (value: *mut C_GValue, b: c_uint);
+    pub fn g_value_get_uint                    (value: *mut C_GValue) -> c_uint;
+    pub fn g_value_set_long                    (value: *mut C_GValue, b: c_long);
+    pub fn g_value_get_long                    (value: *mut C_GValue) -> c_long;
+    pub fn g_value_set_ulong                   (value: *mut C_GValue, b: c_ulong);
+    pub fn g_value_get_ulong                   (value: *mut C_GValue) -> c_ulong;
+    pub fn g_value_set_int64                   (value: *mut C_GValue, b: i64);
+    pub fn g_value_get_int64                   (value: *mut C_GValue) -> i64;
+    pub fn g_value_set_uint64                  (value: *mut C_GValue, b: u64);
+    pub fn g_value_get_uint64                  (value: *mut C_GValue) -> u64;
+    pub fn g_value_set_float                   (value: *mut C_GValue, b: c_float);
+    pub fn g_value_get_float                   (value: *mut C_GValue) -> c_float;
+    pub fn g_value_set_double                  (value: *mut C_GValue, b: c_double);
+    pub fn g_value_get_double                  (value: *mut C_GValue) -> c_double;
+    pub fn g_value_set_enum                    (value: *mut C_GValue, b: GType);
+    pub fn g_value_get_enum                    (value: *mut C_GValue) -> GType;
+    pub fn g_value_set_flags                   (value: *mut C_GValue, b: GType);
+    pub fn g_value_get_flags                   (value: *mut C_GValue) -> GType;
+    pub fn g_value_set_string                  (value: *mut C_GValue, b: *const c_char);
+    pub fn g_value_set_static_string           (value: *mut C_GValue, b: *const c_char);
+    pub fn g_value_get_string                  (value: *mut C_GValue) -> *const c_char;
+    pub fn g_value_dup_string                  (value: *mut C_GValue) -> *mut c_char;
+    pub fn g_value_set_boxed                   (value: *mut C_GValue, b: *const c_void);
+    pub fn g_value_set_static_boxed            (value: *mut C_GValue, b: *const c_void);
+    pub fn g_value_get_boxed                   (value: *mut C_GValue) -> *const c_void;
+    pub fn g_value_set_pointer                 (value: *mut C_GValue, b: *const c_void);
+    pub fn g_value_get_pointer                 (value: *mut C_GValue) -> *const c_void;
+    pub fn g_value_set_object                  (value: *mut C_GValue, b: *const c_void);
+    pub fn g_value_take_object                 (value: *mut C_GValue, b: *const c_void);
+    pub fn g_value_get_object                  (value: *mut C_GValue) -> *const c_void;
+    pub fn g_value_set_gtype                   (value: *mut C_GValue, b: GType);
+    pub fn g_value_get_gtype                   (value: *mut C_GValue) -> GType;
+    pub fn g_value_type_compatible             (src_type: GType, dest_type: GType) -> Gboolean;
+    pub fn g_value_type_transformable          (src_type: GType, dest_type: GType) -> Gboolean;
 }

--- a/glib/src/lib.rs
+++ b/glib/src/lib.rs
@@ -34,7 +34,7 @@ pub use self::glib_container::GlibContainer;
 pub use self::error::{Error};
 pub use self::permission::Permission;
 pub use self::traits::{FFIGObject, Connect};
-pub use self::gvalue::{GValue, GValuePublic};
+pub use self::value::{Value, ValuePublic};
 pub use type_::Type;
 
 mod list;
@@ -44,7 +44,7 @@ mod error;
 mod permission;
 pub mod traits;
 pub mod translate;
-mod gvalue;
+mod value;
 pub mod type_;
 
 pub fn to_gboolean(b: bool) -> ffi::Gboolean {

--- a/glib/src/lib.rs
+++ b/glib/src/lib.rs
@@ -34,6 +34,7 @@ pub use self::glib_container::GlibContainer;
 pub use self::error::{Error};
 pub use self::permission::Permission;
 pub use self::traits::{FFIGObject, Connect};
+pub use self::gvalue::{GValue, GValuePublic};
 pub use type_::Type;
 
 mod list;
@@ -43,6 +44,7 @@ mod error;
 mod permission;
 pub mod traits;
 pub mod translate;
+mod gvalue;
 pub mod type_;
 
 pub fn to_gboolean(b: bool) -> ffi::Gboolean {

--- a/glib/src/value.rs
+++ b/glib/src/value.rs
@@ -21,24 +21,24 @@ use std::ffi::CString;
 use super::{to_bool, to_gboolean, Type};
 use super::translate::{ToGlib, from_glib};
 
-pub trait GValuePublic {
-    fn get(gvalue: &GValue) -> Self;
-    fn set(&self, gvalue: &GValue);
+pub trait ValuePublic {
+    fn get(gvalue: &Value) -> Self;
+    fn set(&self, gvalue: &Value);
 }
 
 // Possible improvment : store a function pointer inside the struct and make the struct templated
-pub struct GValue {
+pub struct Value {
     pointer: *mut ffi::C_GValue
 }
 
-impl GValue {
-    pub fn new() -> Option<GValue> {
+impl Value {
+    pub fn new() -> Option<Value> {
         let tmp_pointer = unsafe { ffi::create_gvalue() };
 
         if tmp_pointer.is_null() {
             None
         } else {
-            Some(GValue {
+            Some(Value {
                 pointer: tmp_pointer
             })
         }
@@ -183,8 +183,8 @@ impl GValue {
         }
     }
 
-    /// Set the contents of a G_TYPE_STRING GValue to v_string . The string is assumed to be static, and is thus not duplicated
-    /// when setting the GValue.
+    /// Set the contents of a G_TYPE_STRING Value to v_string . The string is assumed to be static, and is thus not duplicated
+    /// when setting the Value.
     pub fn set_static_string(&self, v_string: &str) {
         unsafe {
             let c_str = CString::from_slice(v_string.as_bytes());
@@ -229,8 +229,8 @@ impl GValue {
         unsafe { ffi::g_value_set_boxed(self.pointer, ::std::mem::transmute(v_box)) }
     }
 
-    /// Set the contents of a G_TYPE_BOXED derived GValue to v_boxed . The boxed value is assumed to be static, and is thus not duplicated
-    /// when setting the GValue.
+    /// Set the contents of a G_TYPE_BOXED derived Value to v_boxed . The boxed value is assumed to be static, and is thus not duplicated
+    /// when setting the Value.
     pub fn set_static_boxed<T>(&self, v_box: &T) {
         unsafe { ffi::g_value_set_static_boxed(self.pointer, ::std::mem::transmute(v_box)) }
     }
@@ -259,7 +259,7 @@ impl GValue {
         unsafe { ffi::g_value_set_object(self.pointer, ::std::mem::transmute(v_object)) }
     }
 
-    /// Sets the contents of a G_TYPE_OBJECT derived GValue to v_object and takes over the ownership of the callers reference to
+    /// Sets the contents of a G_TYPE_OBJECT derived Value to v_object and takes over the ownership of the callers reference to
     /// v_object ; the caller doesn't have to unref it any more (i.e. the reference count of the object is not increased).
     pub fn take_object<T>(&self, v_object: &T) {
         unsafe { ffi::g_value_take_object(self.pointer, ::std::mem::transmute(v_object)) }
@@ -283,12 +283,12 @@ impl GValue {
         unsafe { from_glib(ffi::g_value_get_gtype(self.pointer)) }
     }
 
-    pub fn set<T: GValuePublic>(&self, val: &T) {
+    pub fn set<T: ValuePublic>(&self, val: &T) {
         val.set(self);
     }
 
-    pub fn get<T: GValuePublic>(&self) -> T {
-        GValuePublic::get(self)
+    pub fn get<T: ValuePublic>(&self) -> T {
+        ValuePublic::get(self)
     }
 
     pub fn compatible(src_type: Type, dest_type: Type) -> bool {
@@ -305,14 +305,14 @@ impl GValue {
     }
 
     #[doc(hidden)]
-    pub fn wrap_pointer(c_value: *mut ffi::C_GValue) -> GValue {
-        GValue {
+    pub fn wrap_pointer(c_value: *mut ffi::C_GValue) -> Value {
+        Value {
             pointer: c_value
         }
     }
 }
 
-impl Drop for GValue {
+impl Drop for Value {
     fn drop(&mut self) {
         if !self.pointer.is_null() {
             unsafe { ::libc::funcs::c95::stdlib::free(self.pointer as *mut ::libc::types::common::c95::c_void) };
@@ -321,115 +321,115 @@ impl Drop for GValue {
     }
 }
 
-impl GValuePublic for i32 {
-    fn get(gvalue: &GValue) -> i32 {
+impl ValuePublic for i32 {
+    fn get(gvalue: &Value) -> i32 {
         gvalue.get_int()
     }
 
-    fn set(&self, gvalue: &GValue) {
+    fn set(&self, gvalue: &Value) {
         gvalue.set_int(*self)
     }
 }
 
-impl GValuePublic for u32 {
-    fn get(gvalue: &GValue) -> u32 {
+impl ValuePublic for u32 {
+    fn get(gvalue: &Value) -> u32 {
         gvalue.get_uint()
     }
 
-    fn set(&self, gvalue: &GValue) {
+    fn set(&self, gvalue: &Value) {
         gvalue.set_uint(*self)
     }
 }
 
-impl GValuePublic for i64 {
-    fn get(gvalue: &GValue) -> i64 {
+impl ValuePublic for i64 {
+    fn get(gvalue: &Value) -> i64 {
         gvalue.get_int64()
     }
 
-    fn set(&self, gvalue: &GValue) {
+    fn set(&self, gvalue: &Value) {
         gvalue.set_int64(*self)
     }
 }
 
-impl GValuePublic for u64 {
-    fn get(gvalue: &GValue) -> u64 {
+impl ValuePublic for u64 {
+    fn get(gvalue: &Value) -> u64 {
         gvalue.get_uint64()
     }
 
-    fn set(&self, gvalue: &GValue) {
+    fn set(&self, gvalue: &Value) {
         gvalue.set_uint64(*self)
     }
 }
 
-impl GValuePublic for bool {
-    fn get(gvalue: &GValue) -> bool {
+impl ValuePublic for bool {
+    fn get(gvalue: &Value) -> bool {
         gvalue.get_boolean()
     }
 
-    fn set(&self, gvalue: &GValue) {
+    fn set(&self, gvalue: &Value) {
         gvalue.set_boolean(*self)
     }
 }
 
-impl GValuePublic for i8 {
-    fn get(gvalue: &GValue) -> i8 {
+impl ValuePublic for i8 {
+    fn get(gvalue: &Value) -> i8 {
         gvalue.get_schar()
     }
 
-    fn set(&self, gvalue: &GValue) {
+    fn set(&self, gvalue: &Value) {
         gvalue.set_schar(*self)
     }
 }
 
-impl GValuePublic for u8 {
-    fn get(gvalue: &GValue) -> u8 {
+impl ValuePublic for u8 {
+    fn get(gvalue: &Value) -> u8 {
         gvalue.get_uchar()
     }
 
-    fn set(&self, gvalue: &GValue) {
+    fn set(&self, gvalue: &Value) {
         gvalue.set_uchar(*self)
     }
 }
 
-impl GValuePublic for f32 {
-    fn get(gvalue: &GValue) -> f32 {
+impl ValuePublic for f32 {
+    fn get(gvalue: &Value) -> f32 {
         gvalue.get_float()
     }
 
-    fn set(&self, gvalue: &GValue) {
+    fn set(&self, gvalue: &Value) {
         gvalue.set_float(*self)
     }
 }
 
-impl GValuePublic for f64 {
-    fn get(gvalue: &GValue) -> f64 {
+impl ValuePublic for f64 {
+    fn get(gvalue: &Value) -> f64 {
         gvalue.get_double()
     }
 
-    fn set(&self, gvalue: &GValue) {
+    fn set(&self, gvalue: &Value) {
         gvalue.set_double(*self)
     }
 }
 
-impl GValuePublic for Type {
-    fn get(gvalue: &GValue) -> Type {
+impl ValuePublic for Type {
+    fn get(gvalue: &Value) -> Type {
         gvalue.get_gtype()
     }
 
-    fn set(&self, gvalue: &GValue) {
+    fn set(&self, gvalue: &Value) {
         gvalue.set_gtype(*self)
     }
 }
 
-impl GValuePublic for String {
-    fn get(gvalue: &GValue) -> String {
+impl ValuePublic for String {
+    fn get(gvalue: &Value) -> String {
         match gvalue.get_string() {
             Some(s) => s,
             None => String::new()
         }
     }
 
-    fn set(&self, gvalue: &GValue) {
+    fn set(&self, gvalue: &Value) {
         gvalue.set_string(self.as_slice())
     }
 }

--- a/gtk3-sys/src/lib.rs
+++ b/gtk3-sys/src/lib.rs
@@ -23,11 +23,11 @@ extern crate "gdk3-sys" as gdk_ffi;
 
 pub mod enums;
 
-use libc::{c_int, c_char, c_uchar, c_float, c_uint, c_double, c_long, c_short, c_void, c_ulong, time_t};
+use libc::{c_int, c_char, c_float, c_uint, c_double, c_long, c_short, c_void, c_ulong, time_t};
 
 pub use glib_ffi::{
     Gboolean, GFALSE, GTRUE, gpointer, GType, C_GObject, C_GPermission,
-    C_GList, C_GSList, C_GError};
+    C_GList, C_GSList, C_GError, C_GValue};
 
 //pub type C_GtkAllocation = C_GdkRectangle;
 
@@ -242,9 +242,6 @@ pub struct C_GtkFontChooserDialog;
 #[derive(Copy)]
 pub struct C_GtkBuildable;
 //pub struct C_GtkPageSetupUnixDialog;
-#[repr(C)]
-#[derive(Copy)]
-pub struct C_GValue;
 #[repr(C)]
 #[derive(Copy)]
 pub struct C_GtkPrintSettings;
@@ -551,59 +548,7 @@ extern "C" {
     // pub fn gtk_window_get_type() -> ();
 
     //=========================================================================
-    // GValue                                                            NOT OK
-    //=========================================================================
-    pub fn create_gvalue                       () -> *mut C_GValue;
-    pub fn get_gtype                           (_type: GType) -> GType;
-    pub fn g_value_init                        (value: *mut C_GValue, _type: GType);
-    pub fn g_value_reset                       (value: *mut C_GValue);
-    pub fn g_value_unset                       (value: *mut C_GValue);
-    pub fn g_strdup_value_contents             (value: *mut C_GValue) -> *mut c_char;
-    pub fn g_value_set_boolean                 (value: *mut C_GValue, b: Gboolean);
-    pub fn g_value_get_boolean                 (value: *mut C_GValue) -> Gboolean;
-    pub fn g_value_set_schar                   (value: *mut C_GValue, b: c_char);
-    pub fn g_value_get_schar                   (value: *mut C_GValue) -> c_char;
-    pub fn g_value_set_uchar                   (value: *mut C_GValue, b: c_uchar);
-    pub fn g_value_get_uchar                   (value: *mut C_GValue) -> c_uchar;
-    pub fn g_value_set_int                     (value: *mut C_GValue, b: c_int);
-    pub fn g_value_get_int                     (value: *mut C_GValue) -> c_int;
-    pub fn g_value_set_uint                    (value: *mut C_GValue, b: c_uint);
-    pub fn g_value_get_uint                    (value: *mut C_GValue) -> c_uint;
-    pub fn g_value_set_long                    (value: *mut C_GValue, b: c_long);
-    pub fn g_value_get_long                    (value: *mut C_GValue) -> c_long;
-    pub fn g_value_set_ulong                   (value: *mut C_GValue, b: c_ulong);
-    pub fn g_value_get_ulong                   (value: *mut C_GValue) -> c_ulong;
-    pub fn g_value_set_int64                   (value: *mut C_GValue, b: i64);
-    pub fn g_value_get_int64                   (value: *mut C_GValue) -> i64;
-    pub fn g_value_set_uint64                  (value: *mut C_GValue, b: u64);
-    pub fn g_value_get_uint64                  (value: *mut C_GValue) -> u64;
-    pub fn g_value_set_float                   (value: *mut C_GValue, b: c_float);
-    pub fn g_value_get_float                   (value: *mut C_GValue) -> c_float;
-    pub fn g_value_set_double                  (value: *mut C_GValue, b: c_double);
-    pub fn g_value_get_double                  (value: *mut C_GValue) -> c_double;
-    pub fn g_value_set_enum                    (value: *mut C_GValue, b: GType);
-    pub fn g_value_get_enum                    (value: *mut C_GValue) -> GType;
-    pub fn g_value_set_flags                   (value: *mut C_GValue, b: GType);
-    pub fn g_value_get_flags                   (value: *mut C_GValue) -> GType;
-    pub fn g_value_set_string                  (value: *mut C_GValue, b: *const c_char);
-    pub fn g_value_set_static_string           (value: *mut C_GValue, b: *const c_char);
-    pub fn g_value_get_string                  (value: *mut C_GValue) -> *const c_char;
-    pub fn g_value_dup_string                  (value: *mut C_GValue) -> *mut c_char;
-    pub fn g_value_set_boxed                   (value: *mut C_GValue, b: *const c_void);
-    pub fn g_value_set_static_boxed            (value: *mut C_GValue, b: *const c_void);
-    pub fn g_value_get_boxed                   (value: *mut C_GValue) -> *const c_void;
-    pub fn g_value_set_pointer                 (value: *mut C_GValue, b: *const c_void);
-    pub fn g_value_get_pointer                 (value: *mut C_GValue) -> *const c_void;
-    pub fn g_value_set_object                  (value: *mut C_GValue, b: *const c_void);
-    pub fn g_value_take_object                 (value: *mut C_GValue, b: *const c_void);
-    pub fn g_value_get_object                  (value: *mut C_GValue) -> *const c_void;
-    pub fn g_value_set_gtype                   (value: *mut C_GValue, b: GType);
-    pub fn g_value_get_gtype                   (value: *mut C_GValue) -> GType;
-    pub fn g_value_type_compatible             (src_type: GType, dest_type: GType) -> Gboolean;
-    pub fn g_value_type_transformable          (src_type: GType, dest_type: GType) -> Gboolean;
-
-    //=========================================================================
-    // GType                                                             NOT OK
+    // GType
     //=========================================================================
     pub fn g_type_name                         (_type: GType) -> *const c_char;
     pub fn g_type_from_name                    (name: *const c_char) -> GType;

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -161,7 +161,6 @@ pub use self::widgets::{
     TreeSelection,
     RecentChooserWidget,
     ComboBox,
-    GValue,
     //g_type,
     ComboBoxText,
     TextMark,

--- a/src/gtk/widgets/list_store.rs
+++ b/src/gtk/widgets/list_store.rs
@@ -13,25 +13,27 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use glib::ffi::GType;
+use glib::{to_bool, GValue, Type};
+use glib::translate::ToGlib;
 use gtk::{self, ffi};
 use gtk::TreeIter;
 use std::ffi::CString;
 use std::num::ToPrimitive;
-use glib::to_bool;
 
 pub struct ListStore {
     pointer: *mut ffi::C_GtkListStore
 }
 
 impl ListStore {
-    pub fn new(column_types: &[GType]) -> Option<ListStore> {
-        let tmp_pointer = unsafe { ffi::gtk_list_store_newv(column_types.len().to_i32().unwrap(), column_types) };
+    pub fn new(column_types: &[Type]) -> Option<ListStore> {
+        let column_types_ffi: Vec<::glib_ffi::GType> = column_types.iter().map(|n| n.to_glib()).collect();
+        let tmp_pointer = unsafe { ffi::gtk_list_store_newv(column_types.len().to_i32().unwrap(), column_types_ffi.as_slice()) };
         check_pointer!(tmp_pointer, ListStore, G_OBJECT_FROM_LIST_STORE)
     }
 
-    pub fn set_column_types(&self, column_types: &[GType]) {
-        unsafe { ffi::gtk_list_store_set_column_types(self.pointer, column_types.len().to_i32().unwrap(), column_types) }
+    pub fn set_column_types(&self, column_types: &[Type]) {
+        let column_types_ffi: Vec<::glib_ffi::GType> = column_types.iter().map(|n| n.to_glib()).collect();
+        unsafe { ffi::gtk_list_store_set_column_types(self.pointer, column_types.len().to_i32().unwrap(), column_types_ffi.as_slice()) }
     }
 
     pub fn set_string(&self, iter: &TreeIter, column: i32, text: &str) {
@@ -102,7 +104,7 @@ impl ListStore {
         }
     }
 
-    pub fn set_value(&self, iter: &TreeIter, column: i32, value: &gtk::GValue) {
+    pub fn set_value(&self, iter: &TreeIter, column: i32, value: &GValue) {
         unsafe { ffi::gtk_list_store_set_value(self.pointer, iter.unwrap_pointer(), column, value.unwrap_pointer()) }
     }
 

--- a/src/gtk/widgets/list_store.rs
+++ b/src/gtk/widgets/list_store.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use glib::{to_bool, GValue, Type};
+use glib::{to_bool, Value, Type};
 use glib::translate::ToGlib;
 use gtk::{self, ffi};
 use gtk::TreeIter;
@@ -104,7 +104,7 @@ impl ListStore {
         }
     }
 
-    pub fn set_value(&self, iter: &TreeIter, column: i32, value: &GValue) {
+    pub fn set_value(&self, iter: &TreeIter, column: i32, value: &Value) {
         unsafe { ffi::gtk_list_store_set_value(self.pointer, iter.unwrap_pointer(), column, value.unwrap_pointer()) }
     }
 

--- a/src/gtk/widgets/mod.rs
+++ b/src/gtk/widgets/mod.rs
@@ -127,7 +127,6 @@ pub use self::combo_box::ComboBox;
 #[cfg(any(feature = "GTK_3_12", feature = "GTK_3_14"))]
 pub use self::popover::Popover;
 pub use self::combo_box_text::ComboBoxText;
-pub use self::value::{GValue, GValuePublic};
 //pub use self::gtype::g_type;
 pub use self::text_mark::TextMark;
 pub use self::text_tag::TextTag;
@@ -261,7 +260,6 @@ mod combo_box;
 #[cfg(any(feature = "GTK_3_12", feature = "GTK_3_14"))]
 mod popover;
 mod combo_box_text;
-mod value;
 //mod gtype;
 mod text_mark;
 mod text_tag;

--- a/src/gtk/widgets/tree_model.rs
+++ b/src/gtk/widgets/tree_model.rs
@@ -13,10 +13,11 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use glib::ffi::GType;
-use gtk::{self, ffi, GValue, TreeIter, TreePath};
-use std::ffi::CString;
+use glib::{GValue, Type};
+use glib::translate::from_glib;
+use gtk::{self, ffi, TreeIter, TreePath};
 use libc::{self, c_char};
+use std::ffi::CString;
 
 pub struct TreeModel {
     pointer: *mut ffi::C_GtkTreeModel
@@ -31,8 +32,8 @@ impl TreeModel {
         unsafe { ffi::gtk_tree_model_get_n_columns(self.pointer) }
     }
 
-    pub fn get_column_type(&self, index_: i32) -> GType {
-        unsafe { ffi::gtk_tree_model_get_column_type(self.pointer, index_) }
+    pub fn get_column_type(&self, index_: i32) -> Type {
+        unsafe { from_glib(ffi::gtk_tree_model_get_column_type(self.pointer, index_)) }
     }
 
     pub fn get_iter(&self, iter: &mut TreeIter, path: &TreePath) -> bool {

--- a/src/gtk/widgets/tree_model.rs
+++ b/src/gtk/widgets/tree_model.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use glib::{GValue, Type};
+use glib::{Value, Type};
 use glib::translate::from_glib;
 use gtk::{self, ffi, TreeIter, TreePath};
 use libc::{self, c_char};
@@ -69,8 +69,8 @@ impl TreeModel {
         }
     }
 
-    pub fn get_value(&self, iter: &TreeIter, column: i32) -> GValue {
-        let value = GValue::new().unwrap();
+    pub fn get_value(&self, iter: &TreeIter, column: i32) -> Value {
+        let value = Value::new().unwrap();
 
         unsafe { ffi::gtk_tree_model_get_value(self.pointer, iter.unwrap_pointer(), column, value.unwrap_pointer()) };
         value

--- a/src/gtk/widgets/tree_store.rs
+++ b/src/gtk/widgets/tree_store.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use glib::{to_bool, GValue, Type};
+use glib::{to_bool, Value, Type};
 use glib::translate::ToGlib;
 use gtk::{self, ffi};
 use gtk::TreeIter;
@@ -119,7 +119,7 @@ impl TreeStore {
         }
     }
 
-    pub fn set_value(&self, iter: &TreeIter, column: i32, value: &GValue) {
+    pub fn set_value(&self, iter: &TreeIter, column: i32, value: &Value) {
         unsafe { ffi::gtk_tree_store_set_value(self.pointer, iter.unwrap_pointer(), column, value.unwrap_pointer()) }
     }
 

--- a/src/gtk/widgets/tree_store.rs
+++ b/src/gtk/widgets/tree_store.rs
@@ -13,25 +13,27 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
+use glib::{to_bool, GValue, Type};
+use glib::translate::ToGlib;
 use gtk::{self, ffi};
-use glib::ffi::GType;
 use gtk::TreeIter;
 use std::ffi::CString;
 use std::num::ToPrimitive;
-use glib::to_bool;
 
 pub struct TreeStore {
     pointer: *mut ffi::C_GtkTreeStore
 }
 
 impl TreeStore {
-    pub fn new(column_types: &[GType]) -> Option<TreeStore> {
-        let tmp_pointer = unsafe { ffi::gtk_tree_store_newv(column_types.len().to_i32().unwrap(), column_types) };
+    pub fn new(column_types: &[Type]) -> Option<TreeStore> {
+        let column_types_ffi: Vec<::glib_ffi::GType> = column_types.iter().map(|n| n.to_glib()).collect();
+        let tmp_pointer = unsafe { ffi::gtk_tree_store_newv(column_types.len().to_i32().unwrap(), column_types_ffi.as_slice()) };
         check_pointer!(tmp_pointer, TreeStore, G_OBJECT_FROM_TREE_STORE)
     }
 
-    pub fn set_column_types(&self, column_types: &[GType]) {
-        unsafe { ffi::gtk_tree_store_set_column_types(self.pointer, column_types.len().to_i32().unwrap(), column_types) }
+    pub fn set_column_types(&self, column_types: &[Type]) {
+        let column_types_ffi: Vec<::glib_ffi::GType> = column_types.iter().map(|n| n.to_glib()).collect();
+        unsafe { ffi::gtk_tree_store_set_column_types(self.pointer, column_types.len().to_i32().unwrap(), column_types_ffi.as_slice()) }
     }
 
     pub fn set_string(&self, iter: &TreeIter, column: i32, text: &str) {
@@ -117,7 +119,7 @@ impl TreeStore {
         }
     }
 
-    pub fn set_value(&self, iter: &TreeIter, column: i32, value: &gtk::GValue) {
+    pub fn set_value(&self, iter: &TreeIter, column: i32, value: &GValue) {
         unsafe { ffi::gtk_tree_store_set_value(self.pointer, iter.unwrap_pointer(), column, value.unwrap_pointer()) }
     }
 

--- a/src/rgtk.rs
+++ b/src/rgtk.rs
@@ -60,7 +60,7 @@ extern crate "cairo-sys" as cairo_ffi;
 extern crate "glib" as glib_main;
 
 pub use glib_main as glib;
-pub use glib_main::GValuePublic;
+pub use glib_main::ValuePublic;
 pub use glib_main::traits::Connect;
 
 pub use gtk::BoxTrait as GtkBoxTrait;

--- a/src/rgtk.rs
+++ b/src/rgtk.rs
@@ -57,11 +57,11 @@ extern crate "glib-sys" as glib_ffi;
 extern crate "gdk3-sys" as gdk_ffi;
 extern crate "gtk3-sys" as gtk_ffi;
 extern crate "cairo-sys" as cairo_ffi;
+extern crate "glib" as glib_main;
 
-extern crate glib;
-
-pub use glib::traits::Connect;
-pub use gtk::widgets::GValuePublic;
+pub use glib_main as glib;
+pub use glib_main::GValuePublic;
+pub use glib_main::traits::Connect;
 
 pub use gtk::BoxTrait as GtkBoxTrait;
 pub use gtk::ActionableTrait as GtkActionableTrait;
@@ -104,10 +104,4 @@ pub use gtk::WindowTrait as GtkWindowTrait;
 pub mod gtk;
 pub mod cairo;
 pub mod gdk;
-
-pub mod ffi {
-    pub mod glib {
-        pub use glib_ffi::*;
-    }
-}
 pub mod pango;


### PR DESCRIPTION
This makes `ListStore`, `TreeStore`, and `GValue` use the new `Type` enum introduced in #225, so we no longer need the `ffi::glib` backdoor. It also moves `GValue` into the glib crate.