### PR TITLE
Use glib::translate to handle arrays and lists of strings

### DIFF
--- a/examples/src/gtktest.rs
+++ b/examples/src/gtktest.rs
@@ -102,11 +102,25 @@ fn main() {
     window.add(&frame);
 
     Connect::connect(&button, Clicked::new(&mut ||{
-        //entry.set_text("Clicked!".to_string());
-        let dialog = gtk::MessageDialog::new_with_markup(None, gtk::DialogFlags::Modal, gtk::MessageType::Info,
-            gtk::ButtonsType::OkCancel, "This is a trap !").unwrap();
+        entry.set_text("Clicked!".to_string());
+
+        let dialog = gtk::AboutDialog::new().unwrap();
+
+        let crew = [
+            "James T. Kirk",
+            "Spock",
+            "Leonard McCoy",
+        ];
+
+        dialog.set_authors(&crew);
+        dialog.set_artists(&crew[1..]);
+
+        println!("Authors: {:?}", dialog.get_authors());
+        println!("Artists: {:?}", dialog.get_artists());
+        println!("Documenters: {:?}", dialog.get_documenters());
 
         dialog.run();
+        dialog.destroy();
     }));
     Connect::connect(&button_font, Clicked::new(&mut ||{
         let dialog = gtk::FontChooserDialog::new("Font chooser test", None).unwrap();
@@ -120,9 +134,17 @@ fn main() {
     }));
     Connect::connect(&file_button, Clicked::new(&mut ||{
         //entry.set_text("Clicked!".to_string());
-        let dialog2 = gtk::FileChooserDialog::new("Choose a file", None, gtk::FileChooserAction::Open).unwrap();
+        let dialog = gtk::FileChooserDialog::new("Choose a file", None, gtk::FileChooserAction::Open).unwrap();
 
-        dialog2.run();
+        dialog.set_select_multiple(true);
+
+        dialog.run();
+
+        let files = dialog.get_filenames();
+
+        dialog.destroy();
+
+        println!("Files: {:?}", files);
     }));
     Connect::connect(&app_button, Clicked::new(&mut ||{
         //entry.set_text("Clicked!".to_string());

--- a/src/gdk/widgets/window.rs
+++ b/src/gdk/widgets/window.rs
@@ -63,10 +63,10 @@ impl WindowAttr {
     }
 }
 
-impl <'a> ToTmp for &'a WindowAttr {
+impl ToTmp for WindowAttr {
     type Tmp = StackBox<ffi::C_GdkWindowAttr, Option<CString>>;
 
-    fn to_tmp_for_borrow(self) -> StackBox<ffi::C_GdkWindowAttr, Option<CString>> {
+    fn to_tmp_for_borrow(&self) -> StackBox<ffi::C_GdkWindowAttr, Option<CString>> {
         let mut tmp_title = self.title.to_tmp_for_borrow();
 
         let attrs = ffi::C_GdkWindowAttr {

--- a/src/gtk/traits/file_chooser.rs
+++ b/src/gtk/traits/file_chooser.rs
@@ -13,13 +13,12 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, FromGlibPtrContainer, ToGlibPtr, ToTmp};
 use gtk::{self, FFIWidget};
 use gtk::cast::GTK_FILE_CHOOSER;
 use gtk::ffi;
 use glib::{to_bool, to_gboolean};
 use glib::{self, GlibContainer};
-use libc::c_char;
 
 pub trait FileChooserTrait: gtk::WidgetTrait {
     fn set_action(&self, action: gtk::FileChooserAction) -> () {
@@ -120,21 +119,10 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
         unsafe { ffi::gtk_file_chooser_unselect_all(GTK_FILE_CHOOSER(self.unwrap_widget())) }
     }
 
-    fn get_filenames(&self) -> glib::SList<String> {
-        let tmp_pointer = unsafe { ffi::gtk_file_chooser_get_filenames(GTK_FILE_CHOOSER(self.unwrap_widget())) };
-
-        if tmp_pointer.is_null() {
-            glib::SList::new()
-        } else {
-            let old_list : glib::SList<*const c_char> = glib::GlibContainer::wrap(tmp_pointer);
-            let mut tmp_vec = glib::SList::new();
-
-            for it in old_list.iter() {
-                unsafe {
-                    tmp_vec.append(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(it)).to_string())
-                }
-            }
-            tmp_vec
+    fn get_filenames(&self) -> Vec<String> {
+        unsafe {
+            FromGlibPtrContainer::take(
+                ffi::gtk_file_chooser_get_filenames(GTK_FILE_CHOOSER(self.unwrap_widget())))
         }
     }
 
@@ -180,21 +168,10 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
         }
     }
 
-    fn get_uris(&self) -> glib::SList<String> {
-        let tmp_pointer = unsafe { ffi::gtk_file_chooser_get_uris(GTK_FILE_CHOOSER(self.unwrap_widget())) };
-
-        if tmp_pointer.is_null() {
-            glib::SList::new()
-        } else {
-            let old_list : glib::SList<*const c_char> = glib::GlibContainer::wrap(tmp_pointer);
-            let mut tmp_vec = glib::SList::new();
-
-            for it in old_list.iter() {
-                unsafe {
-                    tmp_vec.append(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(it)).to_string())
-                }
-            }
-            tmp_vec
+    fn get_uris(&self) -> Vec<String> {
+        unsafe {
+            FromGlibPtrContainer::take(
+                ffi::gtk_file_chooser_get_uris(GTK_FILE_CHOOSER(self.unwrap_widget())))
         }
     }
 

--- a/src/gtk/traits/recent_chooser.rs
+++ b/src/gtk/traits/recent_chooser.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, FromGlibPtrContainer, ToGlibPtr, ToTmp};
 use gtk::cast::{GTK_RECENT_CHOOSER};
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
@@ -135,23 +135,13 @@ pub trait RecentChooserTrait: gtk::WidgetTrait + FFIWidget {
         }
     }
 
-    fn get_uris(&self) -> Option<Vec<String>> {
-        let mut length = 0;
-        let tmp = unsafe { ffi::gtk_recent_chooser_get_uris(GTK_RECENT_CHOOSER(self.unwrap_widget()), &mut length) };
-
-        if tmp.is_null() {
-            None
-        } else {
-            unsafe {
-                let mut ret = Vec::with_capacity(length as usize);
-
-                for count in range(0, length) {
-                    let t = tmp.offset(count as isize) as *const c_char;
-
-                    ret.push(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&t)).to_string());
-                }
-                Some(ret)
-            }
+    fn get_uris(&self) -> Vec<String> {
+        unsafe {
+            let mut length = 0;
+            let ptr = ffi::gtk_recent_chooser_get_uris(
+                GTK_RECENT_CHOOSER(self.unwrap_widget()),
+                &mut length) as *const *const c_char;
+            FromGlibPtrContainer::borrow_num(ptr, length as usize)
         }
     }
 

--- a/src/gtk/widgets/about_dialog.rs
+++ b/src/gtk/widgets/about_dialog.rs
@@ -13,12 +13,12 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::iter::IntoIterator;
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
 use gtk::FFIWidget;
 use gtk::cast::GTK_ABOUT_DIALOG;
-use std::ffi::CString;
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, FromGlibPtrContainer, ToGlibPtr, ToTmp, ToArray};
 
 struct_Widget!(AboutDialog);
 
@@ -148,105 +148,54 @@ impl AboutDialog {
     }
 
     pub fn get_authors(&self) -> Vec<String> {
-        let authors = unsafe { ffi::gtk_about_dialog_get_authors(GTK_ABOUT_DIALOG(self.unwrap_widget())) };
-        let mut ret = Vec::new();
-
-        if !authors.is_null() {
-            let mut it = 0;
-
-            unsafe {
-                loop {
-                    let tmp = authors.offset(it);
-
-                    if tmp.is_null() {
-                        break;
-                    }
-                    ret.push(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&*tmp)).to_string());
-                    it += 1;
-                }
-            }
+        unsafe {
+            FromGlibPtrContainer::borrow(
+                ffi::gtk_about_dialog_get_authors(GTK_ABOUT_DIALOG(self.unwrap_widget())))
         }
-        ret
     }
 
-    pub fn set_authors(&self, authors: &Vec<String>) -> () {
-        let mut tmp_vec = Vec::new();
-
-        for tmp in authors.iter() {
-            let c_str = CString::from_slice(tmp.as_bytes());
-
-            tmp_vec.push(c_str.as_ptr());
+    pub fn set_authors<S, I>(&self, authors: I)
+    where S: Str, I: IntoIterator<Item = S> {
+        unsafe {
+            let mut tmp_authors = authors.to_array_for_borrow();
+            ffi::gtk_about_dialog_set_authors(
+                GTK_ABOUT_DIALOG(self.unwrap_widget()),
+                tmp_authors.to_glib_ptr());
         }
-        tmp_vec.push(::std::ptr::null_mut());
-        unsafe { ffi::gtk_about_dialog_set_authors(GTK_ABOUT_DIALOG(self.unwrap_widget()), tmp_vec.as_slice().as_ptr()) }
     }
 
     pub fn get_artists(&self) -> Vec<String> {
-        let artists = unsafe { ffi::gtk_about_dialog_get_artists(GTK_ABOUT_DIALOG(self.unwrap_widget())) };
-        let mut ret = Vec::new();
-
-        if !artists.is_null() {
-            let mut it = 0;
-
-            unsafe {
-                loop {
-                    let tmp = artists.offset(it);
-
-                    if tmp.is_null() {
-                        break;
-                    }
-                    ret.push(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&*tmp)).to_string());
-                    it += 1;
-                }
-            }
+        unsafe {
+            FromGlibPtrContainer::borrow(
+                ffi::gtk_about_dialog_get_artists(GTK_ABOUT_DIALOG(self.unwrap_widget())))
         }
-        ret
     }
 
-    pub fn set_artists(&self, artists: &Vec<String>) -> () {
-        let mut tmp_vec = Vec::new();
-
-        for tmp in artists.iter() {
-            let c_str = CString::from_slice(tmp.as_bytes());
-
-            tmp_vec.push(c_str.as_ptr());
+    pub fn set_artists<S, I>(&self, artists: I)
+    where S: Str, I: IntoIterator<Item = S> {
+        unsafe {
+            let mut tmp_artists = artists.to_array_for_borrow();
+            ffi::gtk_about_dialog_set_artists(
+                GTK_ABOUT_DIALOG(self.unwrap_widget()),
+                tmp_artists.to_glib_ptr());
         }
-        tmp_vec.push(::std::ptr::null_mut());
-        unsafe { ffi::gtk_about_dialog_set_artists(GTK_ABOUT_DIALOG(self.unwrap_widget()), tmp_vec.as_slice().as_ptr()) }
     }
 
     pub fn get_documenters(&self) -> Vec<String> {
-        let documenters = unsafe { ffi::gtk_about_dialog_get_documenters(GTK_ABOUT_DIALOG(self.unwrap_widget())) };
-        let mut ret = Vec::new();
-
-        if !documenters.is_null() {
-            let mut it = 0;
-
-            unsafe {
-                loop {
-                    let tmp = documenters.offset(it);
-
-                    if tmp.is_null() {
-                        break;
-                    }
-                    ret.push(String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&*tmp)).to_string());
-                    it += 1;
-                }
-            }
+        unsafe {
+            FromGlibPtrContainer::borrow(
+                ffi::gtk_about_dialog_get_documenters(GTK_ABOUT_DIALOG(self.unwrap_widget())))
         }
-        ret
     }
 
-    pub fn set_documenters(&self, documenters: &Vec<String>) -> () {
-        let mut tmp_vec = Vec::new();
-
-        for tmp in documenters.iter() {
-            let c_str = CString::from_slice(tmp.as_bytes());
-            
-            tmp_vec.push(c_str.as_ptr());
+    pub fn set_documenters<S, I>(&self, documenters: I)
+    where S: Str, I: IntoIterator<Item = S> {
+        unsafe {
+            let mut tmp_documenters = documenters.to_array_for_borrow();
+            ffi::gtk_about_dialog_set_documenters(
+                GTK_ABOUT_DIALOG(self.unwrap_widget()),
+                tmp_documenters.to_glib_ptr());
         }
-        tmp_vec.push(::std::ptr::null_mut());
-        unsafe { ffi::gtk_about_dialog_set_documenters(GTK_ABOUT_DIALOG(self.unwrap_widget()), tmp_vec.as_slice().as_ptr()) }
     }
 
     pub fn get_translator_credits(&self) -> Option<String> {
@@ -295,21 +244,16 @@ impl AboutDialog {
         };
     }
 
-    pub fn add_credit_section(&self, section_name: &str, people: &Vec<String>) -> () {
-        let mut tmp_vec = Vec::new();
-
-        for tmp in people.iter() {
-            let c_str = CString::from_slice(tmp.as_bytes());
-
-            tmp_vec.push(c_str.as_ptr());
-        }
-        tmp_vec.push(::std::ptr::null_mut());
+    pub fn add_credit_section<S, I>(&self, section_name: &str, people: I)
+    where S: Str, I: IntoIterator<Item = S> {
         unsafe {
             let mut tmp_section_name = section_name.to_tmp_for_borrow();
+            let mut tmp_people = people.to_array_for_borrow();
+
             ffi::gtk_about_dialog_add_credit_section(
                 GTK_ABOUT_DIALOG(self.unwrap_widget()),
                 tmp_section_name.to_glib_ptr(),
-                tmp_vec.as_slice().as_ptr())
+                tmp_people.to_glib_ptr())
         }
     }
 

--- a/src/gtk/widgets/recent_info.rs
+++ b/src/gtk/widgets/recent_info.rs
@@ -18,7 +18,7 @@ use glib::to_bool;
 use gtk::FFIWidget;
 use gtk::cast::GTK_RECENT_INFO;
 use std::ptr;
-use glib::translate::{FromGlibPtr, FromGlibPtrNotNull, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, FromGlibPtrNotNull, FromGlibPtrContainer, ToGlibPtr, ToTmp};
 use libc::c_char;
 
 struct_Widget!(RecentInfo);
@@ -107,19 +107,13 @@ impl RecentInfo {
         }
     }
 
-    pub fn get_applications(&self) -> Option<Vec<String>> {
-        let mut length = 0;
-        let tmp = unsafe { ffi::gtk_recent_info_get_applications(GTK_RECENT_INFO(self.unwrap_widget()), &mut length) };
-
-        if tmp.is_null() {
-            None
-        } else {
-            let mut ret = Vec::with_capacity(length as usize);
-
-            for count in range(0, length) {
-                ret.push(unsafe { String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&(*tmp.offset(count as isize) as *const c_char))).to_string() });
-            }
-            Some(ret)
+    pub fn get_applications(&self) -> Vec<String> {
+        unsafe {
+            let mut length = 0;
+            let ptr = ffi::gtk_recent_info_get_applications(
+                GTK_RECENT_INFO(self.unwrap_widget()),
+                &mut length) as *const *const c_char;
+            FromGlibPtrContainer::take_num(ptr, length as usize)
         }
     }
 
@@ -137,19 +131,13 @@ impl RecentInfo {
         }
     }
 
-    pub fn get_groups(&self) -> Option<Vec<String>> {
-        let mut length = 0;
-        let tmp = unsafe { ffi::gtk_recent_info_get_groups(GTK_RECENT_INFO(self.unwrap_widget()), &mut length) };
-
-        if tmp.is_null() {
-            None
-        } else {
-            let mut ret = Vec::with_capacity(length as usize);
-
-            for count in range(0, length) {
-                ret.push(unsafe { String::from_utf8_lossy(::std::ffi::c_str_to_bytes(&(*tmp.offset(count as isize) as *const c_char))).to_string() });
-            }
-            Some(ret)
+    pub fn get_groups(&self) -> Vec<String> {
+        unsafe {
+            let mut length = 0;
+            let ptr = ffi::gtk_recent_info_get_groups(
+                GTK_RECENT_INFO(self.unwrap_widget()),
+                &mut length) as *const *const c_char;
+            FromGlibPtrContainer::take_num(ptr, length as usize)
         }
     }
 


### PR DESCRIPTION
This changes the APIs that take or return lists (of strings for now).

On the input side this allows a reference to anything that can iterate over strings:
```rust
    pub fn set_authors<S, I>(&self, authors: I)
    where S: Str, I: IntoIterator<Item = S> {
    ...
```
```rust
        dialog.set_authors(&crew);
```

The return type is `Vec<String>` but could if needed work similarly to `Iterator::collect()` that is generic over the container type.

It's pointless to use a `glib::List` or `SList` because you don't put native types in it, so it can't be passed to the libs unmodified, and thus has no benefits compared to the standard collections.

`AboutDialog` and `FileChooser` were broken and now they work! :)