### PR TITLE
glib::translate refactoring

### DIFF
--- a/glib/src/error.rs
+++ b/glib/src/error.rs
@@ -15,7 +15,7 @@
 
 use ffi::{self, GQuark};
 use glib_container::GlibContainer;
-use translate::{ToGlibPtr, ToTmp};
+use translate::ToGlibPtr;
 
 pub struct Error {
     pointer: *mut ffi::C_GError
@@ -24,8 +24,7 @@ pub struct Error {
 impl Error {
     pub fn new_literal(domain: GQuark, code: i32, message: &str) -> Option<Error> {
         let tmp_pointer = unsafe {
-            let mut tmp_message = message.to_tmp_for_borrow();
-            ffi::g_error_new_literal(domain, code, tmp_message.to_glib_ptr())
+            ffi::g_error_new_literal(domain, code, message.borrow_to_glib().0)
         };
 
         if tmp_pointer.is_null() {
@@ -51,8 +50,7 @@ impl Error {
 
     pub fn set(&mut self, domain: GQuark, code: i32, message: &str) -> () {
         unsafe {
-            let mut tmp_message = message.to_tmp_for_borrow();
-            ffi::g_set_error_literal(&mut self.pointer, domain, code, tmp_message.to_glib_ptr())
+            ffi::g_set_error_literal(&mut self.pointer, domain, code, message.borrow_to_glib().0)
         }
     }
 

--- a/glib/src/traits.rs
+++ b/glib/src/traits.rs
@@ -16,7 +16,7 @@
 use std::marker::PhantomFn;
 use ffi;
 use std::any::Any;
-use translate::{ToGlibPtr, ToTmp};
+use translate::ToGlibPtr;
 
 pub trait FFIGObject {
     fn unwrap_gobject(&self) -> *mut ffi::C_GObject;
@@ -63,13 +63,12 @@ pub trait Connect<'a, T: Signal<'a>>: FFIGObject + PhantomFn<&'a T> {
 
         unsafe {
             let trampoline      = signal.get_trampoline();
-            let mut tmp_signal_name = signal.get_signal_name().replace("_", "-")
-                                        .to_tmp_for_borrow();
+            let signal_name = signal.get_signal_name().replace("_", "-");
             let user_data_ptr   = transmute(Box::new(signal));
             
             ffi::glue_signal_connect(
                 self.unwrap_gobject(),
-                tmp_signal_name.to_glib_ptr(),
+                signal_name.borrow_to_glib().0,
                 Some(trampoline),
                 user_data_ptr
             );

--- a/glib/src/translate.rs
+++ b/glib/src/translate.rs
@@ -143,17 +143,17 @@ impl <S: Str> ToTmp for Option<S> {
 }
 
 /// Translate to an intermediate variable for passing an array
-pub trait ToArray {
+pub trait ToArray<'a> {
     type Tmp;
 
-    fn to_array_for_borrow(self) -> Self::Tmp;
+    fn to_array_for_borrow(&'a self) -> Self::Tmp;
 }
 
-impl <'a, T, I> ToArray for I
-where T: ToTmp, <T as ToTmp>::Tmp: ToGlibPtr, I: IntoIterator<Item = &'a T> {
+impl <'a, T, I: ?Sized> ToArray<'a> for I
+where T: ToTmp, <T as ToTmp>::Tmp: ToGlibPtr, &'a I: IntoIterator<Item = &'a T> {
     type Tmp = PtrArray<T>;
 
-    fn to_array_for_borrow(self) -> PtrArray<T> {
+    fn to_array_for_borrow(&'a self) -> PtrArray<T> {
         let mut tmp_vec: Vec<_> =
             self.into_iter().map(|v| v.to_tmp_for_borrow()).collect();
         let mut ptr_vec: Vec<_> =

--- a/glib/src/translate.rs
+++ b/glib/src/translate.rs
@@ -189,18 +189,18 @@ impl <'a, P: Copy, T: ToGlibPtr<'a, P>> PtrArray<'a, P, T> {
 pub trait FromGlib: Sized {
     type GlibType: Sized;
 
-    fn conv(val: Self::GlibType) -> Self;
+    fn from_glib(val: Self::GlibType) -> Self;
 }
 
 /// Translate a simple type
 pub fn from_glib<T: FromGlib>(val: <T as FromGlib>::GlibType) -> T {
-    FromGlib::conv(val)
+    FromGlib::from_glib(val)
 }
 
 impl FromGlib for bool {
     type GlibType = ffi::Gboolean;
 
-    fn conv(val: ffi::Gboolean) -> bool {
+    fn from_glib(val: ffi::Gboolean) -> bool {
         !(val == ffi::GFALSE)
     }
 }

--- a/glib/src/type_.rs
+++ b/glib/src/type_.rs
@@ -60,7 +60,7 @@ pub trait GetType: PhantomFn<Self> {
 impl FromGlib for Type {
     type GlibType = ffi::GType;
 
-    fn conv(val: ffi::GType) -> Type {
+    fn from_glib(val: ffi::GType) -> Type {
         use self::Type::*;
         match val {
             ffi::G_TYPE_INVALID => Invalid,

--- a/glib/src/value.rs
+++ b/glib/src/value.rs
@@ -19,7 +19,7 @@ use libc::c_char;
 use ffi;
 use super::{to_bool, to_gboolean};
 use type_::Type;
-use translate::{FromGlibPtr, ToGlib, ToGlibPtr, ToTmp, from_glib};
+use translate::{FromGlibPtr, ToGlib, ToGlibPtr, from_glib};
 
 pub trait ValuePublic {
     fn get(gvalue: &Value) -> Self;
@@ -173,8 +173,7 @@ impl Value {
 
     fn set_string(&self, v_string: &str) {
         unsafe {
-            let mut tmp_v_string = v_string.to_tmp_for_borrow();
-            ffi::g_value_set_string(self.pointer, tmp_v_string.to_glib_ptr());
+            ffi::g_value_set_string(self.pointer, v_string.borrow_to_glib().0);
         }
     }
 

--- a/gtk3-sys/src/lib.rs
+++ b/gtk3-sys/src/lib.rs
@@ -1264,6 +1264,7 @@ extern "C" {
     pub fn gtk_file_chooser_dialog_new         (title: *const c_char,
                                                 parent: *mut C_GtkWindow,
                                                 action: enums::FileChooserAction,
+                                                first_button_text: *const c_char,
                                                 ...) -> *mut C_GtkWidget;
 
     //=========================================================================
@@ -1804,11 +1805,14 @@ extern "C" {
     pub fn gtk_dialog_new_with_buttons         (title: *const c_char,
                                                 parent: *mut C_GtkWindow,
                                                 flags: enums::DialogFlags,
+                                                first_button_text: *const c_char,
                                                 ...) -> *mut C_GtkWidget;
     pub fn gtk_dialog_run                      (dialog: *mut C_GtkDialog) -> i32;
     pub fn gtk_dialog_response                 (dialog: *mut C_GtkDialog, response_id: i32) -> ();
     pub fn gtk_dialog_add_button               (dialog: *mut C_GtkDialog, button_text: *const c_char, response_id: i32) -> *mut C_GtkWidget;
-    pub fn gtk_dialog_add_buttons              (dialog: *mut C_GtkDialog, ...);
+    pub fn gtk_dialog_add_buttons              (dialog: *mut C_GtkDialog,
+                                                first_button_text: *const c_char,
+                                                ...);
     pub fn gtk_dialog_add_action_widget        (dialog: *mut C_GtkDialog, child: *mut C_GtkWidget, response_id: i32) -> ();
     pub fn gtk_dialog_set_default_response     (dialog: *mut C_GtkDialog, response_id: i32) -> ();
     pub fn gtk_dialog_set_response_sensitive   (dialog: *mut C_GtkDialog, response_id: i32, setting: Gboolean) -> ();

--- a/src/cairo/context.rs
+++ b/src/cairo/context.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 use c_vec::CVec;
 use std::ptr::Unique;
 use std::mem::transmute;
@@ -539,8 +539,7 @@ impl Context {
 
     pub fn select_font_face(&self, family: &str, slant: FontSlant, weight: FontWeight){
         unsafe {
-            let mut tmp_family = family.to_tmp_for_borrow();
-            ffi::cairo_select_font_face(self.get_ptr(), tmp_family.to_glib_ptr(), slant, weight)
+            ffi::cairo_select_font_face(self.get_ptr(), family.borrow_to_glib().0, slant, weight)
         }
     }
 
@@ -605,8 +604,7 @@ impl Context {
 
     pub fn show_text(&self, text: &str){
         unsafe {
-            let mut tmp_text = text.to_tmp_for_borrow();
-            ffi::cairo_show_text(self.get_ptr(), tmp_text.to_glib_ptr())
+            ffi::cairo_show_text(self.get_ptr(), text.borrow_to_glib().0)
         }
     }
 
@@ -625,10 +623,9 @@ impl Context {
         unsafe {
             let glyphs: &[Glyph] = glyph_vec.as_slice();
             let clusters: &[TextCluster] = cluster_vec.as_slice();
-            let mut tmp_text = text.to_tmp_for_borrow();
 
                 ffi::cairo_show_text_glyphs(self.get_ptr(),
-                                            tmp_text.to_glib_ptr(),
+                                            text.borrow_to_glib().0,
                                             -1 as c_int, //NUL terminated
                                             glyphs.as_ptr(),
                                             glyphs.len() as c_int,
@@ -665,8 +662,7 @@ impl Context {
         };
 
         unsafe {
-            let mut tmp_text = text.to_tmp_for_borrow();
-            ffi::cairo_text_extents(self.get_ptr(), tmp_text.to_glib_ptr(), &mut extents);
+            ffi::cairo_text_extents(self.get_ptr(), text.borrow_to_glib().0, &mut extents);
         }
         extents
     }
@@ -781,8 +777,7 @@ impl Context {
 
     pub fn text_path(&self, str_: &str){
         unsafe {
-            let mut tmp_str_ = str_.to_tmp_for_borrow();
-            ffi::cairo_text_path(self.get_ptr(), tmp_str_.to_glib_ptr())
+            ffi::cairo_text_path(self.get_ptr(), str_.borrow_to_glib().0)
         }
     }
 

--- a/src/cairo/fonts.rs
+++ b/src/cairo/fonts.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 use std::clone::Clone;
 use std::cmp::PartialEq;
 use std::ops::Drop;
@@ -192,8 +192,7 @@ impl FontFace {
     pub fn toy_create(family: &str, slant: FontSlant, weight: FontWeight) -> FontFace {
         let font_face = FontFace(
             unsafe {
-                let mut tmp_family = family.to_tmp_for_borrow();
-                ffi::cairo_toy_font_face_create(tmp_family.to_glib_ptr(), slant, weight)
+                ffi::cairo_toy_font_face_create(family.borrow_to_glib().0, slant, weight)
             }
         );
         font_face.ensure_status();

--- a/src/gdk/keys.rs
+++ b/src/gdk/keys.rs
@@ -17,12 +17,11 @@
 
 use glib::translate::FromGlibPtr;
 use gdk::ffi;
-use libc::{c_uint, c_char};
+use libc::c_uint;
 
 pub fn keyval_name(keyval: u32) -> Option<String> {
     unsafe {
         FromGlibPtr::borrow(
-            ffi::gdk_keyval_name(keyval as c_uint) as *const c_char
-        )
+            ffi::gdk_keyval_name(keyval as c_uint))
     }
 }

--- a/src/gdk/rt.rs
+++ b/src/gdk/rt.rs
@@ -16,7 +16,7 @@
 //! General — Library initialization and miscellaneous functions
 
 use std::ptr;
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 use gdk::ffi;
 
 pub fn init() {
@@ -44,15 +44,13 @@ pub fn notify_startup_complete() {
 
 pub fn notify_startup_complete_with_id(startup_id: &str) {
     unsafe {
-        let mut tmp_startup_id = startup_id.to_tmp_for_borrow();
-        ffi::gdk_notify_startup_complete_with_id(tmp_startup_id.to_glib_ptr());
+        ffi::gdk_notify_startup_complete_with_id(startup_id.borrow_to_glib().0);
     }
 }
 
 pub fn set_allowed_backends(backends: &str) {
     unsafe {
-        let mut tmp_backends = backends.to_tmp_for_borrow();
-        ffi::gdk_set_allowed_backends(tmp_backends.to_glib_ptr())
+        ffi::gdk_set_allowed_backends(backends.borrow_to_glib().0)
     }
 }
 
@@ -65,8 +63,7 @@ pub fn get_program_class() -> Option<String> {
 
 pub fn set_program_class(program_class: &str) {
     unsafe {
-        let mut tmp_program_class = program_class.to_tmp_for_borrow();
-        ffi::gdk_set_program_class(tmp_program_class.to_glib_ptr())
+        ffi::gdk_set_program_class(program_class.borrow_to_glib().0)
     }
 }
 

--- a/src/gdk/widgets/app_launch_context.rs
+++ b/src/gdk/widgets/app_launch_context.rs
@@ -17,7 +17,7 @@
 
 use gdk::{self, ffi};
 use libc::c_int;
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 
 // FIXME: should inherit from GAppLaunchContext
 #[repr(C)]
@@ -45,8 +45,7 @@ impl AppLaunchContext {
 
     pub fn set_icon_name(&self, icon_name: &str) {
         unsafe {
-            let mut tmp_icon_name = icon_name.to_tmp_for_borrow();
-            ffi::gdk_app_launch_context_set_icon_name(self.pointer, tmp_icon_name.to_glib_ptr())
+            ffi::gdk_app_launch_context_set_icon_name(self.pointer, icon_name.borrow_to_glib().0)
         }
     }
 }

--- a/src/gdk/widgets/atom.rs
+++ b/src/gdk/widgets/atom.rs
@@ -14,7 +14,7 @@
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
 use gdk::ffi;
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 use libc::{c_char};
 
 #[derive(Copy)]
@@ -31,8 +31,7 @@ impl Atom {
 
     pub fn intern(atom_name: &str, only_if_exists: bool) -> Option<Atom> {
         let tmp = unsafe {
-            let mut tmp_atom_name = atom_name.to_tmp_for_borrow();
-            ffi::gdk_atom_intern(tmp_atom_name.to_glib_ptr(), ::glib::to_gboolean(only_if_exists))
+            ffi::gdk_atom_intern(atom_name.borrow_to_glib().0, ::glib::to_gboolean(only_if_exists))
         };
 
         if tmp.is_null() {
@@ -46,8 +45,7 @@ impl Atom {
 
     pub fn intern_static_string(atom_name: &str) -> Option<Atom> {
         let tmp = unsafe {
-            let mut tmp_atom_name = atom_name.to_tmp_for_borrow();
-            ffi::gdk_atom_intern_static_string(tmp_atom_name.to_glib_ptr())
+            ffi::gdk_atom_intern_static_string(atom_name.borrow_to_glib().0)
         };
 
         if tmp.is_null() {

--- a/src/gdk/widgets/atom.rs
+++ b/src/gdk/widgets/atom.rs
@@ -15,7 +15,6 @@
 
 use gdk::ffi;
 use glib::translate::{FromGlibPtr, ToGlibPtr};
-use libc::{c_char};
 
 #[derive(Copy)]
 pub struct Atom {
@@ -60,7 +59,7 @@ impl Atom {
     pub fn name(&self) -> Option<String> {
         unsafe {
             FromGlibPtr::take(
-                ffi::gdk_atom_name(self.pointer) as *const c_char)
+                ffi::gdk_atom_name(self.pointer))
         }
     }
 

--- a/src/gdk/widgets/cursor.rs
+++ b/src/gdk/widgets/cursor.rs
@@ -16,7 +16,7 @@
 //! Cursors — Standard and pixmap cursors
 
 use gdk::{self, ffi};
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 //use libc::{c_int};
 
 #[repr(C)]
@@ -52,8 +52,7 @@ impl Cursor {
 
     pub fn new_from_name(display: &gdk::Display, name: &str) -> Option<Cursor> {
         let tmp = unsafe {
-            let mut tmp_name = name.to_tmp_for_borrow();
-            ffi::gdk_cursor_new_from_name(display.unwrap_pointer(), tmp_name.to_glib_ptr())
+            ffi::gdk_cursor_new_from_name(display.unwrap_pointer(), name.borrow_to_glib().0)
         };
 
         if tmp.is_null() {

--- a/src/gdk/widgets/display.rs
+++ b/src/gdk/widgets/display.rs
@@ -17,7 +17,7 @@
 
 use gdk::{self, ffi};
 use libc::{c_uint};
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 use glib::to_bool;
 
 #[repr(C)]
@@ -29,8 +29,7 @@ pub struct Display {
 impl Display {
     pub fn open(display_name: &str) -> Option<Display> {
         let tmp = unsafe {
-            let mut tmp_display_name = display_name.to_tmp_for_borrow();
-            ffi::gdk_display_open(tmp_display_name.to_glib_ptr())
+            ffi::gdk_display_open(display_name.borrow_to_glib().0)
         };
 
         if tmp.is_null() {
@@ -218,8 +217,7 @@ impl Display {
 
     pub fn notify_startup_complete(&self, startup_id: &str) {
         unsafe {
-            let mut tmp_startup_id = startup_id.to_tmp_for_borrow();
-            ffi::gdk_display_notify_startup_complete(self.pointer, tmp_startup_id.to_glib_ptr())
+            ffi::gdk_display_notify_startup_complete(self.pointer, startup_id.borrow_to_glib().0)
         }
     }
 }

--- a/src/gdk/widgets/display_manager.rs
+++ b/src/gdk/widgets/display_manager.rs
@@ -16,7 +16,7 @@
 //! GdkDisplayManager — Maintains a list of all open GdkDisplays
 
 use gdk::{self, ffi};
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 
 #[repr(C)]
 #[derive(Copy)]
@@ -53,8 +53,7 @@ impl DisplayManager {
 
     pub fn open_display(&self, name: &str) -> Option<gdk::Display> {
         let tmp = unsafe {
-            let mut tmp_name = name.to_tmp_for_borrow();
-            ffi::gdk_display_manager_open_display(self.pointer, tmp_name.to_glib_ptr())
+            ffi::gdk_display_manager_open_display(self.pointer, name.borrow_to_glib().0)
         };
 
         if tmp.is_null() {

--- a/src/gdk/widgets/pixbuf.rs
+++ b/src/gdk/widgets/pixbuf.rs
@@ -15,7 +15,7 @@
 
 /// The GdkPixbuf structure contains information that describes an image in memory.
 
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 use gdk::{self, ffi};
 use c_vec::CVec;
 use std::ptr::Unique;
@@ -76,10 +76,9 @@ impl Pixbuf {
 
     pub fn get_option(&self, key: &str) -> Option<String> {
         unsafe {
-            let mut tmp_key = key.to_tmp_for_borrow();
             FromGlibPtr::borrow(
                 ffi::gdk_pixbuf_get_option(self.pointer as *const ffi::C_GdkPixbuf,
-                                           tmp_key.to_glib_ptr()))
+                                           key.borrow_to_glib().0))
         }
     }
 

--- a/src/gdk/widgets/rgba.rs
+++ b/src/gdk/widgets/rgba.rs
@@ -15,7 +15,7 @@
 
 //! RGBA Colors — RGBA colors
 
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 use gdk_ffi as ffi;
 use gdk_ffi::C_GdkRGBA;
 use libc::{c_char};
@@ -90,8 +90,7 @@ impl RGBA for C_GdkRGBA {
 
     fn parse(&mut self, spec: &str) -> bool {
         unsafe {
-            let mut tmp_spec = spec.to_tmp_for_borrow();
-            ::glib::to_bool(ffi::gdk_rgba_parse(self, tmp_spec.to_glib_ptr()))
+            ::glib::to_bool(ffi::gdk_rgba_parse(self, spec.borrow_to_glib().0))
         }
     }
 

--- a/src/gdk/widgets/rgba.rs
+++ b/src/gdk/widgets/rgba.rs
@@ -18,7 +18,6 @@
 use glib::translate::{FromGlibPtr, ToGlibPtr};
 use gdk_ffi as ffi;
 use gdk_ffi::C_GdkRGBA;
-use libc::{c_char};
 
 pub trait RGBA {
     fn white() -> C_GdkRGBA;
@@ -105,7 +104,7 @@ impl RGBA for C_GdkRGBA {
     fn to_string(&self) -> Option<String> {
         unsafe {
             FromGlibPtr::take(
-                ffi::gdk_rgba_to_string(self) as *const c_char)
+                ffi::gdk_rgba_to_string(self))
         }
     }
 }

--- a/src/gdk/widgets/screen.rs
+++ b/src/gdk/widgets/screen.rs
@@ -17,7 +17,7 @@
 
 use glib::translate::{FromGlibPtr};
 use gdk::{self, ffi};
-use libc::{c_int, c_char};
+use libc::c_int;
 
 #[repr(C)]
 #[derive(Copy)]
@@ -105,7 +105,7 @@ impl Screen {
     pub fn make_display_name(&self) -> Option<String> {
         unsafe {
             FromGlibPtr::take(
-                ffi::gdk_screen_make_display_name(self.pointer) as *const c_char)
+                ffi::gdk_screen_make_display_name(self.pointer))
         }
     }
 
@@ -145,7 +145,7 @@ impl Screen {
         unsafe {
             FromGlibPtr::take(
                 ffi::gdk_screen_get_monitor_plug_name(self.pointer,
-                                                      monitor_num as c_int) as *const c_char)
+                                                      monitor_num as c_int))
         }
     }
 

--- a/src/gtk/traits/actionable.rs
+++ b/src/gtk/traits/actionable.rs
@@ -15,7 +15,7 @@
 
 //! GtkActionable — An interface for widgets that can be associated with actions
 
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 use gtk::cast::GTK_ACTIONABLE;
 use gtk::{self, ffi};
 
@@ -29,15 +29,13 @@ pub trait ActionableTrait: gtk::WidgetTrait {
 
     fn set_action_name(&self, action_name: &str) {
         unsafe {
-            let mut tmp_action_name = action_name.to_tmp_for_borrow();
-            ffi::gtk_actionable_set_action_name(GTK_ACTIONABLE(self.unwrap_widget()), tmp_action_name.to_glib_ptr())
+            ffi::gtk_actionable_set_action_name(GTK_ACTIONABLE(self.unwrap_widget()), action_name.borrow_to_glib().0)
         }
     }
 
     fn set_detailed_action_name(&self, detailed_action_name: &str) {
         unsafe {
-            let mut tmp_detailed_action_name = detailed_action_name.to_tmp_for_borrow();
-            ffi::gtk_actionable_set_detailed_action_name(GTK_ACTIONABLE(self.unwrap_widget()), tmp_detailed_action_name.to_glib_ptr())
+            ffi::gtk_actionable_set_detailed_action_name(GTK_ACTIONABLE(self.unwrap_widget()), detailed_action_name.borrow_to_glib().0)
         }
     }
 }

--- a/src/gtk/traits/button.rs
+++ b/src/gtk/traits/button.rs
@@ -15,7 +15,7 @@
 
 use std::mem;
 use libc::c_float;
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 
 use gtk::{ReliefStyle, PositionType};
 use gtk::cast::GTK_BUTTON;
@@ -74,8 +74,7 @@ pub trait ButtonTrait: gtk::WidgetTrait + gtk::ContainerTrait {
 
     fn set_label(&mut self, label: &str) -> () {
         unsafe {
-            let mut tmp_label = label.to_tmp_for_borrow();
-            ffi::gtk_button_set_label(GTK_BUTTON(self.unwrap_widget()), tmp_label.to_glib_ptr())
+            ffi::gtk_button_set_label(GTK_BUTTON(self.unwrap_widget()), label.borrow_to_glib().0)
         }
     }
 
@@ -148,11 +147,10 @@ pub trait ButtonTrait: gtk::WidgetTrait + gtk::ContainerTrait {
 
     fn connect_clicked_signal(&self, handler: Box<ButtonClickedHandler>) {
         let data = unsafe { mem::transmute::<Box<Box<ButtonClickedHandler>>, ffi::gpointer>(Box::new(handler)) };
-        let mut tmp_name = "clicked".to_tmp_for_borrow();
 
         unsafe {
             ffi::g_signal_connect_data(self.unwrap_widget() as ffi::gpointer,
-                                       tmp_name.to_glib_ptr(),
+                                       "clicked".borrow_to_glib().0,
                                        Some(mem::transmute(widget_destroy_callback)),
                                        data,
                                        Some(drop_widget_destroy_handler as extern "C" fn(ffi::gpointer, *const ffi::C_GClosure)),

--- a/src/gtk/traits/cell_layout.rs
+++ b/src/gtk/traits/cell_layout.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 use gtk::{self, ffi};
 use gtk::cast::{GTK_CELL_LAYOUT, GTK_CELL_RENDERER};
 use glib;
@@ -69,11 +69,10 @@ pub trait CellLayoutTrait: gtk::WidgetTrait {
 
     fn add_attribute<T: gtk::CellRendererTrait>(&self, cell: &T, attribute: &str, column: i32) {
         unsafe {
-            let mut tmp_attribute = attribute.to_tmp_for_borrow();
             ffi::gtk_cell_layout_add_attribute(
                 GTK_CELL_LAYOUT(self.unwrap_widget()),
                 GTK_CELL_RENDERER(cell.unwrap_widget()),
-                tmp_attribute.to_glib_ptr(),
+                attribute.borrow_to_glib().0,
                 column)
             }
     }

--- a/src/gtk/traits/combo_box.rs
+++ b/src/gtk/traits/combo_box.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
 use gtk::cast::GTK_COMBO_BOX;
@@ -82,8 +82,7 @@ pub trait ComboBoxTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrait 
 
     fn set_active_id(&self, active_id: &str) -> bool {
         unsafe {
-            let mut tmp_active_id = active_id.to_tmp_for_borrow();
-            to_bool(ffi::gtk_combo_box_set_active_id(GTK_COMBO_BOX(self.unwrap_widget()), tmp_active_id.to_glib_ptr()))
+            to_bool(ffi::gtk_combo_box_set_active_id(GTK_COMBO_BOX(self.unwrap_widget()), active_id.borrow_to_glib().0))
         }
     }
 

--- a/src/gtk/traits/dialog.rs
+++ b/src/gtk/traits/dialog.rs
@@ -133,8 +133,7 @@ pub trait DialogTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrait + 
 
     fn add_button(&self, button_text: &str, response_id: i32) -> Option<gtk::Button> {
         let tmp_pointer = unsafe {
-            let mut tmp_button_text = button_text.to_tmp_for_borrow();
-            ffi::gtk_dialog_add_button(GTK_DIALOG(self.unwrap_widget()), tmp_button_text.to_glib_ptr(), response_id)
+            ffi::gtk_dialog_add_button(GTK_DIALOG(self.unwrap_widget()), button_text.borrow_to_glib().0, response_id)
         };
 
         if tmp_pointer.is_null() {

--- a/src/gtk/traits/entry.rs
+++ b/src/gtk/traits/entry.rs
@@ -14,7 +14,7 @@
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
 use libc::{c_int, c_float, c_double};
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 
 use gtk::{EntryIconPosition, ImageType, InputPurpose, InputHints};
 use gtk::cast::GTK_ENTRY;
@@ -36,8 +36,7 @@ pub trait EntryTrait: gtk::WidgetTrait {
 
     fn set_text(&mut self, text: String) -> () {
         unsafe {
-            let mut tmp_text = text.to_tmp_for_borrow();
-            ffi::gtk_entry_set_text(GTK_ENTRY(self.unwrap_widget()), tmp_text.to_glib_ptr())
+            ffi::gtk_entry_set_text(GTK_ENTRY(self.unwrap_widget()), text.borrow_to_glib().0)
         }
     }
 
@@ -124,8 +123,7 @@ pub trait EntryTrait: gtk::WidgetTrait {
 
     fn set_placeholder(&mut self, text: &str) -> () {
         unsafe {
-            let mut tmp_text = text.to_tmp_for_borrow();
-            ffi::gtk_entry_set_placeholder_text(GTK_ENTRY(self.unwrap_widget()), tmp_text.to_glib_ptr())
+            ffi::gtk_entry_set_placeholder_text(GTK_ENTRY(self.unwrap_widget()), text.borrow_to_glib().0)
         }
     }
 
@@ -226,15 +224,13 @@ pub trait EntryTrait: gtk::WidgetTrait {
 
     fn set_icon_from_stock(&mut self, icon_pos: EntryIconPosition, stock_id: &str) -> () {
         unsafe {
-            let mut tmp_stock_id = stock_id.to_tmp_for_borrow();
-            ffi::gtk_entry_set_icon_from_stock(GTK_ENTRY(self.unwrap_widget()), icon_pos, tmp_stock_id.to_glib_ptr());
+            ffi::gtk_entry_set_icon_from_stock(GTK_ENTRY(self.unwrap_widget()), icon_pos, stock_id.borrow_to_glib().0);
         }
     }
 
     fn set_icon_from_icon_name(&mut self, icon_pos: EntryIconPosition, icon_name: &str) -> () {
         unsafe {
-            let mut tmp_icon_name = icon_name.to_tmp_for_borrow();
-            ffi::gtk_entry_set_icon_from_icon_name(GTK_ENTRY(self.unwrap_widget()), icon_pos, tmp_icon_name.to_glib_ptr())
+            ffi::gtk_entry_set_icon_from_icon_name(GTK_ENTRY(self.unwrap_widget()), icon_pos, icon_name.borrow_to_glib().0)
         }
     }
 
@@ -282,8 +278,7 @@ pub trait EntryTrait: gtk::WidgetTrait {
 
     fn set_icon_tooltip_text(&mut self, icon_pos: EntryIconPosition, tooltip: &str) -> () {
         unsafe {
-            let mut tmp_tooltip = tooltip.to_tmp_for_borrow();
-            ffi::gtk_entry_set_icon_tooltip_text(GTK_ENTRY(self.unwrap_widget()), icon_pos, tmp_tooltip.to_glib_ptr())
+            ffi::gtk_entry_set_icon_tooltip_text(GTK_ENTRY(self.unwrap_widget()), icon_pos, tooltip.borrow_to_glib().0)
         }
     }
 
@@ -297,8 +292,7 @@ pub trait EntryTrait: gtk::WidgetTrait {
 
     fn set_icon_tooltip_markup(&mut self, icon_pos: EntryIconPosition, tooltip: &str) -> () {
         unsafe {
-            let mut tmp_tooltip = tooltip.to_tmp_for_borrow();
-            ffi::gtk_entry_set_icon_tooltip_markup(GTK_ENTRY(self.unwrap_widget()), icon_pos, tmp_tooltip.to_glib_ptr())
+            ffi::gtk_entry_set_icon_tooltip_markup(GTK_ENTRY(self.unwrap_widget()), icon_pos, tooltip.borrow_to_glib().0)
         }
     }
 

--- a/src/gtk/traits/file_chooser.rs
+++ b/src/gtk/traits/file_chooser.rs
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
+use libc::c_char;
 use glib::translate::{FromGlibPtr, FromGlibPtrContainer, ToGlibPtr};
 use gtk::{self, FFIWidget};
 use gtk::cast::GTK_FILE_CHOOSER;
@@ -117,7 +118,7 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
 
     fn get_filenames(&self) -> Vec<String> {
         unsafe {
-            FromGlibPtrContainer::take(
+            FromGlibPtrContainer::<*const c_char, _>::take(
                 ffi::gtk_file_chooser_get_filenames(GTK_FILE_CHOOSER(self.unwrap_widget())))
         }
     }
@@ -162,7 +163,7 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
 
     fn get_uris(&self) -> Vec<String> {
         unsafe {
-            FromGlibPtrContainer::take(
+            FromGlibPtrContainer::<*const c_char, _>::take(
                 ffi::gtk_file_chooser_get_uris(GTK_FILE_CHOOSER(self.unwrap_widget())))
         }
     }

--- a/src/gtk/traits/file_chooser.rs
+++ b/src/gtk/traits/file_chooser.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use glib::translate::{FromGlibPtr, FromGlibPtrContainer, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, FromGlibPtrContainer, ToGlibPtr};
 use gtk::{self, FFIWidget};
 use gtk::cast::GTK_FILE_CHOOSER;
 use gtk::ffi;
@@ -71,8 +71,7 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
 
     fn set_current_name(&self, name: &str) -> () {
         unsafe {
-            let mut tmp_name = name.to_tmp_for_borrow();
-            ffi::gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(self.unwrap_widget()), tmp_name.to_glib_ptr())
+            ffi::gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(self.unwrap_widget()), name.borrow_to_glib().0)
         }
     }
 
@@ -85,8 +84,7 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
 
     fn set_filename(&self, filename: &str) -> bool {
         unsafe {
-            let mut tmp_filename = filename.to_tmp_for_borrow();
-            to_bool(ffi::gtk_file_chooser_set_filename(GTK_FILE_CHOOSER(self.unwrap_widget()), tmp_filename.to_glib_ptr()))
+            to_bool(ffi::gtk_file_chooser_set_filename(GTK_FILE_CHOOSER(self.unwrap_widget()), filename.borrow_to_glib().0))
         }
     }
 
@@ -99,15 +97,13 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
 
     fn select_filename(&self, filename: &str) -> bool {
         unsafe {
-            let mut tmp_filename = filename.to_tmp_for_borrow();
-            to_bool(ffi::gtk_file_chooser_select_filename(GTK_FILE_CHOOSER(self.unwrap_widget()), tmp_filename.to_glib_ptr()))
+            to_bool(ffi::gtk_file_chooser_select_filename(GTK_FILE_CHOOSER(self.unwrap_widget()), filename.borrow_to_glib().0))
         }
     }
 
     fn unselect_filename(&self, filename: &str) -> () {
         unsafe {
-            let mut tmp_filename = filename.to_tmp_for_borrow();
-            ffi::gtk_file_chooser_unselect_filename(GTK_FILE_CHOOSER(self.unwrap_widget()), tmp_filename.to_glib_ptr())
+            ffi::gtk_file_chooser_unselect_filename(GTK_FILE_CHOOSER(self.unwrap_widget()), filename.borrow_to_glib().0)
         }
     }
 
@@ -128,8 +124,7 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
 
     fn set_current_folder(&self, filename: &str) -> bool {
         unsafe {
-            let mut tmp_filename = filename.to_tmp_for_borrow();
-            to_bool(ffi::gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(self.unwrap_widget()), tmp_filename.to_glib_ptr()))
+            to_bool(ffi::gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(self.unwrap_widget()), filename.borrow_to_glib().0))
         }
     }
 
@@ -142,8 +137,7 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
 
     fn set_uri(&self, uri: &str) -> bool {
         unsafe {
-            let mut tmp_uri = uri.to_tmp_for_borrow();
-            to_bool(ffi::gtk_file_chooser_set_uri(GTK_FILE_CHOOSER(self.unwrap_widget()), tmp_uri.to_glib_ptr()))
+            to_bool(ffi::gtk_file_chooser_set_uri(GTK_FILE_CHOOSER(self.unwrap_widget()), uri.borrow_to_glib().0))
         }
     }
 
@@ -156,15 +150,13 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
 
     fn select_uri(&self, uri: &str) -> bool {
         unsafe {
-            let mut tmp_uri = uri.to_tmp_for_borrow();
-            to_bool(ffi::gtk_file_chooser_select_uri(GTK_FILE_CHOOSER(self.unwrap_widget()), tmp_uri.to_glib_ptr()))
+            to_bool(ffi::gtk_file_chooser_select_uri(GTK_FILE_CHOOSER(self.unwrap_widget()), uri.borrow_to_glib().0))
         }
     }
 
     fn unselect_uri(&self, uri: &str) -> () {
         unsafe {
-            let mut tmp_uri = uri.to_tmp_for_borrow();
-            ffi::gtk_file_chooser_unselect_uri(GTK_FILE_CHOOSER(self.unwrap_widget()), tmp_uri.to_glib_ptr())
+            ffi::gtk_file_chooser_unselect_uri(GTK_FILE_CHOOSER(self.unwrap_widget()), uri.borrow_to_glib().0)
         }
     }
 
@@ -177,8 +169,7 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
 
     fn set_current_folder_uri(&self, uri: &str) -> bool {
         unsafe {
-            let mut tmp_uri = uri.to_tmp_for_borrow();
-            to_bool(ffi::gtk_file_chooser_set_current_folder_uri(GTK_FILE_CHOOSER(self.unwrap_widget()), tmp_uri.to_glib_ptr()))
+            to_bool(ffi::gtk_file_chooser_set_current_folder_uri(GTK_FILE_CHOOSER(self.unwrap_widget()), uri.borrow_to_glib().0))
         }
     }
 
@@ -271,29 +262,25 @@ pub trait FileChooserTrait: gtk::WidgetTrait {
 
     fn add_shortcut_folder(&self, folder: &str, error: &mut glib::Error) -> bool {
         unsafe {
-            let mut tmp_folder = folder.to_tmp_for_borrow();
-            to_bool(ffi::gtk_file_chooser_add_shortcut_folder(GTK_FILE_CHOOSER(self.unwrap_widget()), tmp_folder.to_glib_ptr(), &mut error.unwrap()))
+            to_bool(ffi::gtk_file_chooser_add_shortcut_folder(GTK_FILE_CHOOSER(self.unwrap_widget()), folder.borrow_to_glib().0, &mut error.unwrap()))
         }
     }
 
     fn remove_shortcut_folder(&self, folder: &str, error: &mut glib::Error) -> bool {
         unsafe {
-            let mut tmp_folder = folder.to_tmp_for_borrow();
-            to_bool(ffi::gtk_file_chooser_remove_shortcut_folder(GTK_FILE_CHOOSER(self.unwrap_widget()), tmp_folder.to_glib_ptr(), &mut error.unwrap()))
+            to_bool(ffi::gtk_file_chooser_remove_shortcut_folder(GTK_FILE_CHOOSER(self.unwrap_widget()), folder.borrow_to_glib().0, &mut error.unwrap()))
         }
     }
 
     fn add_shortcut_folder_uri(&self, uri: &str, error: &mut glib::Error) -> bool {
         unsafe {
-            let mut tmp_uri = uri.to_tmp_for_borrow();
-            to_bool(ffi::gtk_file_chooser_add_shortcut_folder(GTK_FILE_CHOOSER(self.unwrap_widget()), tmp_uri.to_glib_ptr(), &mut error.unwrap()))
+            to_bool(ffi::gtk_file_chooser_add_shortcut_folder(GTK_FILE_CHOOSER(self.unwrap_widget()), uri.borrow_to_glib().0, &mut error.unwrap()))
         }
     }
 
     fn remove_shortcut_folder_uri(&self, uri: &str, error: &mut glib::Error) -> bool {
         unsafe {
-            let mut tmp_uri = uri.to_tmp_for_borrow();
-            to_bool(ffi::gtk_file_chooser_remove_shortcut_folder(GTK_FILE_CHOOSER(self.unwrap_widget()), tmp_uri.to_glib_ptr(), &mut error.unwrap()))
+            to_bool(ffi::gtk_file_chooser_remove_shortcut_folder(GTK_FILE_CHOOSER(self.unwrap_widget()), uri.borrow_to_glib().0, &mut error.unwrap()))
         }
     }
 }

--- a/src/gtk/traits/font_chooser.rs
+++ b/src/gtk/traits/font_chooser.rs
@@ -18,7 +18,6 @@ use gtk::cast::{GTK_FONT_CHOOSER};
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
 use gtk::FFIWidget;
-use libc::c_char;
 
 pub trait FontChooserTrait: gtk::WidgetTrait {
     fn get_font_size(&self) -> i32 {
@@ -28,7 +27,7 @@ pub trait FontChooserTrait: gtk::WidgetTrait {
     fn get_font(&self) -> Option<String> {
         unsafe {
             FromGlibPtr::borrow(
-                ffi::gtk_font_chooser_get_font(GTK_FONT_CHOOSER(self.unwrap_widget())) as *const c_char)
+                ffi::gtk_font_chooser_get_font(GTK_FONT_CHOOSER(self.unwrap_widget())))
         }
     }
 
@@ -41,8 +40,7 @@ pub trait FontChooserTrait: gtk::WidgetTrait {
     fn get_preview_text(&self) -> Option<String> {
         unsafe {
             FromGlibPtr::borrow(
-                ffi::gtk_font_chooser_get_preview_text(GTK_FONT_CHOOSER(self.unwrap_widget()))
-                    as *const c_char)
+                ffi::gtk_font_chooser_get_preview_text(GTK_FONT_CHOOSER(self.unwrap_widget())))
         }
     }
 

--- a/src/gtk/traits/font_chooser.rs
+++ b/src/gtk/traits/font_chooser.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 use gtk::cast::{GTK_FONT_CHOOSER};
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
@@ -34,8 +34,7 @@ pub trait FontChooserTrait: gtk::WidgetTrait {
 
     fn set_font(&self, font_name: &str) {
         unsafe {
-            let mut tmp_font_name = font_name.to_tmp_for_borrow();
-            ffi::gtk_font_chooser_set_font(GTK_FONT_CHOOSER(self.unwrap_widget()), tmp_font_name.to_glib_ptr() as *mut c_char)
+            ffi::gtk_font_chooser_set_font(GTK_FONT_CHOOSER(self.unwrap_widget()), font_name.borrow_to_glib().0)
         }
     }
 
@@ -49,8 +48,7 @@ pub trait FontChooserTrait: gtk::WidgetTrait {
 
     fn set_preview_text(&self, text: &str) {
         unsafe {
-            let mut tmp_text = text.to_tmp_for_borrow();
-            ffi::gtk_font_chooser_set_preview_text(GTK_FONT_CHOOSER(self.unwrap_widget()), tmp_text.to_glib_ptr())
+            ffi::gtk_font_chooser_set_preview_text(GTK_FONT_CHOOSER(self.unwrap_widget()), text.borrow_to_glib().0)
         }
     }
 

--- a/src/gtk/traits/frame.rs
+++ b/src/gtk/traits/frame.rs
@@ -15,7 +15,7 @@
 
 use libc::c_float;
 
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 use gtk::ShadowType;
 use gtk::cast::GTK_FRAME;
 use gtk::{self, ffi};
@@ -23,9 +23,8 @@ use gtk::{self, ffi};
 pub trait FrameTrait: gtk::WidgetTrait + gtk::ContainerTrait {
     fn set_label(&mut self, label: Option<&str>) -> () {
         unsafe {
-            let mut tmp_label = label.to_tmp_for_borrow();
             ffi::gtk_frame_set_label(GTK_FRAME(self.unwrap_widget()),
-                                     tmp_label.to_glib_ptr());
+                                     label.borrow_to_glib().0);
         }
     }
 

--- a/src/gtk/traits/label.rs
+++ b/src/gtk/traits/label.rs
@@ -14,7 +14,7 @@
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
 use libc::{c_int, c_double};
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
@@ -24,15 +24,13 @@ use gtk::cast::GTK_LABEL;
 pub trait LabelTrait: gtk::WidgetTrait {
     fn set_label(&mut self, text: &str) -> () {
         unsafe {
-            let mut tmp_text = text.to_tmp_for_borrow();
-            ffi::gtk_label_set_label(GTK_LABEL(self.unwrap_widget()), tmp_text.to_glib_ptr())
+            ffi::gtk_label_set_label(GTK_LABEL(self.unwrap_widget()), text.borrow_to_glib().0)
         }
     }
 
     fn set_text(&mut self, text: &str) -> () {
         unsafe {
-            let mut tmp_text = text.to_tmp_for_borrow();
-	    ffi::gtk_label_set_text(GTK_LABEL(self.unwrap_widget()), tmp_text.to_glib_ptr())
+	    ffi::gtk_label_set_text(GTK_LABEL(self.unwrap_widget()), text.borrow_to_glib().0)
         }
     }
 
@@ -44,29 +42,25 @@ pub trait LabelTrait: gtk::WidgetTrait {
 
     fn set_markup(&mut self, text: &str) -> () {
         unsafe {
-            let mut tmp_text = text.to_tmp_for_borrow();
-            ffi::gtk_label_set_markup(GTK_LABEL(self.unwrap_widget()), tmp_text.to_glib_ptr())
+            ffi::gtk_label_set_markup(GTK_LABEL(self.unwrap_widget()), text.borrow_to_glib().0)
         }
     }
 
     fn set_markup_with_mnemonic(&mut self, text: &str) -> () {
         unsafe {
-            let mut tmp_text = text.to_tmp_for_borrow();
-            ffi::gtk_label_set_markup_with_mnemonic(GTK_LABEL(self.unwrap_widget()), tmp_text.to_glib_ptr())
+            ffi::gtk_label_set_markup_with_mnemonic(GTK_LABEL(self.unwrap_widget()), text.borrow_to_glib().0)
         }
     }
 
     fn set_pattern(&mut self, text: &str) -> () {
         unsafe {
-            let mut tmp_text = text.to_tmp_for_borrow();
-            ffi::gtk_label_set_pattern(GTK_LABEL(self.unwrap_widget()), tmp_text.to_glib_ptr())
+            ffi::gtk_label_set_pattern(GTK_LABEL(self.unwrap_widget()), text.borrow_to_glib().0)
         }
     }
 
     fn set_text_with_mnemonic(&mut self, text: &str) -> () {
         unsafe {
-            let mut tmp_text = text.to_tmp_for_borrow();
-            ffi::gtk_label_set_text_with_mnemonic(GTK_LABEL(self.unwrap_widget()), tmp_text.to_glib_ptr());
+            ffi::gtk_label_set_text_with_mnemonic(GTK_LABEL(self.unwrap_widget()), text.borrow_to_glib().0);
         }
     }
 

--- a/src/gtk/traits/menu_item.rs
+++ b/src/gtk/traits/menu_item.rs
@@ -15,7 +15,7 @@
 
 //! The widget used for item in menus
 
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 use gtk::{self, ffi};
 use gtk::cast::GTK_MENU_ITEM;
 use glib::{to_bool, to_gboolean};
@@ -55,8 +55,7 @@ pub trait MenuItemTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrait 
 
     fn set_accel_path(&mut self, accel_path: &str) {
         unsafe {
-            let mut tmp_accel_path = accel_path.to_tmp_for_borrow();
-            ffi::gtk_menu_item_set_accel_path(GTK_MENU_ITEM(self.unwrap_widget()), tmp_accel_path.to_glib_ptr())
+            ffi::gtk_menu_item_set_accel_path(GTK_MENU_ITEM(self.unwrap_widget()), accel_path.borrow_to_glib().0)
         }
     }
 
@@ -69,9 +68,8 @@ pub trait MenuItemTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrait 
 
     fn set_label(&mut self, label: &str) {
         unsafe {
-            let mut tmp_label = label.to_tmp_for_borrow();
             ffi::gtk_menu_item_set_label(GTK_MENU_ITEM(self.unwrap_widget()),
-                                         tmp_label.to_glib_ptr())
+                                         label.borrow_to_glib().0)
         }
     }
 

--- a/src/gtk/traits/recent_chooser.rs
+++ b/src/gtk/traits/recent_chooser.rs
@@ -89,8 +89,7 @@ pub trait RecentChooserTrait: gtk::WidgetTrait + FFIWidget {
     fn get_current_uri(&self) -> Option<String> {
         unsafe {
             FromGlibPtr::borrow(
-                ffi::gtk_recent_chooser_get_current_uri(GTK_RECENT_CHOOSER(self.unwrap_widget()))
-                    as *const c_char)
+                ffi::gtk_recent_chooser_get_current_uri(GTK_RECENT_CHOOSER(self.unwrap_widget())))
         }
     }
 

--- a/src/gtk/traits/recent_chooser.rs
+++ b/src/gtk/traits/recent_chooser.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use glib::translate::{FromGlibPtr, FromGlibPtrContainer, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, FromGlibPtrContainer, ToGlibPtr};
 use gtk::cast::{GTK_RECENT_CHOOSER};
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
@@ -106,8 +106,7 @@ pub trait RecentChooserTrait: gtk::WidgetTrait + FFIWidget {
 
     fn unselect_uri(&self, uri: &str) -> bool {
         unsafe {
-            let mut tmp_uri = uri.to_tmp_for_borrow();
-            to_bool(ffi::gtk_recent_chooser_unselect_uri(GTK_RECENT_CHOOSER(self.unwrap_widget()), tmp_uri.to_glib_ptr()))
+            to_bool(ffi::gtk_recent_chooser_unselect_uri(GTK_RECENT_CHOOSER(self.unwrap_widget()), uri.borrow_to_glib().0))
         }
     }
 

--- a/src/gtk/traits/text_buffer.rs
+++ b/src/gtk/traits/text_buffer.rs
@@ -13,15 +13,14 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 use gtk::{self, ffi};
 use gtk::cast::GTK_TEXT_BUFFER;
 
 pub trait TextBufferTrait: gtk::WidgetTrait {
     fn set_text(&self, text: String) {
         unsafe {
-            let mut tmp_text = text.to_tmp_for_borrow();
-            ffi::gtk_text_buffer_set_text(GTK_TEXT_BUFFER(self.unwrap_widget()), tmp_text.to_glib_ptr(), text.len() as i32)
+            ffi::gtk_text_buffer_set_text(GTK_TEXT_BUFFER(self.unwrap_widget()), text.borrow_to_glib().0, text.len() as i32)
         }
     }
 

--- a/src/gtk/traits/tool_button.rs
+++ b/src/gtk/traits/tool_button.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 use gtk::cast::GTK_TOOLBUTTON;
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
@@ -21,23 +21,20 @@ use glib::{to_bool, to_gboolean};
 pub trait ToolButtonTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrait + gtk::ToolItemTrait {
     fn set_label(&mut self, label: &str) -> () {
         unsafe {
-            let mut tmp_label = label.to_tmp_for_borrow();
-            ffi::gtk_tool_button_set_label(GTK_TOOLBUTTON(self.unwrap_widget()), tmp_label.to_glib_ptr())
+            ffi::gtk_tool_button_set_label(GTK_TOOLBUTTON(self.unwrap_widget()), label.borrow_to_glib().0)
         }
     }
 
     fn set_stock_id(&mut self, stock_id: &str) -> () {
         unsafe {
-            let mut tmp_stock_id = stock_id.to_tmp_for_borrow();
-            ffi::gtk_tool_button_set_stock_id(GTK_TOOLBUTTON(self.unwrap_widget()), tmp_stock_id.to_glib_ptr())
+            ffi::gtk_tool_button_set_stock_id(GTK_TOOLBUTTON(self.unwrap_widget()), stock_id.borrow_to_glib().0)
         }
     }
 
     fn set_icon_name(&mut self, icon_name: &str) -> () {
         unsafe {
-            let mut tmp_icon_name = icon_name.to_tmp_for_borrow();
             ffi::gtk_tool_button_set_icon_name(GTK_TOOLBUTTON(self.unwrap_widget()),
-                                               tmp_icon_name.to_glib_ptr());
+                                               icon_name.borrow_to_glib().0);
         }
     }
 

--- a/src/gtk/traits/tool_item.rs
+++ b/src/gtk/traits/tool_item.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
 use gtk::cast::GTK_TOOLITEM;
@@ -70,16 +70,14 @@ pub trait ToolItemTrait: gtk::WidgetTrait + gtk::ContainerTrait + gtk::BinTrait 
 
     fn set_tooltip_text(&mut self, text: &str) -> () {
         unsafe {
-            let mut tmp_text = text.to_tmp_for_borrow();
             ffi::gtk_tool_item_set_tooltip_text(GTK_TOOLITEM(self.unwrap_widget()),
-                                                tmp_text.to_glib_ptr())
+                                                text.borrow_to_glib().0)
         }
     }
 
     fn set_tooltip_markup(&mut self, markup: &str) -> () {
         unsafe {
-            let mut tmp_markup = markup.to_tmp_for_borrow();
-            ffi::gtk_tool_item_set_tooltip_markup(GTK_TOOLITEM(self.unwrap_widget()), tmp_markup.to_glib_ptr())
+            ffi::gtk_tool_item_set_tooltip_markup(GTK_TOOLITEM(self.unwrap_widget()), markup.borrow_to_glib().0)
         }
     }
 

--- a/src/gtk/traits/widget.rs
+++ b/src/gtk/traits/widget.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use libc::{c_int, c_char};
+use libc::c_int;
 use glib::translate::{FromGlibPtr, ToGlibPtr};
 use gtk::ffi;
 use glib::{to_bool, to_gboolean};
@@ -307,8 +307,7 @@ pub trait WidgetTrait: gtk::FFIWidget + gtk::GObjectTrait {
     fn get_tooltip_markup(&self) -> Option<String> {
         unsafe {
             FromGlibPtr::take(
-                ffi::gtk_widget_get_tooltip_markup(self.unwrap_widget())
-                    as *const c_char)
+                ffi::gtk_widget_get_tooltip_markup(self.unwrap_widget()))
         }
     }
 
@@ -322,8 +321,7 @@ pub trait WidgetTrait: gtk::FFIWidget + gtk::GObjectTrait {
     fn get_tooltip_text(&self) -> Option<String> {
         unsafe {
             FromGlibPtr::take(
-                ffi::gtk_widget_get_tooltip_text(self.unwrap_widget())
-                    as *const c_char)
+                ffi::gtk_widget_get_tooltip_text(self.unwrap_widget()))
         }
     }
 

--- a/src/gtk/traits/widget.rs
+++ b/src/gtk/traits/widget.rs
@@ -14,7 +14,7 @@
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
 use libc::{c_int, c_char};
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 use gtk::ffi;
 use glib::{to_bool, to_gboolean};
 use gdk;
@@ -91,8 +91,7 @@ pub trait WidgetTrait: gtk::FFIWidget + gtk::GObjectTrait {
     }
 
     fn set_name(&self, name: &str) {
-        let mut tmp_name = name.to_tmp_for_borrow();
-        unsafe { ffi::gtk_widget_set_name(self.unwrap_widget(), tmp_name.to_glib_ptr()) }
+        unsafe { ffi::gtk_widget_set_name(self.unwrap_widget(), name.borrow_to_glib().0) }
     }
 
     fn get_name(&self) -> Option<String> {
@@ -188,8 +187,7 @@ pub trait WidgetTrait: gtk::FFIWidget + gtk::GObjectTrait {
     }
 
     fn override_symbolic_color(&self, name: &str, color: &gdk_ffi::C_GdkRGBA) {
-        let mut tmp_name = name.to_tmp_for_borrow();
-        unsafe { ffi::gtk_widget_override_symbolic_color(self.unwrap_widget(), tmp_name.to_glib_ptr(), color); }
+        unsafe { ffi::gtk_widget_override_symbolic_color(self.unwrap_widget(), name.borrow_to_glib().0, color); }
     }
 
     fn override_cursor(&self, cursor: &gdk_ffi::C_GdkRGBA, secondary_cursor: &gdk_ffi::C_GdkRGBA) {
@@ -316,8 +314,7 @@ pub trait WidgetTrait: gtk::FFIWidget + gtk::GObjectTrait {
 
     fn set_tooltip_markup(&self, markup: &str) {
         unsafe {
-            let mut tmp_markup = markup.to_tmp_for_borrow();
-            ffi::gtk_widget_set_tooltip_markup(self.unwrap_widget(), tmp_markup.to_glib_ptr() as *mut c_char);
+            ffi::gtk_widget_set_tooltip_markup(self.unwrap_widget(), markup.borrow_to_glib().0);
         }
     }
 
@@ -332,8 +329,7 @@ pub trait WidgetTrait: gtk::FFIWidget + gtk::GObjectTrait {
 
     fn set_tooltip_text(&self, text: &str) {
         unsafe {
-            let mut tmp_text = text.to_tmp_for_borrow();
-            ffi::gtk_widget_set_tooltip_text(self.unwrap_widget(), tmp_text.to_glib_ptr() as *mut c_char);
+            ffi::gtk_widget_set_tooltip_text(self.unwrap_widget(), text.borrow_to_glib().0);
         }
     }
 
@@ -663,8 +659,7 @@ pub trait WidgetTrait: gtk::FFIWidget + gtk::GObjectTrait {
 
     fn child_notify(&self, child_property: &str) {
         unsafe {
-            let mut tmp_child_property = child_property.to_tmp_for_borrow();
-            ffi::gtk_widget_child_notify(self.unwrap_widget(), tmp_child_property.to_glib_ptr())
+            ffi::gtk_widget_child_notify(self.unwrap_widget(), child_property.borrow_to_glib().0)
         }
     }
 

--- a/src/gtk/traits/window.rs
+++ b/src/gtk/traits/window.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 use gtk::{self, ffi};
 use glib::to_gboolean;
 use gtk::cast::GTK_WINDOW;
@@ -22,8 +22,7 @@ use gtk::WindowPosition;
 pub trait WindowTrait : gtk::WidgetTrait {
     fn set_title(&mut self, title: &str) -> () {
         unsafe {
-            let mut tmp_title = title.to_tmp_for_borrow();
-            ffi::gtk_window_set_title(GTK_WINDOW(self.unwrap_widget()), tmp_title.to_glib_ptr());
+            ffi::gtk_window_set_title(GTK_WINDOW(self.unwrap_widget()), title.borrow_to_glib().0);
         }
     }
 

--- a/src/gtk/widgets/about_dialog.rs
+++ b/src/gtk/widgets/about_dialog.rs
@@ -18,7 +18,7 @@ use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
 use gtk::FFIWidget;
 use gtk::cast::GTK_ABOUT_DIALOG;
-use glib::translate::{FromGlibPtr, FromGlibPtrContainer, ToGlibPtr, ToTmp, ToArray};
+use glib::translate::{FromGlibPtr, FromGlibPtrContainer, ToGlibPtr};
 
 struct_Widget!(AboutDialog);
 
@@ -42,8 +42,7 @@ impl AboutDialog {
 
     pub fn set_program_name(&self, name: &str) -> () {
         unsafe {
-            let mut tmp_name = name.to_tmp_for_borrow();
-            ffi::gtk_about_dialog_set_program_name(GTK_ABOUT_DIALOG(self.unwrap_widget()), tmp_name.to_glib_ptr())
+            ffi::gtk_about_dialog_set_program_name(GTK_ABOUT_DIALOG(self.unwrap_widget()), name.borrow_to_glib().0)
         };
     }
 
@@ -56,8 +55,7 @@ impl AboutDialog {
 
     pub fn set_version(&self, version: &str) -> () {
         unsafe {
-            let mut tmp_version = version.to_tmp_for_borrow();
-            ffi::gtk_about_dialog_set_version(GTK_ABOUT_DIALOG(self.unwrap_widget()), tmp_version.to_glib_ptr())
+            ffi::gtk_about_dialog_set_version(GTK_ABOUT_DIALOG(self.unwrap_widget()), version.borrow_to_glib().0)
         };
     }
 
@@ -70,8 +68,7 @@ impl AboutDialog {
 
     pub fn set_copyright(&self, copyright: &str) -> () {
         unsafe {
-            let mut tmp_copyright = copyright.to_tmp_for_borrow();
-            ffi::gtk_about_dialog_set_copyright(GTK_ABOUT_DIALOG(self.unwrap_widget()), tmp_copyright.to_glib_ptr())
+            ffi::gtk_about_dialog_set_copyright(GTK_ABOUT_DIALOG(self.unwrap_widget()), copyright.borrow_to_glib().0)
         };
     }
 
@@ -84,8 +81,7 @@ impl AboutDialog {
 
     pub fn set_comments(&self, comments: &str) -> () {
         unsafe {
-            let mut tmp_comments = comments.to_tmp_for_borrow();
-            ffi::gtk_about_dialog_set_comments(GTK_ABOUT_DIALOG(self.unwrap_widget()), tmp_comments.to_glib_ptr())
+            ffi::gtk_about_dialog_set_comments(GTK_ABOUT_DIALOG(self.unwrap_widget()), comments.borrow_to_glib().0)
         };
     }
 
@@ -98,8 +94,7 @@ impl AboutDialog {
 
     pub fn set_license(&self, license: &str) -> () {
         unsafe {
-            let mut tmp_license = license.to_tmp_for_borrow();
-            ffi::gtk_about_dialog_set_license(GTK_ABOUT_DIALOG(self.unwrap_widget()), tmp_license.to_glib_ptr())
+            ffi::gtk_about_dialog_set_license(GTK_ABOUT_DIALOG(self.unwrap_widget()), license.borrow_to_glib().0)
         };
     }
 
@@ -128,8 +123,7 @@ impl AboutDialog {
 
     pub fn set_website(&self, website: &str) -> () {
         unsafe {
-            let mut tmp_website = website.to_tmp_for_borrow();
-            ffi::gtk_about_dialog_set_website(GTK_ABOUT_DIALOG(self.unwrap_widget()), tmp_website.to_glib_ptr())
+            ffi::gtk_about_dialog_set_website(GTK_ABOUT_DIALOG(self.unwrap_widget()), website.borrow_to_glib().0)
         };
     }
 
@@ -142,8 +136,7 @@ impl AboutDialog {
 
     pub fn set_website_label(&self, website_label: &str) -> () {
         unsafe {
-            let mut tmp_website_label = website_label.to_tmp_for_borrow();
-            ffi::gtk_about_dialog_set_website_label(GTK_ABOUT_DIALOG(self.unwrap_widget()), tmp_website_label.to_glib_ptr())
+            ffi::gtk_about_dialog_set_website_label(GTK_ABOUT_DIALOG(self.unwrap_widget()), website_label.borrow_to_glib().0)
         };
     }
 
@@ -157,10 +150,9 @@ impl AboutDialog {
     pub fn set_authors<'a, S, I: ?Sized>(&self, authors: &'a I)
     where S: Str, &'a I: IntoIterator<Item = &'a S> {
         unsafe {
-            let mut tmp_authors = authors.to_array_for_borrow();
             ffi::gtk_about_dialog_set_authors(
                 GTK_ABOUT_DIALOG(self.unwrap_widget()),
-                tmp_authors.to_glib_ptr());
+                authors.borrow_to_glib().0);
         }
     }
 
@@ -174,10 +166,9 @@ impl AboutDialog {
     pub fn set_artists<'a, S, I: ?Sized>(&self, artists: &'a I)
     where S: Str, &'a I: IntoIterator<Item = &'a S> {
         unsafe {
-            let mut tmp_artists = artists.to_array_for_borrow();
             ffi::gtk_about_dialog_set_artists(
                 GTK_ABOUT_DIALOG(self.unwrap_widget()),
-                tmp_artists.to_glib_ptr());
+                artists.borrow_to_glib().0);
         }
     }
 
@@ -191,10 +182,9 @@ impl AboutDialog {
     pub fn set_documenters<'a, S, I: ?Sized>(&self, documenters: &'a I)
     where S: Str, &'a I: IntoIterator<Item = &'a S> {
         unsafe {
-            let mut tmp_documenters = documenters.to_array_for_borrow();
             ffi::gtk_about_dialog_set_documenters(
                 GTK_ABOUT_DIALOG(self.unwrap_widget()),
-                tmp_documenters.to_glib_ptr());
+                documenters.borrow_to_glib().0);
         }
     }
 
@@ -207,10 +197,9 @@ impl AboutDialog {
 
     pub fn set_translator_credits(&self, translator_credits: &str) -> () {
         unsafe {
-            let mut tmp_translator_credits = translator_credits.to_tmp_for_borrow();
             ffi::gtk_about_dialog_set_translator_credits(
                 GTK_ABOUT_DIALOG(self.unwrap_widget()),
-                tmp_translator_credits.to_glib_ptr())
+                translator_credits.borrow_to_glib().0)
         };
     }
 
@@ -237,23 +226,19 @@ impl AboutDialog {
 
     pub fn set_logo_icon_name(&self, logo_icon_name: &str) -> () {
         unsafe {
-            let mut tmp_logo_icon_name = logo_icon_name.to_tmp_for_borrow();
             ffi::gtk_about_dialog_set_logo_icon_name(
                 GTK_ABOUT_DIALOG(self.unwrap_widget()),
-                tmp_logo_icon_name.to_glib_ptr())
+                logo_icon_name.borrow_to_glib().0)
         };
     }
 
     pub fn add_credit_section<'a, S, I: ?Sized>(&self, section_name: &str, people: &'a I)
     where S: Str, &'a I: IntoIterator<Item = &'a S> {
         unsafe {
-            let mut tmp_section_name = section_name.to_tmp_for_borrow();
-            let mut tmp_people = people.to_array_for_borrow();
-
             ffi::gtk_about_dialog_add_credit_section(
                 GTK_ABOUT_DIALOG(self.unwrap_widget()),
-                tmp_section_name.to_glib_ptr(),
-                tmp_people.to_glib_ptr())
+                section_name.borrow_to_glib().0,
+                people.borrow_to_glib().0)
         }
     }
 

--- a/src/gtk/widgets/about_dialog.rs
+++ b/src/gtk/widgets/about_dialog.rs
@@ -154,8 +154,8 @@ impl AboutDialog {
         }
     }
 
-    pub fn set_authors<'a, S, I>(&self, authors: I)
-    where S: Str, I: IntoIterator<Item = &'a S> {
+    pub fn set_authors<'a, S, I: ?Sized>(&self, authors: &'a I)
+    where S: Str, &'a I: IntoIterator<Item = &'a S> {
         unsafe {
             let mut tmp_authors = authors.to_array_for_borrow();
             ffi::gtk_about_dialog_set_authors(
@@ -171,8 +171,8 @@ impl AboutDialog {
         }
     }
 
-    pub fn set_artists<'a, S, I>(&self, artists: I)
-    where S: Str, I: IntoIterator<Item = &'a S> {
+    pub fn set_artists<'a, S, I: ?Sized>(&self, artists: &'a I)
+    where S: Str, &'a I: IntoIterator<Item = &'a S> {
         unsafe {
             let mut tmp_artists = artists.to_array_for_borrow();
             ffi::gtk_about_dialog_set_artists(
@@ -188,8 +188,8 @@ impl AboutDialog {
         }
     }
 
-    pub fn set_documenters<'a, S, I>(&self, documenters: I)
-    where S: Str, I: IntoIterator<Item = &'a S> {
+    pub fn set_documenters<'a, S, I: ?Sized>(&self, documenters: &'a I)
+    where S: Str, &'a I: IntoIterator<Item = &'a S> {
         unsafe {
             let mut tmp_documenters = documenters.to_array_for_borrow();
             ffi::gtk_about_dialog_set_documenters(
@@ -244,8 +244,8 @@ impl AboutDialog {
         };
     }
 
-    pub fn add_credit_section<'a, S, I>(&self, section_name: &str, people: I)
-    where S: Str, I: IntoIterator<Item = &'a S> {
+    pub fn add_credit_section<'a, S, I: ?Sized>(&self, section_name: &str, people: &'a I)
+    where S: Str, &'a I: IntoIterator<Item = &'a S> {
         unsafe {
             let mut tmp_section_name = section_name.to_tmp_for_borrow();
             let mut tmp_people = people.to_array_for_borrow();

--- a/src/gtk/widgets/app_chooser_dialog.rs
+++ b/src/gtk/widgets/app_chooser_dialog.rs
@@ -16,7 +16,7 @@
 use gtk::{self, ffi};
 use gtk::FFIWidget;
 use gtk::cast::{GTK_WINDOW, GTK_APP_CHOOSER_DIALOG};
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 
 struct_Widget!(AppChooserDialog);
 
@@ -27,10 +27,9 @@ impl AppChooserDialog {
                 Some(ref p) => GTK_WINDOW(p.unwrap_widget()),
                 None => ::std::ptr::null_mut()
             };
-            let mut tmp_content_type = content_type.to_tmp_for_borrow();
 
             ffi::gtk_app_chooser_dialog_new_for_content_type(parent, flags,
-                                                             tmp_content_type.to_glib_ptr())
+                                                             content_type.borrow_to_glib().0)
         };
 
         if tmp_pointer.is_null() {
@@ -52,8 +51,7 @@ impl AppChooserDialog {
 
     pub fn set_heading(&self, heading: &str) -> () {
         unsafe {
-            let mut tmp_heading = heading.to_tmp_for_borrow();
-            ffi::gtk_app_chooser_dialog_set_heading(GTK_APP_CHOOSER_DIALOG(self.unwrap_widget()), tmp_heading.to_glib_ptr())
+            ffi::gtk_app_chooser_dialog_set_heading(GTK_APP_CHOOSER_DIALOG(self.unwrap_widget()), heading.borrow_to_glib().0)
         }
     }
 

--- a/src/gtk/widgets/app_chooser_widget.rs
+++ b/src/gtk/widgets/app_chooser_widget.rs
@@ -17,7 +17,7 @@
 
 use gtk::cast::GTK_APP_CHOOSER_WIDGET;
 use gtk::{self, ffi};
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 use glib::{to_bool, to_gboolean};
 
 struct_Widget!(AppChooserWidget);
@@ -25,8 +25,7 @@ struct_Widget!(AppChooserWidget);
 impl AppChooserWidget {
     pub fn new(content_type: &str) -> Option<AppChooserWidget> {
         let tmp_pointer = unsafe {
-            let mut tmp_content_type = content_type.to_tmp_for_borrow();
-            ffi::gtk_app_chooser_widget_new(tmp_content_type.to_glib_ptr())
+            ffi::gtk_app_chooser_widget_new(content_type.borrow_to_glib().0)
         };
         check_pointer!(tmp_pointer, AppChooserWidget)
     }
@@ -83,8 +82,7 @@ impl AppChooserWidget {
 
     pub fn set_default_text(&self, text: &str) {
         unsafe {
-            let mut tmp_text = text.to_tmp_for_borrow();
-            ffi::gtk_app_chooser_widget_set_default_text(GTK_APP_CHOOSER_WIDGET(self.pointer), tmp_text.to_glib_ptr())
+            ffi::gtk_app_chooser_widget_set_default_text(GTK_APP_CHOOSER_WIDGET(self.pointer), text.borrow_to_glib().0)
         }
     }
 

--- a/src/gtk/widgets/aspect_frame.rs
+++ b/src/gtk/widgets/aspect_frame.rs
@@ -17,7 +17,7 @@
 
 use libc::c_float;
 
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 use gtk::cast::GTK_ASPECTFRAME;
 use gtk::{self, ffi};
 use glib::to_gboolean;
@@ -28,8 +28,7 @@ struct_Widget!(AspectFrame);
 impl AspectFrame {
     pub fn new(label: Option<&str>, x_align: f32, y_align: f32, ratio: f32, obey_child: bool) -> Option<AspectFrame> {
         let tmp_pointer = unsafe {
-            let mut tmp_label = label.to_tmp_for_borrow();
-            ffi::gtk_aspect_frame_new(tmp_label.to_glib_ptr(),
+            ffi::gtk_aspect_frame_new(label.borrow_to_glib().0,
                                       x_align as c_float, y_align as c_float,
                                       ratio as c_float, to_gboolean(obey_child))
         };

--- a/src/gtk/widgets/builder.rs
+++ b/src/gtk/widgets/builder.rs
@@ -16,7 +16,7 @@
 use gtk::ffi::{self, C_GtkBuilder};
 use libc::{c_char, c_long};
 use gtk::traits::GObjectTrait;
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 
 #[repr(C)]
 #[derive(Copy)]
@@ -39,8 +39,7 @@ impl Builder {
 
     pub fn new_from_file(file_name: &str) -> Option<Builder> {
         let tmp = unsafe {
-            let mut tmp_file_name = file_name.to_tmp_for_borrow();
-            ffi::gtk_builder_new_from_file(tmp_file_name.to_glib_ptr())
+            ffi::gtk_builder_new_from_file(file_name.borrow_to_glib().0)
         };
 
         if tmp.is_null() {
@@ -54,8 +53,7 @@ impl Builder {
 
     pub fn new_from_resource(resource_path: &str) -> Option<Builder> {
         let tmp = unsafe {
-            let mut tmp_resource_path = resource_path.to_tmp_for_borrow();
-            ffi::gtk_builder_new_from_resource(tmp_resource_path.to_glib_ptr())
+            ffi::gtk_builder_new_from_resource(resource_path.borrow_to_glib().0)
         };
 
         if tmp.is_null() {
@@ -85,8 +83,7 @@ impl Builder {
 
     pub fn get_object<T: GObjectTrait>(&self, name: &str) -> Option<T> {
         let tmp = unsafe {
-            let mut tmp_name = name.to_tmp_for_borrow();
-            ffi::gtk_builder_get_object(self.pointer, tmp_name.to_glib_ptr())
+            ffi::gtk_builder_get_object(self.pointer, name.borrow_to_glib().0)
         };
 
         if tmp.is_null() {

--- a/src/gtk/widgets/button.rs
+++ b/src/gtk/widgets/button.rs
@@ -16,7 +16,7 @@
 //! A widget that emits a signal when clicked on
 
 use gtk::{self, ffi};
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 #[cfg(any(feature = "GTK_3_10",feature = "GTK_3_12", feature = "GTK_3_14"))]
 use gtk::IconSize;
 
@@ -42,16 +42,14 @@ impl Button {
 
     pub fn new_with_label(label: &str) -> Option<Button> {
         let tmp_pointer = unsafe {
-            let mut tmp_label = label.to_tmp_for_borrow();
-            ffi::gtk_button_new_with_label(tmp_label.to_glib_ptr())
+            ffi::gtk_button_new_with_label(label.borrow_to_glib().0)
         };
         check_pointer!(tmp_pointer, Button)
     }
 
     pub fn new_with_mnemonic(mnemonic: &str) -> Option<Button> {
         let tmp_pointer = unsafe {
-            let mut tmp_mnemonic = mnemonic.to_tmp_for_borrow();
-            ffi::gtk_button_new_with_mnemonic(tmp_mnemonic.to_glib_ptr())
+            ffi::gtk_button_new_with_mnemonic(mnemonic.borrow_to_glib().0)
         };
         check_pointer!(tmp_pointer, Button)
     }
@@ -59,16 +57,14 @@ impl Button {
     #[cfg(any(feature = "GTK_3_10",feature = "GTK_3_12", feature = "GTK_3_14"))]
     pub fn new_from_icon_name(icon_name: &str, size: IconSize) -> Option<Button> {
         let tmp_pointer = unsafe {
-            let mut tmp_icon_name = icon_name.to_tmp_for_borrow();
-            ffi::gtk_button_new_from_icon_name(tmp_icon_name.to_glib_ptr(), size)
+            ffi::gtk_button_new_from_icon_name(icon_name.borrow_to_glib().0, size)
         };
         check_pointer!(tmp_pointer, Button)
     }
 
     pub fn new_from_stock(stock_id: &str) -> Option<Button> {
         let tmp_pointer = unsafe {
-            let mut tmp_stock_id = stock_id.to_tmp_for_borrow();
-            ffi::gtk_button_new_from_stock(tmp_stock_id.to_glib_ptr())
+            ffi::gtk_button_new_from_stock(stock_id.borrow_to_glib().0)
         };
         check_pointer!(tmp_pointer, Button)
     }

--- a/src/gtk/widgets/check_button.rs
+++ b/src/gtk/widgets/check_button.rs
@@ -15,7 +15,7 @@
 
 //! Create widgets with a discrete toggle button
 
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 use gtk::{self, ffi};
 
 /// CheckButton — Create widgets with a discrete toggle button
@@ -29,16 +29,14 @@ impl CheckButton {
 
     pub fn new_with_label(label: &str) -> Option<CheckButton> {
         let tmp_pointer = unsafe {
-            let mut tmp_label = label.to_tmp_for_borrow();
-            ffi::gtk_check_button_new_with_label(tmp_label.to_glib_ptr())
+            ffi::gtk_check_button_new_with_label(label.borrow_to_glib().0)
         };
         check_pointer!(tmp_pointer, CheckButton)
     }
 
     pub fn new_with_mnemonic(mnemonic: &str) -> Option<CheckButton> {
         let tmp_pointer = unsafe {
-            let mut tmp_mnemonic = mnemonic.to_tmp_for_borrow();
-            ffi::gtk_check_button_new_with_mnemonic(tmp_mnemonic.to_glib_ptr())
+            ffi::gtk_check_button_new_with_mnemonic(mnemonic.borrow_to_glib().0)
         };
         check_pointer!(tmp_pointer, CheckButton)
     }

--- a/src/gtk/widgets/check_menu_item.rs
+++ b/src/gtk/widgets/check_menu_item.rs
@@ -16,7 +16,7 @@
 //! The widget used for item in menus
 
 use gtk::{self, ffi};
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 
 /// CheckMenuItem — The widget used for item in menus
 struct_Widget!(CheckMenuItem);
@@ -29,17 +29,15 @@ impl CheckMenuItem {
 
     pub fn new_with_label(label: &str) -> Option<CheckMenuItem> {
         let tmp_pointer = unsafe {
-            let mut tmp_label = label.to_tmp_for_borrow();
-            ffi::gtk_check_menu_item_new_with_label(tmp_label.to_glib_ptr())
+            ffi::gtk_check_menu_item_new_with_label(label.borrow_to_glib().0)
         };
         check_pointer!(tmp_pointer, CheckMenuItem)
     }
 
     pub fn new_with_mnemonic(mnemonic: &str) -> Option<CheckMenuItem> {
         let tmp_pointer = unsafe {
-            let mut tmp_mnemonic = mnemonic.to_tmp_for_borrow();
             ffi::gtk_check_menu_item_new_with_mnemonic(
-                    tmp_mnemonic.to_glib_ptr())
+                    mnemonic.borrow_to_glib().0)
         };
         check_pointer!(tmp_pointer, CheckMenuItem)
     }

--- a/src/gtk/widgets/color_button.rs
+++ b/src/gtk/widgets/color_button.rs
@@ -15,7 +15,7 @@
 
 //! A button to launch a color selection dialog
 
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 use gtk::cast::GTK_COLORBUTTON;
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
@@ -96,8 +96,7 @@ impl ColorButton {
 
     pub fn set_title(&mut self, title: &str) -> () {
         unsafe {
-            let mut tmp_title = title.to_tmp_for_borrow();
-            ffi::gtk_color_button_set_title(GTK_COLORBUTTON(self.pointer), tmp_title.to_glib_ptr());
+            ffi::gtk_color_button_set_title(GTK_COLORBUTTON(self.pointer), title.borrow_to_glib().0);
         }
     }
 

--- a/src/gtk/widgets/color_chooser_dialog.rs
+++ b/src/gtk/widgets/color_chooser_dialog.rs
@@ -16,15 +16,14 @@
 use gtk::{self, ffi};
 use gtk::FFIWidget;
 use gtk::cast::{GTK_WINDOW};
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 
 struct_Widget!(ColorChooserDialog);
 
 impl ColorChooserDialog {
     pub fn new(title: &str, parent: Option<gtk::Window>) -> Option<ColorChooserDialog> {
         let tmp_pointer = unsafe {
-            let mut tmp_title = title.to_tmp_for_borrow();
-            ffi::gtk_color_chooser_dialog_new(tmp_title.to_glib_ptr(),
+            ffi::gtk_color_chooser_dialog_new(title.borrow_to_glib().0,
                 match parent {
                     Some(ref p) => GTK_WINDOW(p.unwrap_widget()),
                     None => ::std::ptr::null_mut()

--- a/src/gtk/widgets/combo_box_text.rs
+++ b/src/gtk/widgets/combo_box_text.rs
@@ -17,7 +17,7 @@
 
 use gtk::{self, ffi};
 use gtk::cast::GTK_COMBO_BOX_TEXT;
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 use libc::c_char;
 
 struct_Widget!(ComboBoxText);
@@ -35,53 +35,44 @@ impl ComboBoxText {
 
     pub fn append(&self, id: &str, text: &str) {
         unsafe {
-            let mut tmp_id = id.to_tmp_for_borrow();
-            let mut tmp_text = text.to_tmp_for_borrow();
             ffi::gtk_combo_box_text_append(GTK_COMBO_BOX_TEXT(self.pointer),
-                                           tmp_id.to_glib_ptr(),
-                                           tmp_text.to_glib_ptr())
+                                           id.borrow_to_glib().0,
+                                           text.borrow_to_glib().0)
         }
     }
 
     pub fn prepend(&self, id: &str, text: &str) {
         unsafe {
-            let mut tmp_id = id.to_tmp_for_borrow();
-            let mut tmp_text = text.to_tmp_for_borrow();
             ffi::gtk_combo_box_text_prepend(GTK_COMBO_BOX_TEXT(self.pointer),
-                                            tmp_id.to_glib_ptr(),
-                                            tmp_text.to_glib_ptr())
+                                            id.borrow_to_glib().0,
+                                            text.borrow_to_glib().0)
         }
     }
 
     pub fn insert(&self, position: i32, id: &str, text: &str) {
         unsafe {
-            let mut tmp_id = id.to_tmp_for_borrow();
-            let mut tmp_text = text.to_tmp_for_borrow();
             ffi::gtk_combo_box_text_insert(GTK_COMBO_BOX_TEXT(self.pointer),
                                            position,
-                                           tmp_id.to_glib_ptr(),
-                                           tmp_text.to_glib_ptr())
+                                           id.borrow_to_glib().0,
+                                           text.borrow_to_glib().0)
         }
     }
 
     pub fn append_text(&self, text: &str) {
         unsafe {
-            let mut tmp_text = text.to_tmp_for_borrow();
-            ffi::gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(self.pointer), tmp_text.to_glib_ptr())
+            ffi::gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(self.pointer), text.borrow_to_glib().0)
         }
     }
 
     pub fn prepend_text(&self, text: &str) {
         unsafe {
-            let mut tmp_text = text.to_tmp_for_borrow();
-            ffi::gtk_combo_box_text_prepend_text(GTK_COMBO_BOX_TEXT(self.pointer), tmp_text.to_glib_ptr())
+            ffi::gtk_combo_box_text_prepend_text(GTK_COMBO_BOX_TEXT(self.pointer), text.borrow_to_glib().0)
         }
     }
 
     pub fn insert_text(&self, position: i32, text: &str) {
         unsafe {
-            let mut tmp_text = text.to_tmp_for_borrow();
-            ffi::gtk_combo_box_text_insert_text(GTK_COMBO_BOX_TEXT(self.pointer), position, tmp_text.to_glib_ptr())
+            ffi::gtk_combo_box_text_insert_text(GTK_COMBO_BOX_TEXT(self.pointer), position, text.borrow_to_glib().0)
         }
     }
 

--- a/src/gtk/widgets/combo_box_text.rs
+++ b/src/gtk/widgets/combo_box_text.rs
@@ -18,7 +18,6 @@
 use gtk::{self, ffi};
 use gtk::cast::GTK_COMBO_BOX_TEXT;
 use glib::translate::{FromGlibPtr, ToGlibPtr};
-use libc::c_char;
 
 struct_Widget!(ComboBoxText);
 
@@ -87,7 +86,7 @@ impl ComboBoxText {
     pub fn get_active_text(&self) -> Option<String> {
         unsafe {
             FromGlibPtr::borrow(
-                ffi::gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(self.pointer)) as *const c_char)
+                ffi::gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(self.pointer)))
         }
     }
 }

--- a/src/gtk/widgets/dialog.rs
+++ b/src/gtk/widgets/dialog.rs
@@ -14,7 +14,7 @@
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::ptr;
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 use gtk::{self, ffi};
 use gtk::cast::GTK_WINDOW;
 use gtk::FFIWidget;
@@ -33,14 +33,13 @@ impl Dialog {
     pub fn with_buttons<T: DialogButtons>(title: &str, parent: Option<gtk::Window>,
                                           flags: gtk::DialogFlags, buttons: T) -> Dialog {
         unsafe {
-            let mut tmp_title = title.to_tmp_for_borrow();
             let parent = match parent {
                 Some(w) => GTK_WINDOW(w.unwrap_widget()),
                 None => ptr::null_mut(),
             };
             gtk::FFIWidget::wrap_widget(
                 buttons.invoke3(ffi::gtk_dialog_new_with_buttons,
-                                tmp_title.to_glib_ptr(),
+                                title.borrow_to_glib().0,
                                 parent,
                                 flags))
         }

--- a/src/gtk/widgets/entry_buffer.rs
+++ b/src/gtk/widgets/entry_buffer.rs
@@ -16,7 +16,7 @@
 //! Text buffer for gtk::Entry
 
 use libc::{c_int, c_uint};
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 use gtk::ffi;
 
 // TODO:
@@ -36,8 +36,7 @@ pub struct EntryBuffer {
 impl EntryBuffer {
     pub fn new(initial_chars: Option<&str>) -> Option<EntryBuffer> {
         let tmp_pointer = unsafe {
-            let mut tmp_initial_chars = initial_chars.to_tmp_for_borrow();
-            ffi::gtk_entry_buffer_new(tmp_initial_chars.to_glib_ptr(), -1)
+            ffi::gtk_entry_buffer_new(initial_chars.borrow_to_glib().0, -1)
         };
         if tmp_pointer.is_null() {
             None
@@ -57,8 +56,7 @@ impl EntryBuffer {
 
     pub fn set_text(&mut self, text: &str) -> () {
         unsafe {
-            let mut tmp_text = text.to_tmp_for_borrow();
-            ffi::gtk_entry_buffer_set_text(self.pointer, tmp_text.to_glib_ptr(), -1);
+            ffi::gtk_entry_buffer_set_text(self.pointer, text.borrow_to_glib().0, -1);
         }
     }
 
@@ -88,9 +86,8 @@ impl EntryBuffer {
 
     pub fn insert_text(&mut self, position: u32, text: &str) -> () {
         unsafe {
-            let mut tmp_text = text.to_tmp_for_borrow();
             ffi::gtk_entry_buffer_insert_text(self.pointer, position as c_uint,
-                                              tmp_text.to_glib_ptr(), -1);
+                                              text.borrow_to_glib().0, -1);
         }
     }
 
@@ -108,9 +105,8 @@ impl EntryBuffer {
 
     pub fn emit_inserted_text(&mut self, position: u32, text: &str) -> () {
         unsafe {
-            let mut tmp_text = text.to_tmp_for_borrow();
             ffi::gtk_entry_buffer_emit_inserted_text(self.pointer, position as c_uint,
-                                                     tmp_text.to_glib_ptr(), -1);
+                                                     text.borrow_to_glib().0, -1);
         }
     }
 

--- a/src/gtk/widgets/entry_completion.rs
+++ b/src/gtk/widgets/entry_completion.rs
@@ -19,7 +19,6 @@ use gtk::{self, ffi};
 use gtk::TreeModel;
 use gtk::cast::GTK_ENTRY_COMPLETION;
 use glib::translate::{FromGlibPtr, ToGlibPtr};
-use libc::c_char;
 
 struct_Widget!(EntryCompletion);
 
@@ -73,8 +72,7 @@ impl EntryCompletion {
             FromGlibPtr::borrow(
                 ffi::gtk_entry_completion_compute_prefix(
                     GTK_ENTRY_COMPLETION(self.pointer),
-                    key.borrow_to_glib().0)
-                as *const c_char)
+                    key.borrow_to_glib().0))
         }
     }
 

--- a/src/gtk/widgets/entry_completion.rs
+++ b/src/gtk/widgets/entry_completion.rs
@@ -18,7 +18,7 @@
 use gtk::{self, ffi};
 use gtk::TreeModel;
 use gtk::cast::GTK_ENTRY_COMPLETION;
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 use libc::c_char;
 
 struct_Widget!(EntryCompletion);
@@ -70,11 +70,10 @@ impl EntryCompletion {
 
     pub fn compute_prefix(&self, key: &str) -> Option<String> {
         unsafe {
-            let mut tmp_key = key.to_tmp_for_borrow();
             FromGlibPtr::borrow(
                 ffi::gtk_entry_completion_compute_prefix(
                     GTK_ENTRY_COMPLETION(self.pointer),
-                    tmp_key.to_glib_ptr())
+                    key.borrow_to_glib().0)
                 as *const c_char)
         }
     }
@@ -96,15 +95,13 @@ impl EntryCompletion {
 
     pub fn insert_action_text(&self, index_: i32, text: &str) {
         unsafe {
-            let mut tmp_text = text.to_tmp_for_borrow();
-            ffi::gtk_entry_completion_insert_action_text(GTK_ENTRY_COMPLETION(self.pointer), index_, tmp_text.to_glib_ptr())
+            ffi::gtk_entry_completion_insert_action_text(GTK_ENTRY_COMPLETION(self.pointer), index_, text.borrow_to_glib().0)
         }
     }
 
     pub fn insert_action_markup(&self, index_: i32, markup: &str) {
         unsafe {
-            let mut tmp_markup = markup.to_tmp_for_borrow();
-            ffi::gtk_entry_completion_insert_action_markup(GTK_ENTRY_COMPLETION(self.pointer), index_, tmp_markup.to_glib_ptr())
+            ffi::gtk_entry_completion_insert_action_markup(GTK_ENTRY_COMPLETION(self.pointer), index_, markup.borrow_to_glib().0)
         }
     }
 

--- a/src/gtk/widgets/expander.rs
+++ b/src/gtk/widgets/expander.rs
@@ -17,7 +17,7 @@
 
 use libc::c_int;
 
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 use gtk::cast::GTK_EXPANDER;
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
@@ -29,16 +29,14 @@ struct_Widget!(Expander);
 impl Expander {
     pub fn new(label: &str) -> Option<Expander> {
         let tmp_pointer = unsafe {
-            let mut tmp_label = label.to_tmp_for_borrow();
-            ffi::gtk_expander_new(tmp_label.to_glib_ptr())
+            ffi::gtk_expander_new(label.borrow_to_glib().0)
         };
         check_pointer!(tmp_pointer, Expander)
     }
 
     pub fn new_with_mnemonic(mnemonic: &str) -> Option<Expander> {
         let tmp_pointer = unsafe {
-            let mut tmp_mnemonic = mnemonic.to_tmp_for_borrow();
-            ffi::gtk_expander_new_with_mnemonic(tmp_mnemonic.to_glib_ptr())
+            ffi::gtk_expander_new_with_mnemonic(mnemonic.borrow_to_glib().0)
         };
         check_pointer!(tmp_pointer, Expander)
     }
@@ -93,8 +91,7 @@ impl Expander {
 
     pub fn set_label(&mut self, label: &str) -> () {
         unsafe {
-            let mut tmp_label = label.to_tmp_for_borrow();
-            ffi::gtk_expander_set_label(GTK_EXPANDER(self.pointer), tmp_label.to_glib_ptr());
+            ffi::gtk_expander_set_label(GTK_EXPANDER(self.pointer), label.borrow_to_glib().0);
         }
     }
 

--- a/src/gtk/widgets/file_chooser_dialog.rs
+++ b/src/gtk/widgets/file_chooser_dialog.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 use gtk::{self, ffi};
 use gtk::FFIWidget;
 use gtk::cast::{GTK_WINDOW};
@@ -25,7 +25,6 @@ impl FileChooserDialog {
     pub fn new<T: DialogButtons>(title: &str, parent: Option<gtk::Window>,
                                  action: gtk::FileChooserAction, buttons: T) -> FileChooserDialog {
         unsafe {
-            let mut tmp_title = title.to_tmp_for_borrow();
             let parent = match parent {
                 Some(ref p) => GTK_WINDOW(p.unwrap_widget()),
                 None => GTK_WINDOW(::std::ptr::null_mut())
@@ -34,7 +33,7 @@ impl FileChooserDialog {
             gtk::FFIWidget::wrap_widget(
                 buttons.invoke3(
                     ffi::gtk_file_chooser_dialog_new,
-                    tmp_title.to_glib_ptr(),
+                    title.borrow_to_glib().0,
                     parent,
                     action))
 

--- a/src/gtk/widgets/file_filter.rs
+++ b/src/gtk/widgets/file_filter.rs
@@ -14,7 +14,7 @@
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
 use gtk::ffi;
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 
 pub struct FileFilter {
     pointer : *mut ffi::C_GtkFileFilter
@@ -33,8 +33,7 @@ impl FileFilter {
 
     pub fn set_name(&self, name: &str) -> () {
         unsafe {
-            let mut tmp_name = name.to_tmp_for_borrow();
-            ffi::gtk_file_filter_set_name(self.pointer, tmp_name.to_glib_ptr())
+            ffi::gtk_file_filter_set_name(self.pointer, name.borrow_to_glib().0)
         };
     }
 
@@ -47,15 +46,13 @@ impl FileFilter {
 
     pub fn add_mime_type(&self, mime_type: &str) -> () {
         unsafe {
-            let mut tmp_mime_type = mime_type.to_tmp_for_borrow();
-            ffi::gtk_file_filter_add_mime_type(self.pointer, tmp_mime_type.to_glib_ptr())
+            ffi::gtk_file_filter_add_mime_type(self.pointer, mime_type.borrow_to_glib().0)
         };
     }
 
     pub fn add_pattern(&self, pattern: &str) -> () {
         unsafe {
-            let mut tmp_pattern = pattern.to_tmp_for_borrow();
-            ffi::gtk_file_filter_add_pattern(self.pointer, tmp_pattern.to_glib_ptr())
+            ffi::gtk_file_filter_add_pattern(self.pointer, pattern.borrow_to_glib().0)
         };
     }
 

--- a/src/gtk/widgets/font_button.rs
+++ b/src/gtk/widgets/font_button.rs
@@ -15,7 +15,7 @@
 
 //! A button to launch a font chooser dialog
 
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
 use gtk::cast::GTK_FONTBUTTON;
@@ -35,15 +35,13 @@ impl FontButton {
 
     pub fn new_with_font(font_name: &str) -> Option<FontButton> {
         let tmp_pointer = unsafe {
-            let mut tmp_font_name = font_name.to_tmp_for_borrow();
-            ffi::gtk_font_button_new_with_font(tmp_font_name.to_glib_ptr())
+            ffi::gtk_font_button_new_with_font(font_name.borrow_to_glib().0)
         };
         check_pointer!(tmp_pointer, FontButton)
     }
 
     pub fn set_font_name(&mut self, font_name: &str) -> bool {
-        let mut tmp_font_name = font_name.to_tmp_for_borrow();
-        unsafe { to_bool(ffi::gtk_font_button_set_font_name(GTK_FONTBUTTON(self.pointer), tmp_font_name.to_glib_ptr())) }
+        unsafe { to_bool(ffi::gtk_font_button_set_font_name(GTK_FONTBUTTON(self.pointer), font_name.borrow_to_glib().0)) }
     }
 
     pub fn get_font_name(&self) -> Option<String> {
@@ -87,8 +85,7 @@ impl FontButton {
 
     pub fn set_title(&mut self, title: &str) -> () {
         unsafe {
-            let mut tmp_title = title.to_tmp_for_borrow();
-            ffi::gtk_font_button_set_title(GTK_FONTBUTTON(self.pointer), tmp_title.to_glib_ptr());
+            ffi::gtk_font_button_set_title(GTK_FONTBUTTON(self.pointer), title.borrow_to_glib().0);
         }
     }
 

--- a/src/gtk/widgets/font_chooser_dialog.rs
+++ b/src/gtk/widgets/font_chooser_dialog.rs
@@ -16,15 +16,14 @@
 use gtk::{self, ffi};
 use gtk::FFIWidget;
 use gtk::cast::{GTK_WINDOW};
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 
 struct_Widget!(FontChooserDialog);
 
 impl FontChooserDialog {
     pub fn new(title: &str, parent: Option<gtk::Window>) -> Option<FontChooserDialog> {
         let tmp = unsafe {
-            let mut tmp_title = title.to_tmp_for_borrow();
-            ffi::gtk_font_chooser_dialog_new(tmp_title.to_glib_ptr(),
+            ffi::gtk_font_chooser_dialog_new(title.borrow_to_glib().0,
                 match parent {
                     Some(ref p) => GTK_WINDOW(p.unwrap_widget()),
                     None => GTK_WINDOW(::std::ptr::null_mut())

--- a/src/gtk/widgets/frame.rs
+++ b/src/gtk/widgets/frame.rs
@@ -15,7 +15,7 @@
 
 //! A bin with a decorative frame and optional label
 
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 use gtk::{self, ffi};
 
 /// Frame — A bin with a decorative frame and optional label
@@ -24,8 +24,7 @@ struct_Widget!(Frame);
 impl Frame {
     pub fn new(label: Option<&str>) -> Option<Frame> {
         let tmp_pointer = unsafe {
-            let mut tmp_label = label.to_tmp_for_borrow();
-            ffi::gtk_frame_new(tmp_label.to_glib_ptr())
+            ffi::gtk_frame_new(label.borrow_to_glib().0)
         };
         check_pointer!(tmp_pointer, Frame)
     }

--- a/src/gtk/widgets/gtype.rs
+++ b/src/gtk/widgets/gtype.rs
@@ -19,7 +19,7 @@
 pub mod g_type {
     use gtk::ffi;
     use std::ffi::CString;
-    use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+    use glib::translate::{FromGlibPtr, ToGlibPtr};
     use glib_ffi::{self};
 
     pub fn name(_type: glib_ffi::GType) -> Option<String> {
@@ -31,8 +31,7 @@ pub mod g_type {
 
     pub fn from_name(name: &str) -> glib_ffi::GType {
         unsafe {
-            let mut tmp_name = name.to_tmp_for_borrow();
-            ffi::g_type_from_name(tmp_name.to_glib_ptr())
+            ffi::g_type_from_name(name.borrow_to_glib().0)
         }
     }
 

--- a/src/gtk/widgets/header_bar.rs
+++ b/src/gtk/widgets/header_bar.rs
@@ -19,7 +19,7 @@
 
 use gtk::cast::{GTK_HEADER_BAR};
 use gtk::{self, ffi};
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 use glib::{to_bool, to_gboolean};
 
 /// GtkHeaderBar — A Box::new(with) a centered child
@@ -33,9 +33,8 @@ impl HeaderBar {
 
     pub fn set_title(&mut self, title: &str) {
         unsafe {
-            let mut tmp_title = title.to_tmp_for_borrow();
             ffi::gtk_header_bar_set_title(GTK_HEADER_BAR(self.pointer),
-                                          tmp_title.to_glib_ptr())
+                                          title.borrow_to_glib().0)
         }
     }
 
@@ -48,9 +47,8 @@ impl HeaderBar {
 
     pub fn set_subtitle(&mut self, subtitle: &str) {
         unsafe {
-            let mut tmp_subtitle = subtitle.to_tmp_for_borrow();
             ffi::gtk_header_bar_set_subtitle(GTK_HEADER_BAR(self.pointer),
-                                             tmp_subtitle.to_glib_ptr())
+                                             subtitle.borrow_to_glib().0)
         }
     }
 

--- a/src/gtk/widgets/image.rs
+++ b/src/gtk/widgets/image.rs
@@ -18,7 +18,7 @@
 use gtk::{self, ffi};
 use gtk::cast::GTK_IMAGE;
 use gtk::FFIWidget;
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 
 /// Image — A widget displaying an image
 struct_Widget!(Image);
@@ -26,33 +26,29 @@ struct_Widget!(Image);
 impl Image {
     pub fn new_from_file(filename: &str) -> Option<Image> {
         let tmp_pointer = unsafe {
-            let mut tmp_filename = filename.to_tmp_for_borrow();
-            ffi::gtk_image_new_from_file(tmp_filename.to_glib_ptr())
+            ffi::gtk_image_new_from_file(filename.borrow_to_glib().0)
         };
         check_pointer!(tmp_pointer, Image)
     }
 
     pub fn new_from_icon_name(icon_name: &str, size: gtk::IconSize) -> Option<Image> {
         let tmp_pointer = unsafe {
-            let mut tmp_icon_name = icon_name.to_tmp_for_borrow();
-            ffi::gtk_image_new_from_icon_name(tmp_icon_name.to_glib_ptr(), size)
+            ffi::gtk_image_new_from_icon_name(icon_name.borrow_to_glib().0, size)
         };
         check_pointer!(tmp_pointer, Image)
     }
 
     pub fn set_from_file(&self, filename: &str) {
         unsafe {
-            let mut tmp_filename = filename.to_tmp_for_borrow();
             ffi::gtk_image_set_from_file(GTK_IMAGE(self.unwrap_widget()),
-                                         tmp_filename.to_glib_ptr());
+                                         filename.borrow_to_glib().0);
         };
     }
 
     pub fn set_from_icon_name(&self, icon_name: &str, size: gtk::IconSize) {
         unsafe {
-            let mut tmp_icon_name = icon_name.to_tmp_for_borrow();
             ffi::gtk_image_set_from_icon_name(GTK_IMAGE(self.unwrap_widget()),
-                                              tmp_icon_name.to_glib_ptr(), size)
+                                              icon_name.borrow_to_glib().0, size)
         };
     }
 }

--- a/src/gtk/widgets/info_bar.rs
+++ b/src/gtk/widgets/info_bar.rs
@@ -16,7 +16,7 @@
 //! Report important messages to the user
 
 use libc::c_int;
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 
 use gtk::MessageType;
 use gtk::cast::GTK_INFOBAR;
@@ -40,8 +40,7 @@ impl InfoBar {
 
     pub fn add_button(&mut self, button_text: &str, response_id: i32) -> gtk::Button {
         let button = unsafe {
-            let mut tmp_button_text = button_text.to_tmp_for_borrow();
-            ffi::gtk_info_bar_add_button(GTK_INFOBAR(self.pointer), tmp_button_text.to_glib_ptr(), response_id as c_int)
+            ffi::gtk_info_bar_add_button(GTK_INFOBAR(self.pointer), button_text.borrow_to_glib().0, response_id as c_int)
         };
         gtk::FFIWidget::wrap_widget(button)
     }

--- a/src/gtk/widgets/label.rs
+++ b/src/gtk/widgets/label.rs
@@ -15,7 +15,7 @@
 
 //! A widget that displays a small to medium amount of text
 
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 use gtk::{self, ffi};
 
 /// Label — A widget that displays a small to medium amount of text
@@ -32,16 +32,14 @@ struct_Widget!(Label);
 impl Label {
     pub fn new(text: &str) -> Option<Label> {
         let tmp_pointer = unsafe {
-            let mut tmp_text = text.to_tmp_for_borrow();
-            ffi::gtk_label_new(tmp_text.to_glib_ptr())
+            ffi::gtk_label_new(text.borrow_to_glib().0)
         };
         check_pointer!(tmp_pointer, Label)
     }
 
     pub fn new_with_mnemonic(text: &str) -> Option<Label> {
         let tmp_pointer = unsafe {
-            let mut tmp_text = text.to_tmp_for_borrow();
-            ffi::gtk_label_new_with_mnemonic(tmp_text.to_glib_ptr())
+            ffi::gtk_label_new_with_mnemonic(text.borrow_to_glib().0)
         };
         check_pointer!(tmp_pointer, Label)
     }

--- a/src/gtk/widgets/level_bar.rs
+++ b/src/gtk/widgets/level_bar.rs
@@ -16,7 +16,7 @@
 //! A bar that can used as a level indicator
 
 use libc::c_double;
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
@@ -101,32 +101,29 @@ impl LevelBar {
 
     pub fn add_offset_value(&mut self, name: &str, value: f64) -> () {
         unsafe {
-            let mut tmp_name = name.to_tmp_for_borrow();
             ffi::gtk_level_bar_add_offset_value(
                 GTK_LEVELBAR(self.pointer),
-                tmp_name.to_glib_ptr(),
+                name.borrow_to_glib().0,
                 value as c_double)
         }
     }
 
     pub fn remove_offset_value(&mut self, name: &str) -> () {
         unsafe {
-            let mut tmp_name = name.to_tmp_for_borrow();
             ffi::gtk_level_bar_remove_offset_value(
                 GTK_LEVELBAR(self.pointer),
-                tmp_name.to_glib_ptr());
+                name.borrow_to_glib().0);
         }
     }
 
     pub fn get_offset_value(&self, name: &str) -> Option<f64> {
         unsafe {
             let mut value = 0.;
-            let mut tmp_name = name.to_tmp_for_borrow();
 
             let res = to_bool(
                 ffi::gtk_level_bar_get_offset_value(
                     GTK_LEVELBAR(self.pointer),
-                    tmp_name.to_glib_ptr(),
+                    name.borrow_to_glib().0,
                     &mut value));
 
             if res {

--- a/src/gtk/widgets/link_button.rs
+++ b/src/gtk/widgets/link_button.rs
@@ -15,7 +15,7 @@
 
 //! Create buttons bound to a URL
 
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 use gtk::cast::GTK_LINKBUTTON;
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
@@ -30,17 +30,14 @@ struct_Widget!(LinkButton);
 impl LinkButton {
     pub fn new(uri: &str) -> Option<LinkButton> {
         let tmp_pointer = unsafe {
-            let mut tmp_uri = uri.to_tmp_for_borrow();
-            ffi::gtk_link_button_new(tmp_uri.to_glib_ptr())
+            ffi::gtk_link_button_new(uri.borrow_to_glib().0)
         };
         check_pointer!(tmp_pointer, LinkButton)
     }
 
     pub fn new_with_label(uri: &str, label: &str) -> Option<LinkButton> {
         let tmp_pointer = unsafe {
-            let mut tmp_uri = uri.to_tmp_for_borrow();
-            let mut tmp_label = label.to_tmp_for_borrow();
-            ffi::gtk_link_button_new_with_label(tmp_uri.to_glib_ptr(), tmp_label.to_glib_ptr())
+            ffi::gtk_link_button_new_with_label(uri.borrow_to_glib().0, label.borrow_to_glib().0)
         };
         check_pointer!(tmp_pointer, LinkButton)
     }
@@ -54,8 +51,7 @@ impl LinkButton {
 
     pub fn set_uri(&mut self, uri: &str) -> () {
         unsafe {
-            let mut tmp_uri = uri.to_tmp_for_borrow();
-            ffi::gtk_link_button_set_uri(GTK_LINKBUTTON(self.pointer), tmp_uri.to_glib_ptr())
+            ffi::gtk_link_button_set_uri(GTK_LINKBUTTON(self.pointer), uri.borrow_to_glib().0)
         }
     }
 

--- a/src/gtk/widgets/list_store.rs
+++ b/src/gtk/widgets/list_store.rs
@@ -17,7 +17,7 @@ use glib::{to_bool, Value, Type};
 use glib::translate::ToGlib;
 use gtk::{self, ffi};
 use gtk::TreeIter;
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 use std::num::ToPrimitive;
 
 pub struct ListStore {
@@ -38,8 +38,7 @@ impl ListStore {
 
     pub fn set_string(&self, iter: &TreeIter, column: i32, text: &str) {
         unsafe {
-            let mut tmp_text = text.to_tmp_for_borrow();
-            ffi::gtk_list_store_set(self.pointer, iter.unwrap_pointer(), column, tmp_text.to_glib_ptr(), -1)
+            ffi::gtk_list_store_set(self.pointer, iter.unwrap_pointer(), column, text.borrow_to_glib().0, -1)
         }
     }
 

--- a/src/gtk/widgets/menu_item.rs
+++ b/src/gtk/widgets/menu_item.rs
@@ -16,7 +16,7 @@
 //! The widget used for item in menus
 
 use gtk::{self, ffi};
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 
 /// MenuItem — The widget used for item in menus
 struct_Widget!(MenuItem);
@@ -29,16 +29,14 @@ impl MenuItem {
 
     pub fn new_with_label(label: &str) -> Option<MenuItem> {
         let tmp_pointer = unsafe {
-            let mut tmp_label = label.to_tmp_for_borrow();
-            ffi::gtk_menu_item_new_with_label(tmp_label.to_glib_ptr())
+            ffi::gtk_menu_item_new_with_label(label.borrow_to_glib().0)
         };
         check_pointer!(tmp_pointer, MenuItem)
     }
 
     pub fn new_with_mnemonic(mnemonic: &str) -> Option<MenuItem> {
         let tmp_pointer = unsafe {
-            let mut tmp_mnemonic = mnemonic.to_tmp_for_borrow();
-            ffi::gtk_menu_item_new_with_mnemonic(tmp_mnemonic.to_glib_ptr())
+            ffi::gtk_menu_item_new_with_mnemonic(mnemonic.borrow_to_glib().0)
         };
         check_pointer!(tmp_pointer, MenuItem)
     }

--- a/src/gtk/widgets/menu_tool_button.rs
+++ b/src/gtk/widgets/menu_tool_button.rs
@@ -19,7 +19,7 @@ use std::ptr;
 
 use gtk::cast::GTK_MENUTOOLBUTTON;
 use gtk::{self, ffi};
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 
 /// MenuToolButton — A ToolItem containing a button with an additional dropdown menu
 struct_Widget!(MenuToolButton);
@@ -27,38 +27,34 @@ struct_Widget!(MenuToolButton);
 impl MenuToolButton {
     pub fn new<T: gtk::WidgetTrait>(icon_widget: Option<&T>, label: Option<&str>) -> Option<MenuToolButton> {
         let tmp_pointer = unsafe {
-            let mut tmp_label = label.to_tmp_for_borrow();
             let icon_widget_ptr = match icon_widget {
                 Some(i) => i.unwrap_widget(),
                 None    => ptr::null_mut(),
             };
 
-            ffi::gtk_menu_tool_button_new(icon_widget_ptr, tmp_label.to_glib_ptr())
+            ffi::gtk_menu_tool_button_new(icon_widget_ptr, label.borrow_to_glib().0)
         };
         check_pointer!(tmp_pointer, MenuToolButton)
     }
 
     pub fn new_from_stock(stock_id: &str) -> Option<MenuToolButton> {
         let tmp_pointer = unsafe {
-            let mut tmp_stock_id = stock_id.to_tmp_for_borrow();
-            ffi::gtk_menu_tool_button_new_from_stock(tmp_stock_id.to_glib_ptr())
+            ffi::gtk_menu_tool_button_new_from_stock(stock_id.borrow_to_glib().0)
         };
         check_pointer!(tmp_pointer, MenuToolButton)
     }
 
     pub fn set_arrow_tooltip_text(&mut self, text: &str) -> () {
         unsafe {
-            let mut tmp_text = text.to_tmp_for_borrow();
-            ffi::gtk_menu_tool_button_set_arrow_tooltip_text(GTK_MENUTOOLBUTTON(self.pointer), tmp_text.to_glib_ptr())
+            ffi::gtk_menu_tool_button_set_arrow_tooltip_text(GTK_MENUTOOLBUTTON(self.pointer), text.borrow_to_glib().0)
         }
     }
 
     pub fn set_arrow_tooltip_markup(&mut self, markup: &str) -> () {
         unsafe {
-            let mut tmp_markup = markup.to_tmp_for_borrow();
             ffi::gtk_menu_tool_button_set_arrow_tooltip_markup(
                 GTK_MENUTOOLBUTTON(self.pointer),
-                tmp_markup.to_glib_ptr())
+                markup.borrow_to_glib().0)
         }
     }
 }

--- a/src/gtk/widgets/message_dialog.rs
+++ b/src/gtk/widgets/message_dialog.rs
@@ -16,7 +16,7 @@
 use gtk::{self, ffi};
 use gtk::FFIWidget;
 use gtk::cast::{GTK_MESSAGE_DIALOG, GTK_WINDOW};
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 
 struct_Widget!(MessageDialog);
 
@@ -48,8 +48,7 @@ impl MessageDialog {
 
     pub fn set_markup(&self, markup: &str) -> () {
         unsafe {
-            let mut tmp_markup = markup.to_tmp_for_borrow();
-            ffi::gtk_message_dialog_set_markup(GTK_MESSAGE_DIALOG(self.unwrap_widget()), tmp_markup.to_glib_ptr())
+            ffi::gtk_message_dialog_set_markup(GTK_MESSAGE_DIALOG(self.unwrap_widget()), markup.borrow_to_glib().0)
         }
     }
 

--- a/src/gtk/widgets/note_book.rs
+++ b/src/gtk/widgets/note_book.rs
@@ -18,7 +18,7 @@
 use gtk::{self, ffi};
 use gtk::cast::GTK_NOTEBOOK;
 use gtk::FFIWidget;
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 use glib::{to_bool, to_gboolean};
 
 /// GtkNotebook — A tabbed notebook container
@@ -114,9 +114,8 @@ impl NoteBook {
 
     pub fn set_group_name(&mut self, group_name: &str) {
         unsafe {
-            let mut tmp_group_name = group_name.to_tmp_for_borrow();
             ffi::gtk_notebook_set_group_name(GTK_NOTEBOOK(self.pointer),
-                                             tmp_group_name.to_glib_ptr())
+                                             group_name.borrow_to_glib().0)
         }
     }
 
@@ -270,10 +269,9 @@ impl NoteBook {
 
     pub fn set_tab_label_text<T: gtk::WidgetTrait>(&mut self, child: &T, tab_text: &str) {
         unsafe {
-            let mut tmp_tab_text = tab_text.to_tmp_for_borrow();
             ffi::gtk_notebook_set_tab_label_text(GTK_NOTEBOOK(self.pointer),
                                                  child.unwrap_widget(),
-                                                 tmp_tab_text.to_glib_ptr())
+                                                 tab_text.borrow_to_glib().0)
         }
     }
 
@@ -307,10 +305,9 @@ impl NoteBook {
 
     pub fn set_menu_label_text<T: gtk::WidgetTrait>(&mut self, child: &T, tab_text: &str) {
         unsafe {
-            let mut tmp_tab_text = tab_text.to_tmp_for_borrow();
             ffi::gtk_notebook_set_menu_label_text(GTK_NOTEBOOK(self.pointer),
                                                   child.unwrap_widget(),
-                                                  tmp_tab_text.to_glib_ptr())
+                                                  tab_text.borrow_to_glib().0)
         }
     }
 

--- a/src/gtk/widgets/paper_size.rs
+++ b/src/gtk/widgets/paper_size.rs
@@ -14,7 +14,7 @@
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
 use gtk::{self, ffi};
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 use glib::{to_bool, to_gboolean};
 use gtk::FFIWidget;
 use gtk::cast::{GTK_PAPER_SIZE};
@@ -26,8 +26,7 @@ struct_Widget!(PaperSize);
 impl PaperSize {
     pub fn new(name: &str) -> Option<PaperSize> {
         let tmp_pointer = unsafe {
-            let mut tmp_name = name.to_tmp_for_borrow();
-            ffi::gtk_paper_size_new(tmp_name.to_glib_ptr())
+            ffi::gtk_paper_size_new(name.borrow_to_glib().0)
         };
 
         if tmp_pointer.is_null() {
@@ -39,10 +38,8 @@ impl PaperSize {
 
     pub fn new_from_ppd(ppd_name: &str, ppd_display_name: &str, width: f64, height: f64) -> Option<PaperSize> {
         let tmp_pointer = unsafe {
-            let mut tmp_ppd_name = ppd_name.to_tmp_for_borrow();
-            let mut tmp_ppd_display_name = ppd_display_name.to_tmp_for_borrow();
-            ffi::gtk_paper_size_new_from_ppd(tmp_ppd_name.to_glib_ptr(),
-                                             tmp_ppd_display_name.to_glib_ptr(),
+            ffi::gtk_paper_size_new_from_ppd(ppd_name.borrow_to_glib().0,
+                                             ppd_display_name.borrow_to_glib().0,
                                              width, height)
         };
 
@@ -55,10 +52,8 @@ impl PaperSize {
 
     pub fn new_custom(name: &str, display_name: &str, width: f64, height: f64, unit: gtk::Unit) -> Option<PaperSize> {
         let tmp_pointer = unsafe {
-            let mut tmp_name = name.to_tmp_for_borrow();
-            let mut tmp_display_name = display_name.to_tmp_for_borrow();
-            ffi::gtk_paper_size_new_custom(tmp_name.to_glib_ptr(),
-                                           tmp_display_name.to_glib_ptr(),
+            ffi::gtk_paper_size_new_custom(name.borrow_to_glib().0,
+                                           display_name.borrow_to_glib().0,
                                            width, height, unit)
         };
 

--- a/src/gtk/widgets/print_settings.rs
+++ b/src/gtk/widgets/print_settings.rs
@@ -17,7 +17,7 @@ use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
 use gtk::FFIWidget;
 use gtk::cast::{GTK_PRINT_SETTINGS, GTK_PAPER_SIZE};
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 
 struct_Widget!(PrintSettings);
 
@@ -44,106 +44,91 @@ impl PrintSettings {
 
     pub fn has_key(&self, key: &str) -> bool {
         unsafe {
-            let mut tmp_key = key.to_tmp_for_borrow();
             to_bool(
                 ffi::gtk_print_settings_has_key(GTK_PRINT_SETTINGS(self.unwrap_widget()),
-                                                tmp_key.to_glib_ptr()))
+                                                key.borrow_to_glib().0))
         }
     }
 
     pub fn get(&self, key: &str) -> Option<String> {
         unsafe {
-            let mut tmp_key = key.to_tmp_for_borrow();
             FromGlibPtr::borrow(
-                ffi::gtk_print_settings_get(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_key.to_glib_ptr()))
+                ffi::gtk_print_settings_get(GTK_PRINT_SETTINGS(self.unwrap_widget()), key.borrow_to_glib().0))
         }
     }
 
     pub fn set(&self, key: &str, value: &str) {
         unsafe {
-            let mut tmp_key = key.to_tmp_for_borrow();
-            let mut tmp_value = value.to_tmp_for_borrow();
             ffi::gtk_print_settings_set(GTK_PRINT_SETTINGS(
                 self.unwrap_widget()),
-                tmp_key.to_glib_ptr(),
-                tmp_value.to_glib_ptr())
+                key.borrow_to_glib().0,
+                value.borrow_to_glib().0)
         }
     }
 
     pub fn unset(&self, key: &str) {
         unsafe {
-            let mut tmp_key = key.to_tmp_for_borrow();
-            ffi::gtk_print_settings_unset(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_key.to_glib_ptr())
+            ffi::gtk_print_settings_unset(GTK_PRINT_SETTINGS(self.unwrap_widget()), key.borrow_to_glib().0)
         }
     }
 
     pub fn get_bool(&self, key: &str) -> bool {
         unsafe {
-            let mut tmp_key = key.to_tmp_for_borrow();
-            to_bool(ffi::gtk_print_settings_get_bool(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_key.to_glib_ptr()))
+            to_bool(ffi::gtk_print_settings_get_bool(GTK_PRINT_SETTINGS(self.unwrap_widget()), key.borrow_to_glib().0))
         }
     }
 
     pub fn set_bool(&self, key: &str, value: bool) {
         unsafe {
-            let mut tmp_key = key.to_tmp_for_borrow();
-            ffi::gtk_print_settings_set_bool(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_key.to_glib_ptr(), to_gboolean(value))
+            ffi::gtk_print_settings_set_bool(GTK_PRINT_SETTINGS(self.unwrap_widget()), key.borrow_to_glib().0, to_gboolean(value))
         }
     }
 
     pub fn get_double(&self, key: &str) -> f64 {
         unsafe {
-            let mut tmp_key = key.to_tmp_for_borrow();
-            ffi::gtk_print_settings_get_double(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_key.to_glib_ptr())
+            ffi::gtk_print_settings_get_double(GTK_PRINT_SETTINGS(self.unwrap_widget()), key.borrow_to_glib().0)
         }
     }
 
     pub fn set_double(&self, key: &str, value: f64) {
         unsafe {
-            let mut tmp_key = key.to_tmp_for_borrow();
-            ffi::gtk_print_settings_set_double(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_key.to_glib_ptr(), value)
+            ffi::gtk_print_settings_set_double(GTK_PRINT_SETTINGS(self.unwrap_widget()), key.borrow_to_glib().0, value)
         }
     }
 
     pub fn get_double_with_default(&self, key: &str, def: f64) -> f64 {
         unsafe {
-            let mut tmp_key = key.to_tmp_for_borrow();
-            ffi::gtk_print_settings_get_double_with_default(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_key.to_glib_ptr(), def)
+            ffi::gtk_print_settings_get_double_with_default(GTK_PRINT_SETTINGS(self.unwrap_widget()), key.borrow_to_glib().0, def)
         }
     }
 
     pub fn get_length(&self, key: &str, unit: gtk::Unit) -> f64 {
         unsafe {
-            let mut tmp_key = key.to_tmp_for_borrow();
-            ffi::gtk_print_settings_get_length(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_key.to_glib_ptr(), unit)
+            ffi::gtk_print_settings_get_length(GTK_PRINT_SETTINGS(self.unwrap_widget()), key.borrow_to_glib().0, unit)
         }
     }
 
     pub fn set_length(&self, key: &str, value: f64, unit: gtk::Unit) {
         unsafe {
-            let mut tmp_key = key.to_tmp_for_borrow();
-            ffi::gtk_print_settings_set_length(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_key.to_glib_ptr(), value, unit)
+            ffi::gtk_print_settings_set_length(GTK_PRINT_SETTINGS(self.unwrap_widget()), key.borrow_to_glib().0, value, unit)
         }
     }
 
     pub fn get_int(&self, key: &str) -> i32 {
         unsafe {
-            let mut tmp_key = key.to_tmp_for_borrow();
-            ffi::gtk_print_settings_get_int(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_key.to_glib_ptr())
+            ffi::gtk_print_settings_get_int(GTK_PRINT_SETTINGS(self.unwrap_widget()), key.borrow_to_glib().0)
         }
     }
 
     pub fn set_int(&self, key: &str, value: i32) {
         unsafe {
-            let mut tmp_key = key.to_tmp_for_borrow();
-            ffi::gtk_print_settings_set_int(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_key.to_glib_ptr(), value)
+            ffi::gtk_print_settings_set_int(GTK_PRINT_SETTINGS(self.unwrap_widget()), key.borrow_to_glib().0, value)
         }
     }
 
     pub fn get_int_with_default(&self, key: &str, def: i32) -> i32 {
         unsafe {
-            let mut tmp_key = key.to_tmp_for_borrow();
-            ffi::gtk_print_settings_get_int_with_default(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_key.to_glib_ptr(), def)
+            ffi::gtk_print_settings_get_int_with_default(GTK_PRINT_SETTINGS(self.unwrap_widget()), key.borrow_to_glib().0, def)
         }
     }
 
@@ -156,8 +141,7 @@ impl PrintSettings {
 
     pub fn set_printer(&self, printer: &str) {
         unsafe {
-            let mut tmp_printer = printer.to_tmp_for_borrow();
-            ffi::gtk_print_settings_set_printer(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_printer.to_glib_ptr())
+            ffi::gtk_print_settings_set_printer(GTK_PRINT_SETTINGS(self.unwrap_widget()), printer.borrow_to_glib().0)
         }
     }
 
@@ -302,8 +286,7 @@ impl PrintSettings {
 
     pub fn set_default_source(&self, default_source: &str) {
         unsafe {
-            let mut tmp_default_source = default_source.to_tmp_for_borrow();
-            ffi::gtk_print_settings_set_default_source(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_default_source.to_glib_ptr())
+            ffi::gtk_print_settings_set_default_source(GTK_PRINT_SETTINGS(self.unwrap_widget()), default_source.borrow_to_glib().0)
         }
     }
 
@@ -316,8 +299,7 @@ impl PrintSettings {
 
     pub fn set_media_type(&self, media_type: &str) {
         unsafe {
-            let mut tmp_media_type = media_type.to_tmp_for_borrow();
-            ffi::gtk_print_settings_set_media_type(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_media_type.to_glib_ptr())
+            ffi::gtk_print_settings_set_media_type(GTK_PRINT_SETTINGS(self.unwrap_widget()), media_type.borrow_to_glib().0)
         }
     }
 
@@ -330,8 +312,7 @@ impl PrintSettings {
 
     pub fn set_dither(&self, dither: &str) {
         unsafe {
-            let mut tmp_dither = dither.to_tmp_for_borrow();
-            ffi::gtk_print_settings_set_dither(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_dither.to_glib_ptr())
+            ffi::gtk_print_settings_set_dither(GTK_PRINT_SETTINGS(self.unwrap_widget()), dither.borrow_to_glib().0)
         }
     }
 
@@ -344,8 +325,7 @@ impl PrintSettings {
 
     pub fn set_finishings(&self, finishings: &str) {
         unsafe {
-            let mut tmp_finishings = finishings.to_tmp_for_borrow();
-            ffi::gtk_print_settings_set_finishings(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_finishings.to_glib_ptr())
+            ffi::gtk_print_settings_set_finishings(GTK_PRINT_SETTINGS(self.unwrap_widget()), finishings.borrow_to_glib().0)
         }
     }
 
@@ -358,8 +338,7 @@ impl PrintSettings {
 
     pub fn set_output_bin(&self, output_bin: &str) {
         unsafe {
-            let mut tmp_output_bin = output_bin.to_tmp_for_borrow();
-            ffi::gtk_print_settings_set_output_bin(GTK_PRINT_SETTINGS(self.unwrap_widget()), tmp_output_bin.to_glib_ptr())
+            ffi::gtk_print_settings_set_output_bin(GTK_PRINT_SETTINGS(self.unwrap_widget()), output_bin.borrow_to_glib().0)
         }
     }
 }

--- a/src/gtk/widgets/progress_bar.rs
+++ b/src/gtk/widgets/progress_bar.rs
@@ -16,7 +16,7 @@
 //! A widget which indicates progress visually
 
 use libc::c_double;
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 
 use gtk::{self, ffi};
 use glib::{to_bool, to_gboolean};
@@ -51,8 +51,7 @@ impl ProgressBar {
 
     pub fn set_text(&mut self, text: &str) -> () {
         unsafe {
-            let mut tmp_text = text.to_tmp_for_borrow();
-            ffi::gtk_progress_bar_set_text(GTK_PROGRESSBAR(self.pointer), tmp_text.to_glib_ptr());
+            ffi::gtk_progress_bar_set_text(GTK_PROGRESSBAR(self.pointer), text.borrow_to_glib().0);
         }
     }
 

--- a/src/gtk/widgets/radio_button.rs
+++ b/src/gtk/widgets/radio_button.rs
@@ -17,7 +17,7 @@
 
 use std::ptr;
 
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 use gtk::{self, ffi};
 use gtk::cast::GTK_RADIOBUTTON;
 
@@ -32,18 +32,16 @@ impl RadioButton {
 
     pub fn new_with_label(label: &str) -> Option<RadioButton> {
         let tmp_pointer = unsafe {
-            let mut tmp_label = label.to_tmp_for_borrow();
             ffi::gtk_radio_button_new_with_label(ptr::null_mut(),
-                                                 tmp_label.to_glib_ptr())
+                                                 label.borrow_to_glib().0)
         };
         check_pointer!(tmp_pointer, RadioButton)
     }
 
     pub fn new_with_mnemonic(mnemonic: &str) -> Option<RadioButton> {
         let tmp_pointer = unsafe {
-            let mut tmp_mnemonic = mnemonic.to_tmp_for_borrow();
             ffi::gtk_radio_button_new_with_mnemonic(ptr::null_mut(),
-                                                    tmp_mnemonic.to_glib_ptr())
+                                                    mnemonic.borrow_to_glib().0)
         };
         check_pointer!(tmp_pointer, RadioButton)
     }

--- a/src/gtk/widgets/recent_chooser_dialog.rs
+++ b/src/gtk/widgets/recent_chooser_dialog.rs
@@ -14,7 +14,7 @@
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::ptr;
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 use gtk::{self, ffi};
 use gtk::FFIWidget;
 use gtk::ResponseType;
@@ -24,9 +24,6 @@ struct_Widget!(RecentChooserDialog);
 
 impl RecentChooserDialog {
     pub fn new(title: &str, parent: Option<gtk::Window>) -> Option<RecentChooserDialog> {
-        let mut tmp_title = title.to_tmp_for_borrow();
-        let mut tmp_ok = "Ok".to_tmp_for_borrow();
-        let mut tmp_cancel = "Cancel".to_tmp_for_borrow();
         let parent = match parent {
             Some(ref p) => GTK_WINDOW(p.unwrap_widget()),
             None => ptr::null_mut()
@@ -34,9 +31,9 @@ impl RecentChooserDialog {
 
         let tmp_pointer = unsafe {
             ffi::gtk_recent_chooser_dialog_new(
-                tmp_title.to_glib_ptr(), parent,
-                tmp_ok.to_glib_ptr(), ResponseType::Ok,
-                tmp_cancel.to_glib_ptr(), ResponseType::Cancel,
+                title.borrow_to_glib().0, parent,
+                "Ok".borrow_to_glib().0, ResponseType::Ok,
+                "Cancel".borrow_to_glib().0, ResponseType::Cancel,
                 ptr::null::<()>())
         };
 
@@ -48,9 +45,6 @@ impl RecentChooserDialog {
     }
 
     pub fn new_for_manager(title: &str, parent: Option<gtk::Window>, manager: &gtk::RecentManager) -> Option<RecentChooserDialog> {
-        let mut tmp_title = title.to_tmp_for_borrow();
-        let mut tmp_ok = "Ok".to_tmp_for_borrow();
-        let mut tmp_cancel = "Cancel".to_tmp_for_borrow();
         let parent = match parent {
             Some(ref p) => GTK_WINDOW(p.unwrap_widget()),
             None => ptr::null_mut()
@@ -58,10 +52,10 @@ impl RecentChooserDialog {
 
         let tmp_pointer = unsafe {
             ffi::gtk_recent_chooser_dialog_new_for_manager(
-                tmp_title.to_glib_ptr(), parent,
+                title.borrow_to_glib().0, parent,
                 GTK_RECENT_MANAGER(manager.unwrap_widget()),
-                tmp_ok.to_glib_ptr(), ResponseType::Ok,
-                tmp_cancel.to_glib_ptr(), ResponseType::Cancel,
+                "Ok".borrow_to_glib().0, ResponseType::Ok,
+                "Cancel".borrow_to_glib().0, ResponseType::Cancel,
                 ptr::null::<()>())
         };
 

--- a/src/gtk/widgets/recent_data.rs
+++ b/src/gtk/widgets/recent_data.rs
@@ -15,8 +15,7 @@
 
 use gtk::ffi;
 use libc::c_char;
-use std::ffi::CString;
-use glib::translate::{ToGlib, ToGlibPtr, ToTmp, ToArray, StackBox, PtrArray};
+use glib::translate::{ToGlib, ToGlibPtr, Stash};
 
 pub struct RecentData {
     display_name: String,
@@ -28,29 +27,31 @@ pub struct RecentData {
     is_private: bool
 }
 
-impl ToTmp for RecentData {
-    type Tmp = StackBox<ffi::C_GtkRecentData, ([CString; 5], PtrArray<String>)>;
+impl <'a> ToGlibPtr<'a, *mut ffi::C_GtkRecentData> for RecentData {
+    type Storage = (Box<ffi::C_GtkRecentData>,
+                    [Stash<'a, *mut c_char, String>; 5],
+                    Stash<'a, *mut *mut c_char, Vec<String>>);
 
-    fn to_tmp_for_borrow(&self)
-        -> StackBox<ffi::C_GtkRecentData, ([CString; 5], PtrArray<String>)> {
-        let mut tmp_display_name = self.display_name.to_tmp_for_borrow();
-        let mut tmp_description = self.description.to_tmp_for_borrow();
-        let mut tmp_mime_type = self.mime_type.to_tmp_for_borrow();
-        let mut tmp_app_name = self.app_name.to_tmp_for_borrow();
-        let mut tmp_app_exec = self.app_exec.to_tmp_for_borrow();
-        let mut tmp_groups = self.groups.to_array_for_borrow();
+    fn borrow_to_glib(&'a self)
+        -> Stash<*mut ffi::C_GtkRecentData, RecentData> {
+        let display_name = self.display_name.borrow_to_glib();
+        let description = self.description.borrow_to_glib();
+        let mime_type = self.mime_type.borrow_to_glib();
+        let app_name = self.app_name.borrow_to_glib();
+        let app_exec = self.app_exec.borrow_to_glib();
+        let groups = self.groups.borrow_to_glib();
 
-        let data = ffi::C_GtkRecentData {
-            display_name: tmp_display_name.to_glib_ptr() as *mut c_char,
-            description: tmp_description.to_glib_ptr() as *mut c_char,
-            mime_type: tmp_mime_type.to_glib_ptr() as *mut c_char,
-            app_name: tmp_app_name.to_glib_ptr() as *mut c_char,
-            app_exec: tmp_app_exec.to_glib_ptr() as *mut c_char,
-            groups: tmp_groups.to_glib_ptr() as *mut *mut c_char,
+        let mut data = Box::new(ffi::C_GtkRecentData {
+            display_name: display_name.0,
+            description: description.0,
+            mime_type: mime_type.0,
+            app_name: app_name.0,
+            app_exec: app_exec.0,
+            groups: groups.0,
             is_private: self.is_private.to_glib(),
-        };
+        });
 
-        StackBox(data, ([tmp_display_name, tmp_description, tmp_mime_type,
-                         tmp_app_name, tmp_app_exec], tmp_groups))
+        Stash(&mut *data, (data, [display_name, description, mime_type,
+                                            app_name, app_exec], groups))
     }
 }

--- a/src/gtk/widgets/recent_data.rs
+++ b/src/gtk/widgets/recent_data.rs
@@ -38,7 +38,7 @@ impl ToTmp for RecentData {
         let mut tmp_mime_type = self.mime_type.to_tmp_for_borrow();
         let mut tmp_app_name = self.app_name.to_tmp_for_borrow();
         let mut tmp_app_exec = self.app_exec.to_tmp_for_borrow();
-        let mut tmp_groups = (*self.groups).to_array_for_borrow();
+        let mut tmp_groups = self.groups.to_array_for_borrow();
 
         let data = ffi::C_GtkRecentData {
             display_name: tmp_display_name.to_glib_ptr() as *mut c_char,

--- a/src/gtk/widgets/recent_filter.rs
+++ b/src/gtk/widgets/recent_filter.rs
@@ -15,7 +15,7 @@
 
 use gtk::{self, ffi};
 use glib::to_bool;
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 
 #[derive(Copy)]
 pub struct RecentFilter {
@@ -35,15 +35,13 @@ impl RecentFilter {
 
     pub fn add_application(&self, application: &str) -> () {
         unsafe {
-            let mut tmp_application = application.to_tmp_for_borrow();
-            ffi::gtk_recent_filter_add_application(self.pointer, tmp_application.to_glib_ptr())
+            ffi::gtk_recent_filter_add_application(self.pointer, application.borrow_to_glib().0)
         }
     }
 
     pub fn add_group(&self, group: &str) -> () {
         unsafe {
-            let mut tmp_group = group.to_tmp_for_borrow();
-            ffi::gtk_recent_filter_add_group(self.pointer, tmp_group.to_glib_ptr())
+            ffi::gtk_recent_filter_add_group(self.pointer, group.borrow_to_glib().0)
         }
     }
 

--- a/src/gtk/widgets/recent_info.rs
+++ b/src/gtk/widgets/recent_info.rs
@@ -119,7 +119,7 @@ impl RecentInfo {
     pub fn last_application(&self) -> Option<String> {
         unsafe {
             FromGlibPtr::borrow(
-                ffi::gtk_recent_info_last_application(GTK_RECENT_INFO(self.unwrap_widget())) as *const c_char)
+                ffi::gtk_recent_info_last_application(GTK_RECENT_INFO(self.unwrap_widget())))
         }
     }
 
@@ -150,14 +150,14 @@ impl RecentInfo {
     pub fn get_short_name(&self) -> Option<String> {
         unsafe {
             FromGlibPtr::borrow(
-                ffi::gtk_recent_info_get_short_name(GTK_RECENT_INFO(self.unwrap_widget())) as *const c_char)
+                ffi::gtk_recent_info_get_short_name(GTK_RECENT_INFO(self.unwrap_widget())))
         }
     }
 
     pub fn get_uri_display(&self) -> Option<String> {
         unsafe {
             FromGlibPtr::borrow(
-                ffi::gtk_recent_info_get_uri_display(GTK_RECENT_INFO(self.unwrap_widget())) as *const c_char)
+                ffi::gtk_recent_info_get_uri_display(GTK_RECENT_INFO(self.unwrap_widget())))
         }
     }
 

--- a/src/gtk/widgets/recent_info.rs
+++ b/src/gtk/widgets/recent_info.rs
@@ -18,7 +18,7 @@ use glib::to_bool;
 use gtk::FFIWidget;
 use gtk::cast::GTK_RECENT_INFO;
 use std::ptr;
-use glib::translate::{FromGlibPtr, FromGlibPtrNotNull, FromGlibPtrContainer, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, FromGlibPtrNotNull, FromGlibPtrContainer, ToGlibPtr};
 use libc::c_char;
 
 struct_Widget!(RecentInfo);
@@ -87,12 +87,11 @@ impl RecentInfo {
             let mut app_exec = ptr::null();
             let mut count = 0u32;
             let mut time_ = 0i64;
-            let mut tmp_app_name = app_name.to_tmp_for_borrow();
 
             let ret = to_bool(
                 ffi::gtk_recent_info_get_application_info(
                     GTK_RECENT_INFO(self.unwrap_widget()),
-                    tmp_app_name.to_glib_ptr(),
+                    app_name.borrow_to_glib().0,
                     &mut app_exec,
                     &mut count,
                     &mut time_));
@@ -126,8 +125,7 @@ impl RecentInfo {
 
     pub fn has_application(&self, app_name: &str) -> bool {
         unsafe {
-            let mut tmp_app_name = app_name.to_tmp_for_borrow();
-            to_bool(ffi::gtk_recent_info_has_application(GTK_RECENT_INFO(self.unwrap_widget()), tmp_app_name.to_glib_ptr()))
+            to_bool(ffi::gtk_recent_info_has_application(GTK_RECENT_INFO(self.unwrap_widget()), app_name.borrow_to_glib().0))
         }
     }
 
@@ -143,10 +141,9 @@ impl RecentInfo {
 
     pub fn has_group(&self, group_name: &str) -> bool {
         unsafe {
-            let mut tmp_group_name = group_name.to_tmp_for_borrow();
             to_bool(
                 ffi::gtk_recent_info_has_group(GTK_RECENT_INFO(self.unwrap_widget()),
-                                               tmp_group_name.to_glib_ptr()))
+                                               group_name.borrow_to_glib().0))
         }
     }
 

--- a/src/gtk/widgets/recent_manager.rs
+++ b/src/gtk/widgets/recent_manager.rs
@@ -18,7 +18,7 @@ use glib::to_bool;
 use gtk::FFIWidget;
 use gtk::cast::GTK_RECENT_MANAGER;
 use glib;
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 
 struct_Widget!(RecentManager);
 
@@ -45,33 +45,29 @@ impl RecentManager {
 
     pub fn add_item(&self, uri: &str) -> bool {
         unsafe {
-            let mut tmp_uri = uri.to_tmp_for_borrow();
             to_bool(
                 ffi::gtk_recent_manager_add_item(
                     GTK_RECENT_MANAGER(self.unwrap_widget()),
-                    tmp_uri.to_glib_ptr()))
+                    uri.borrow_to_glib().0))
         }
     }
 
     pub fn add_full(&self, uri: &str, recent_data: &gtk::RecentData) -> bool {
         unsafe {
-            let mut tmp_uri = uri.to_tmp_for_borrow();
-            let mut tmp_recent_data = recent_data.to_tmp_for_borrow();
             to_bool(
                 ffi::gtk_recent_manager_add_full(
                     GTK_RECENT_MANAGER(self.unwrap_widget()),
-                    tmp_uri.to_glib_ptr(),
-                    tmp_recent_data.to_glib_ptr()))
+                    uri.borrow_to_glib().0,
+                    recent_data.borrow_to_glib().0))
         }
     }
 
     pub fn has_item(&self, uri: &str) -> bool {
         unsafe {
-            let mut tmp_uri = uri.to_tmp_for_borrow();
             to_bool(
                 ffi::gtk_recent_manager_has_item(
                     GTK_RECENT_MANAGER(self.unwrap_widget()),
-                    tmp_uri.to_glib_ptr()))
+                    uri.borrow_to_glib().0))
         }
     }
 

--- a/src/gtk/widgets/scale.rs
+++ b/src/gtk/widgets/scale.rs
@@ -16,7 +16,7 @@
 //! A slider widget for selecting a value from a range
 
 use libc::{c_double, c_int};
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 
 use gtk::{Orientation, PositionType};
 use gtk::cast::GTK_SCALE;
@@ -97,8 +97,7 @@ impl Scale {
 
     pub fn add_mark(&mut self, value: f64, position: PositionType, markup: &str) -> () {
         unsafe {
-            let mut tmp_markup = markup.to_tmp_for_borrow();
-            ffi::gtk_scale_add_mark(GTK_SCALE(self.pointer), value as c_double, position, tmp_markup.to_glib_ptr());
+            ffi::gtk_scale_add_mark(GTK_SCALE(self.pointer), value as c_double, position, markup.borrow_to_glib().0);
         }
     }
 

--- a/src/gtk/widgets/stack.rs
+++ b/src/gtk/widgets/stack.rs
@@ -19,7 +19,7 @@
 
 use gtk::{self, ffi};
 use gtk::cast::GTK_STACK;
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 use glib::{to_bool, to_gboolean};
 
 /// GtkStack — A stacking container
@@ -33,21 +33,18 @@ impl Stack {
 
     pub fn add_named<T: gtk::WidgetTrait>(&mut self, child: &T, name: &str) {
         unsafe {
-            let mut tmp_name = name.to_tmp_for_borrow();
             ffi::gtk_stack_add_named(GTK_STACK(self.pointer),
                                      child.unwrap_widget(),
-                                     tmp_name.to_glib_ptr())
+                                     name.borrow_to_glib().0)
         }
     }
 
     pub fn add_titled<T: gtk::WidgetTrait>(&mut self, child: &T, name: &str, title: &str) {
         unsafe {
-            let mut tmp_name = name.to_tmp_for_borrow();
-            let mut tmp_title = title.to_tmp_for_borrow();
             ffi::gtk_stack_add_titled(GTK_STACK(self.pointer),
                                       child.unwrap_widget(),
-                                      tmp_name.to_glib_ptr(),
-                                      tmp_title.to_glib_ptr())
+                                      name.borrow_to_glib().0,
+                                      title.borrow_to_glib().0)
         }
     }
 
@@ -69,9 +66,8 @@ impl Stack {
 
     pub fn set_visible_child_name(&mut self, name: &str) {
         unsafe {
-            let mut tmp_name = name.to_tmp_for_borrow();
             ffi::gtk_stack_set_visible_child_name(GTK_STACK(self.pointer),
-                                                  tmp_name.to_glib_ptr())
+                                                  name.borrow_to_glib().0)
         }
     }
 
@@ -84,9 +80,8 @@ impl Stack {
 
     pub fn set_visible_child_full(&mut self, name: &str, transition: gtk::StackTransitionType) {
         unsafe {
-            let mut tmp_name = name.to_tmp_for_borrow();
             ffi::gtk_stack_set_visible_child_full(GTK_STACK(self.pointer),
-                                                  tmp_name.to_glib_ptr(),
+                                                  name.borrow_to_glib().0,
                                                   transition)
         }
     }

--- a/src/gtk/widgets/status_bar.rs
+++ b/src/gtk/widgets/status_bar.rs
@@ -15,7 +15,7 @@
 
 //! An adapter which makes widgets scrollable
 
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 use gtk::cast::GTK_STATUSBAR;
 use gtk::{self, ffi};
 
@@ -31,10 +31,9 @@ impl StatusBar {
 
     pub fn push(&mut self, context_id: u32, text: &str) -> u32 {
         unsafe {
-            let mut tmp_text = text.to_tmp_for_borrow();
             ffi::gtk_statusbar_push(GTK_STATUSBAR(self.pointer),
                                     context_id,
-                                    tmp_text.to_glib_ptr())
+                                    text.borrow_to_glib().0)
         }
     }
 

--- a/src/gtk/widgets/text_iter.rs
+++ b/src/gtk/widgets/text_iter.rs
@@ -16,7 +16,6 @@
 //! GtkTextIter — Text buffer iterator
 
 use gtk::{self, ffi};
-use libc::c_char;
 use glib::{to_bool, to_gboolean};
 use glib::translate::{FromGlibPtr};
 
@@ -92,8 +91,7 @@ impl TextIter {
             FromGlibPtr::borrow(
                 ffi::gtk_text_iter_get_slice(
                     self.pointer as *const ffi::C_GtkTextIter,
-                    end.pointer as *const ffi::C_GtkTextIter)
-                as *const c_char)
+                    end.pointer as *const ffi::C_GtkTextIter))
         }
     }
 
@@ -102,8 +100,7 @@ impl TextIter {
             FromGlibPtr::borrow(
                 ffi::gtk_text_iter_get_text(
                     self.pointer as *const ffi::C_GtkTextIter,
-                    end.pointer as *const ffi::C_GtkTextIter)
-                as *const c_char)
+                    end.pointer as *const ffi::C_GtkTextIter))
         }
     }
 
@@ -112,8 +109,7 @@ impl TextIter {
             FromGlibPtr::borrow(
                 ffi::gtk_text_iter_get_visible_slice(
                     self.pointer as *const ffi::C_GtkTextIter,
-                    end.pointer as *const ffi::C_GtkTextIter)
-                as *const c_char)
+                    end.pointer as *const ffi::C_GtkTextIter))
         }
     }
 
@@ -122,8 +118,7 @@ impl TextIter {
             FromGlibPtr::borrow(
                 ffi::gtk_text_iter_get_visible_text(
                     self.pointer as *const ffi::C_GtkTextIter,
-                    end.pointer as *const ffi::C_GtkTextIter)
-                as *const c_char)
+                    end.pointer as *const ffi::C_GtkTextIter))
         }
     }
 

--- a/src/gtk/widgets/text_mark.rs
+++ b/src/gtk/widgets/text_mark.rs
@@ -16,7 +16,7 @@
 //! GtkTextMark — A position in the buffer preserved across buffer modifications
 
 use gtk::{self, ffi};
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 use glib::{to_bool, to_gboolean};
 
 pub struct TextMark {
@@ -26,8 +26,7 @@ pub struct TextMark {
 impl TextMark {
     pub fn new(name: &str, left_gravity: bool) -> Option<TextMark> {
         let tmp_pointer = unsafe {
-            let mut tmp_name = name.to_tmp_for_borrow();
-            ffi::gtk_text_mark_new(tmp_name.to_glib_ptr(), to_gboolean(left_gravity))
+            ffi::gtk_text_mark_new(name.borrow_to_glib().0, to_gboolean(left_gravity))
         };
 
         if tmp_pointer.is_null() {

--- a/src/gtk/widgets/text_tag.rs
+++ b/src/gtk/widgets/text_tag.rs
@@ -16,7 +16,7 @@
 //! GtkTextTag — A tag that can be applied to text in a GtkTextBuffer
 
 use gtk::ffi;
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 
 #[derive(Copy)]
 pub struct TextTag {
@@ -26,8 +26,7 @@ pub struct TextTag {
 impl TextTag {
     pub fn new(name: &str) -> Option<TextTag> {
         let tmp_pointer = unsafe {
-            let mut tmp_name = name.to_tmp_for_borrow();
-            ffi::gtk_text_tag_new(tmp_name.to_glib_ptr())
+            ffi::gtk_text_tag_new(name.borrow_to_glib().0)
         };
 
         if tmp_pointer.is_null() {

--- a/src/gtk/widgets/toggle_button.rs
+++ b/src/gtk/widgets/toggle_button.rs
@@ -15,7 +15,7 @@
 
 //! A button to launch a font chooser dialog
 
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 use gtk::{self, ffi};
 
 /// ToggleButton — A button to launch a font chooser dialog
@@ -33,16 +33,14 @@ impl ToggleButton {
 
     pub fn new_with_label(label: &str) -> Option<ToggleButton> {
         let tmp_pointer = unsafe {
-            let mut tmp_label = label.to_tmp_for_borrow();
-            ffi::gtk_toggle_button_new_with_label(tmp_label.to_glib_ptr())
+            ffi::gtk_toggle_button_new_with_label(label.borrow_to_glib().0)
         };
         check_pointer!(tmp_pointer, ToggleButton)
     }
 
     pub fn new_with_mnemonic(mnemonic: &str) -> Option<ToggleButton> {
         let tmp_pointer = unsafe {
-            let mut tmp_mnemonic = mnemonic.to_tmp_for_borrow();
-            ffi::gtk_toggle_button_new_with_mnemonic(tmp_mnemonic.to_glib_ptr())
+            ffi::gtk_toggle_button_new_with_mnemonic(mnemonic.borrow_to_glib().0)
         };
         check_pointer!(tmp_pointer, ToggleButton)
     }

--- a/src/gtk/widgets/toggle_tool_button.rs
+++ b/src/gtk/widgets/toggle_tool_button.rs
@@ -16,7 +16,7 @@
 //! A ToolItem containing a toggle button
 
 use gtk::{self, ffi};
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 
 /// ToggleToolButton — A ToolItem containing a toggle button
 struct_Widget!(ToggleToolButton);
@@ -28,8 +28,7 @@ impl ToggleToolButton {
     }
 
     pub fn new_from_stock(stock_id: &str) -> Option<ToggleToolButton> {
-        let mut tmp_stock_id = stock_id.to_tmp_for_borrow();
-        let tmp_pointer = unsafe { ffi::gtk_toggle_tool_button_new_from_stock(tmp_stock_id.to_glib_ptr()) };
+        let tmp_pointer = unsafe { ffi::gtk_toggle_tool_button_new_from_stock(stock_id.borrow_to_glib().0) };
         check_pointer!(tmp_pointer, ToggleToolButton)
     }
 }

--- a/src/gtk/widgets/tool_button.rs
+++ b/src/gtk/widgets/tool_button.rs
@@ -17,7 +17,7 @@
 
 use std::ptr;
 
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 use gtk::{self, ffi};
 
 /// ToolButton — A ToolItem subclass that displays buttons
@@ -26,20 +26,18 @@ struct_Widget!(ToolButton);
 impl ToolButton {
     pub fn new<T: gtk::WidgetTrait>(icon_widget: Option<&T>, label: Option<&str>) -> Option<ToolButton> {
         let tmp_pointer = unsafe {
-            let mut tmp_label = label.to_tmp_for_borrow();
             let icon_widget_ptr = match icon_widget {
                 Some(i) => i.unwrap_widget(),
                 None    => ptr::null_mut(),
             };
-            ffi::gtk_tool_button_new(icon_widget_ptr, tmp_label.to_glib_ptr())
+            ffi::gtk_tool_button_new(icon_widget_ptr, label.borrow_to_glib().0)
         };
         check_pointer!(tmp_pointer, ToolButton)
     }
 
     pub fn new_from_stock(stock_id: &str) -> Option<ToolButton> {
         let tmp_pointer = unsafe {
-            let mut tmp_stock_id = stock_id.to_tmp_for_borrow();
-            ffi::gtk_tool_button_new_from_stock(tmp_stock_id.to_glib_ptr())
+            ffi::gtk_tool_button_new_from_stock(stock_id.borrow_to_glib().0)
         };
         check_pointer!(tmp_pointer, ToolButton)
     }

--- a/src/gtk/widgets/tool_item_group.rs
+++ b/src/gtk/widgets/tool_item_group.rs
@@ -18,7 +18,7 @@
 use gtk::{self, ffi, ToolItem};
 use gtk::FFIWidget;
 use gtk::cast::{GTK_TOOL_ITEM_GROUP, GTK_TOOL_ITEM};
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 use glib::{to_bool, to_gboolean};
 
 struct_Widget!(ToolItemGroup);
@@ -26,8 +26,7 @@ struct_Widget!(ToolItemGroup);
 impl ToolItemGroup {
     pub fn new(label: &str) -> Option<ToolItemGroup> {
         let tmp_pointer = unsafe {
-            let mut tmp_label = label.to_tmp_for_borrow();
-            ffi::gtk_tool_item_group_new(tmp_label.to_glib_ptr())
+            ffi::gtk_tool_item_group_new(label.borrow_to_glib().0)
         };
         check_pointer!(tmp_pointer, ToolItemGroup)
     }
@@ -73,8 +72,7 @@ impl ToolItemGroup {
 
     pub fn set_label(&self, label: &str) {
         unsafe {
-            let mut tmp_label = label.to_tmp_for_borrow();
-            ffi::gtk_tool_item_group_set_label(GTK_TOOL_ITEM_GROUP(self.unwrap_widget()), tmp_label.to_glib_ptr())
+            ffi::gtk_tool_item_group_set_label(GTK_TOOL_ITEM_GROUP(self.unwrap_widget()), label.borrow_to_glib().0)
         }
     }
 

--- a/src/gtk/widgets/tree_model.rs
+++ b/src/gtk/widgets/tree_model.rs
@@ -15,7 +15,7 @@
 
 use libc::c_char;
 use glib::{Value, Type};
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp, from_glib};
+use glib::translate::{FromGlibPtr, ToGlibPtr, from_glib};
 use gtk::{self, ffi, TreeIter, TreePath};
 
 pub struct TreeModel {
@@ -43,8 +43,7 @@ impl TreeModel {
     }
 
     pub fn get_iter_from_string(&self, iter: &mut TreeIter, path_string: &str) -> bool {
-        let mut tmp_path_string = path_string.to_tmp_for_borrow();
-        match unsafe { ffi::gtk_tree_model_get_iter_from_string(self.pointer, iter.unwrap_pointer(), tmp_path_string.to_glib_ptr()) } {
+        match unsafe { ffi::gtk_tree_model_get_iter_from_string(self.pointer, iter.unwrap_pointer(), path_string.borrow_to_glib().0) } {
                 0 => false,
                 _ => true
             }

--- a/src/gtk/widgets/tree_model.rs
+++ b/src/gtk/widgets/tree_model.rs
@@ -13,7 +13,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
-use libc::c_char;
 use glib::{Value, Type};
 use glib::translate::{FromGlibPtr, ToGlibPtr, from_glib};
 use gtk::{self, ffi, TreeIter, TreePath};
@@ -132,8 +131,7 @@ impl TreeModel {
         unsafe {
             FromGlibPtr::take(
                 ffi::gtk_tree_model_get_string_from_iter(self.pointer,
-                                                         iter.unwrap_pointer())
-                    as *const c_char)
+                                                         iter.unwrap_pointer()))
         }
     }
 

--- a/src/gtk/widgets/tree_path.rs
+++ b/src/gtk/widgets/tree_path.rs
@@ -16,7 +16,6 @@
 extern crate libc;
 
 use gtk::ffi;
-use libc::{c_char};
 use glib::translate::{FromGlibPtr, ToGlibPtr};
 
 #[derive(Copy)]
@@ -79,8 +78,7 @@ impl TreePath {
     pub fn to_string(&self) -> Option<String> {
         unsafe {
             FromGlibPtr::take(
-                ffi::gtk_tree_path_to_string(self.pointer)
-                    as *const c_char)
+                ffi::gtk_tree_path_to_string(self.pointer))
         }
     }
 

--- a/src/gtk/widgets/tree_path.rs
+++ b/src/gtk/widgets/tree_path.rs
@@ -17,7 +17,7 @@ extern crate libc;
 
 use gtk::ffi;
 use libc::{c_char};
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 
 #[derive(Copy)]
 pub struct TreePath {
@@ -38,9 +38,8 @@ impl TreePath {
     }
 
     pub fn new_from_string(path: &str) -> Option<TreePath> {
-        let mut tmp_path = path.to_tmp_for_borrow();
         let tmp = unsafe {
-            ffi::gtk_tree_path_new_from_string(tmp_path.to_glib_ptr())
+            ffi::gtk_tree_path_new_from_string(path.borrow_to_glib().0)
         };
 
         if tmp.is_null() {

--- a/src/gtk/widgets/tree_store.rs
+++ b/src/gtk/widgets/tree_store.rs
@@ -17,7 +17,7 @@ use glib::{to_bool, Value, Type};
 use glib::translate::ToGlib;
 use gtk::{self, ffi};
 use gtk::TreeIter;
-use glib::translate::{ToGlibPtr, ToTmp};
+use glib::translate::ToGlibPtr;
 use std::num::ToPrimitive;
 
 pub struct TreeStore {
@@ -37,8 +37,7 @@ impl TreeStore {
     }
 
     pub fn set_string(&self, iter: &TreeIter, column: i32, text: &str) {
-        let mut tmp_text = text.to_tmp_for_borrow();
-        unsafe { ffi::gtk_tree_store_set(self.pointer, iter.unwrap_pointer(), column, tmp_text.to_glib_ptr(), -1) }
+        unsafe { ffi::gtk_tree_store_set(self.pointer, iter.unwrap_pointer(), column, text.borrow_to_glib().0, -1) }
     }
 
     pub fn remove(&self, iter: &TreeIter) -> bool {

--- a/src/gtk/widgets/tree_view_column.rs
+++ b/src/gtk/widgets/tree_view_column.rs
@@ -17,7 +17,7 @@
 
 use glib;
 use gtk::{self, ffi, cast};
-use glib::translate::{FromGlibPtr, ToGlibPtr, ToTmp};
+use glib::translate::{FromGlibPtr, ToGlibPtr};
 use glib::{to_bool, to_gboolean};
 
 pub struct TreeViewColumn {
@@ -140,9 +140,8 @@ impl TreeViewColumn {
 
     pub fn set_title(&mut self, title: &str) {
         unsafe {
-            let mut tmp_title = title.to_tmp_for_borrow();
             ffi::gtk_tree_view_column_set_title(self.pointer,
-                                                tmp_title.to_glib_ptr());
+                                                title.borrow_to_glib().0);
         }
     }
 
@@ -275,11 +274,10 @@ impl TreeViewColumn {
 
     pub fn add_attribute<T: gtk::FFIWidget + gtk::CellRendererTrait>(&self, cell: &T, attribute: &str, column: i32) {
         unsafe {
-            let mut tmp_attribute = attribute.to_tmp_for_borrow();
             ffi::gtk_tree_view_column_add_attribute(
                 self.pointer,
                 cast::GTK_CELL_RENDERER(cell.unwrap_widget()),
-                tmp_attribute.to_glib_ptr(),
+                attribute.borrow_to_glib().0,
                 column)
         }
 }


### PR DESCRIPTION
* Simplify `ToGlibPtr`. Remove `ToArray` and `ToTmp`. Use `Stash` for unified temporary storage. Don't bind temporary variables where the lifetime of the enclosing statement is sufficient i.e. almost everywhere.
* Make glib type an input type parameter instead of associated type for both `FromGlibPtr` and `ToGlibPtr`. Support both `*const c_char` and `*mut c_char` to avoid casting at the use sites.
* Fix the fn name in `FromGlib`.
* Tweak the `DialogButtons` implementation and related ffi definitions.