### PR TITLE
Add to_bool back

### DIFF
--- a/src/gtk/widgets/info_bar.rs
+++ b/src/gtk/widgets/info_bar.rs
@@ -21,7 +21,7 @@ use glib::translate::ToGlibPtr;
 use gtk::MessageType;
 use gtk::cast::GTK_INFOBAR;
 use gtk::{self, ffi};
-use glib::to_gboolean;
+use glib::{to_bool, to_gboolean};
 
 /// InfoBar — Report important messages to the user
 struct_Widget!(InfoBar);


### PR DESCRIPTION
This was removed in #239, but it is still required by this file. Build fails when GTK >= 3.10 is used.