### PR TITLE
Support variadic methods on dialogs

### DIFF
--- a/examples/src/gtktest.rs
+++ b/examples/src/gtktest.rs
@@ -40,6 +40,7 @@ fn main() {
     let mut button_box = gtk::ButtonBox::new(gtk::Orientation::Horizontal).unwrap();
     let mut label = gtk::Label::new("Yeah a wonderful label too !").unwrap();
     let button = gtk::Button::new_with_label("Whattttt a button !").unwrap();
+    let button_about = gtk::Button::new_with_label("About?").unwrap();
     let button_recent = gtk::Button::new_with_label("Choose a recent one !").unwrap();
     let button_font = gtk::Button::new_with_label("Choose a font !").unwrap();
     let app_button = gtk::Button::new_with_label("App ?").unwrap();
@@ -101,8 +102,20 @@ fn main() {
     window.set_window_position(gtk::WindowPosition::Center);
     window.add(&frame);
 
-    Connect::connect(&button, Clicked::new(&mut ||{
-        entry.set_text("Clicked!".to_string());
+    Connect::connect(&button, Clicked::new(&mut || {
+
+        let dialog = gtk::Dialog::with_buttons(
+            "Hello!", None, gtk::DialogFlags::Modal,
+            [("No", 0), ("Yes", 1), ("Yes!", 2)]);
+
+        let ret = dialog.run();
+
+        dialog.destroy();
+
+        entry.set_text(format!("Clicked {}", ret));
+    }));
+
+    Connect::connect(&button_about, Clicked::new(&mut ||{
 
         let dialog = gtk::AboutDialog::new().unwrap();
 
@@ -134,7 +147,9 @@ fn main() {
     }));
     Connect::connect(&file_button, Clicked::new(&mut ||{
         //entry.set_text("Clicked!".to_string());
-        let dialog = gtk::FileChooserDialog::new("Choose a file", None, gtk::FileChooserAction::Open).unwrap();
+        let dialog = gtk::FileChooserDialog::new(
+            "Choose a file", None, gtk::FileChooserAction::Open,
+            [("Open", gtk::ResponseType::Ok), ("Cancel", gtk::ResponseType::Cancel)]);
 
         dialog.set_select_multiple(true);
 
@@ -176,6 +191,7 @@ fn main() {
         button_box.add(&tmp_button)
     }};
     button_box.add(&button);
+    button_box.add(&button_about);
     button_box.add(&button_font);
     button_box.add(&button_recent);
     button_box.add(&file_button);

--- a/examples/src/text_viewer.rs
+++ b/examples/src/text_viewer.rs
@@ -33,11 +33,13 @@ fn main() {
     open_button.set_is_important(true);
     Connect::connect(&open_button, Clicked::new(&mut || {
         // TODO move this to a impl?
-        let file_chooser = gtk::FileChooserDialog::new("Open File", None, gtk::FileChooserAction::Open).unwrap();
+        let file_chooser = gtk::FileChooserDialog::new(
+            "Open File", None, gtk::FileChooserAction::Open,
+            [("Open", gtk::ResponseType::Ok), ("Cancel", gtk::ResponseType::Cancel)]);
         let response: Option<gtk::ResponseType> = FromPrimitive::from_i32(file_chooser.run());
 
         match response {
-            Some(gtk::ResponseType::Accept) => {
+            Some(gtk::ResponseType::Ok) => {
                 let filename = file_chooser.get_filename().unwrap();
                 let file = File::open(&filename).unwrap();
 

--- a/gtk3-sys/src/lib.rs
+++ b/gtk3-sys/src/lib.rs
@@ -1262,8 +1262,10 @@ extern "C" {
     // GtkFileChooserDialog                                              NOT OK
     //=========================================================================
     //pub fn gtk_file_chooser_dialog_new         (title: *const c_char, parent: *const const C_GtkWindow, action: enums::FileChooserAction, first_button_text: *const c_char, ...) -> *const const C_GtkWidget;
-    pub fn gtk_file_chooser_dialog_new         (title: *const c_char, parent: *mut C_GtkWindow, action: enums::FileChooserAction, button_text1: *const c_char,
-        type1: enums::ResponseType, button_text2: *const c_char, type2: enums::ResponseType, end: *mut c_void) -> *mut C_GtkWidget;
+    pub fn gtk_file_chooser_dialog_new         (title: *const c_char,
+                                                parent: *mut C_GtkWindow,
+                                                action: enums::FileChooserAction,
+                                                ...) -> *mut C_GtkWidget;
 
     //=========================================================================
     // GtkIconView                                                       NOT OK
@@ -1800,11 +1802,14 @@ extern "C" {
     // GtkDialog                                                         NOT OK
     //=========================================================================
     pub fn gtk_dialog_new                      () -> *mut C_GtkWidget;
-    //pub fn gtk_dialog_new_with_buttons         (title: *const c_char, parent: *const const C_GtkWindow, flags: DialogFlags, first_button_text: *const c_char, ...) -> *const const C_GtkWidget;
+    pub fn gtk_dialog_new_with_buttons         (title: *const c_char,
+                                                parent: *mut C_GtkWindow,
+                                                flags: enums::DialogFlags,
+                                                ...) -> *mut C_GtkWidget;
     pub fn gtk_dialog_run                      (dialog: *mut C_GtkDialog) -> i32;
     pub fn gtk_dialog_response                 (dialog: *mut C_GtkDialog, response_id: i32) -> ();
     pub fn gtk_dialog_add_button               (dialog: *mut C_GtkDialog, button_text: *const c_char, response_id: i32) -> *mut C_GtkWidget;
-    //pub fn gtk_dialog_add_buttons              (dialog: *const const C_GtkDialog, first_button_text: *const c_char, ...) -> ();
+    pub fn gtk_dialog_add_buttons              (dialog: *mut C_GtkDialog, ...);
     pub fn gtk_dialog_add_action_widget        (dialog: *mut C_GtkDialog, child: *mut C_GtkWidget, response_id: i32) -> ();
     pub fn gtk_dialog_set_default_response     (dialog: *mut C_GtkDialog, response_id: i32) -> ();
     pub fn gtk_dialog_set_response_sensitive   (dialog: *mut C_GtkDialog, response_id: i32, setting: Gboolean) -> ();

--- a/src/gtk/mod.rs
+++ b/src/gtk/mod.rs
@@ -309,6 +309,7 @@ pub use self::traits::CheckMenuItemTrait;
 pub use self::traits::ColorChooserTrait;
 pub use self::traits::ComboBoxTrait;
 pub use self::traits::ContainerTrait;
+pub use self::traits::DialogButtons;
 pub use self::traits::DialogTrait;
 pub use self::traits::EditableTrait;
 pub use self::traits::EntryTrait;

--- a/src/gtk/traits/mod.rs
+++ b/src/gtk/traits/mod.rs
@@ -30,6 +30,7 @@ pub use self::tool_shell::ToolShellTrait;
 pub use self::tool_item::ToolItemTrait;
 pub use self::tool_button::ToolButtonTrait;
 pub use self::toggle_tool_button::ToggleToolButtonTrait;
+pub use self::dialog::DialogButtons;
 pub use self::dialog::DialogTrait;
 pub use self::color_chooser::ColorChooserTrait;
 pub use self::scrollable::ScrollableTrait;

--- a/src/gtk/widgets/dialog.rs
+++ b/src/gtk/widgets/dialog.rs
@@ -13,33 +13,38 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::ptr;
+use glib::translate::{ToGlibPtr, ToTmp};
 use gtk::{self, ffi};
+use gtk::cast::GTK_WINDOW;
+use gtk::FFIWidget;
+use gtk::DialogButtons;
 
 struct_Widget!(Dialog);
 
 impl Dialog {
-    fn new() -> Option<Dialog> {
-        let tmp_pointer = unsafe {
-            ffi::gtk_dialog_new()
-        };
-
-        if tmp_pointer.is_null() {
-            None
-        } else {
-            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
+    pub fn new() -> Dialog {
+        unsafe {
+            gtk::FFIWidget::wrap_widget(
+                ffi::gtk_dialog_new())
         }
     }
 
-    /*fn new_width_buttons(title: &str, parent: Window, DialogFlags: flags, first_button_text: &str, ...) -> Option<Dialog> {
-        let tmp_pointer = unsafe {
-            ffi::gtk_dialog_new_with_buttons();
-        };
-        if tmp_pointer.is_null() {
-            None
-        } else {
-            Some(gtk::FFIWidget::wrap_widget(tmp_pointer))
+    pub fn with_buttons<T: DialogButtons>(title: &str, parent: Option<gtk::Window>,
+                                          flags: gtk::DialogFlags, buttons: T) -> Dialog {
+        unsafe {
+            let mut tmp_title = title.to_tmp_for_borrow();
+            let parent = match parent {
+                Some(w) => GTK_WINDOW(w.unwrap_widget()),
+                None => ptr::null_mut(),
+            };
+            gtk::FFIWidget::wrap_widget(
+                buttons.invoke3(ffi::gtk_dialog_new_with_buttons,
+                                tmp_title.to_glib_ptr(),
+                                parent,
+                                flags))
         }
-    }*/
+    }
 }
 
 impl_drop!(Dialog);


### PR DESCRIPTION
`DialogButtons` trait allows to take fixed-length arrays of button definitions generically over their length.
Add `Dialog::with_buttons` and `add_buttons` that take such an array.
While there, publish `Dialog::new`.
Make `FileChooserDialog::new` take button arrays too.
Update the examples.