### PR TITLE
Quell unused stuff warnings when building for lower GTK versions

### DIFF
--- a/examples/src/gtktest.rs
+++ b/examples/src/gtktest.rs
@@ -1,4 +1,4 @@
-#![crate_type = "bin"]
+#![cfg_attr(not(feature = "GTK_3_10"), allow(unused_variables, unused_mut))]
 
 extern crate rgtk;
 

--- a/src/gtk/widgets/builder.rs
+++ b/src/gtk/widgets/builder.rs
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with rgtk.  If not, see <http://www.gnu.org/licenses/>.
 
+#![cfg_attr(not(feature = "GTK_3_10"), allow(unused_imports))]
+
 use gtk::ffi::{self, C_GtkBuilder};
 use libc::{c_char, c_long};
 use gtk::traits::GObjectTrait;

--- a/src/gtk/widgets/info_bar.rs
+++ b/src/gtk/widgets/info_bar.rs
@@ -15,6 +15,8 @@
 
 //! Report important messages to the user
 
+#![cfg_attr(not(feature = "GTK_3_10"), allow(unused_imports))]
+
 use libc::c_int;
 use glib::translate::ToGlibPtr;
 

--- a/src/gtk/widgets/level_bar.rs
+++ b/src/gtk/widgets/level_bar.rs
@@ -15,6 +15,8 @@
 
 //! A bar that can used as a level indicator
 
+#![cfg_attr(not(feature = "GTK_3_8"), allow(unused_imports))]
+
 use libc::c_double;
 use glib::translate::ToGlibPtr;
 


### PR DESCRIPTION
This should make the project warning-free regardless of the enabled features.