### PR TITLE
Update build instructions in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,27 +3,44 @@ rgtk [![Build Status](https://travis-ci.org/jeremyletang/rgtk.svg?branch=master)
 
 __Rust__ bindings and wrappers for __GLib__, __GDK 3__, __GTK+ 3__  and __Cairo__.
 
-Installation
-============
+## Building
 
 __rgtk__ expects __GTK+__, __GLib__ and __Cairo__ development files to be installed on your system. Optionally, it is recommended to install the debug packages containing helpful debug symbols.
 
-For Debian based system:
+### Debian and Ubuntu
+
 ```Shell
-> apt-get install libgtk-3-dev   libglib2.0-dev   libcairo2-dev
-> apt-get install libgtk-3-0-dbg libglib2.0-0-dbg libcairo2-dbg
+> sudo apt-get install libgtk-3-dev
+> sudo apt-get install libgtk-3-0-dbg libglib2.0-0-dbg libcairo2-dbg
 ```
 
-For Fedora:
+### Fedora
+
 ```Shell
-> yum install gtk3-devel glib2-devel
+> sudo yum install gtk3-devel glib2-devel
 ```
 
-For OSX, install [XQuartz](http://xquartz.macosforge.org/landing/), then:
+### OS X
+
+Install [XQuartz](http://xquartz.macosforge.org/landing/), then:
 ```Shell
 > brew install gtk+3 --without-x11
 > export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/opt/X11/lib/pkgconfig
 ```
+
+### Windows
+
+Install [mingw-w64](http://mingw-w64.yaxm.org/) (select the win32 threading model) and download a __GTK+__ SDK:
+ * The GNOME project has an official distribution of GTK+ 3.6: [x86](http://www.gtk.org/download/win32.php), [x64](http://www.gtk.org/download/win64.php).
+ * [GTK+ for Windows Runtime Environment Installer: 64-bit](https://github.com/tschoonj/GTK-for-Windows-Runtime-Environment-Installer) supports GTK+ 3.14, its SDK downloads can currently be found [here](http://lvserver.ugent.be/gtk-win64/sdk/).
+
+Make sure both mingw's and the sdk's `bin` directories are in your `PATH` e.g. (assuming mingw is installed in `C:\mingw-w64` and the SDK unpacked into `C:\gtk`)
+```
+C:\> set PATH="C:\mingw-w64\bin;C:\gtk\bin;%PATH%"
+```
+It's crucial that GCC from mingw is used by Rust so either make sure that mingw is earlier in the `PATH` or delete `gcc.exe` and `ld.exe` from the Rust installation.
+
+## Versions and features
 
 __rgtk__ targets __GTK+__ 3.6 and __Cairo__ 1.10 by default, other versions support is enabled by requesting a corresponding feature e.g.
 ```Shell
@@ -36,15 +53,13 @@ We are currently targetting rust master compiler to build __rgtk__, make sure yo
 In `examples` you can find some tests showing off the functionality, these can be built and run as follows:
 
 ```Shell
-> cd examples/gtktest
-> cargo run
-
-> cd examples/cairotest
-> cargo run
+> cd examples
+> cargo build --release
+# Or, if your system has GTK 3.10 or later
+> cargo build --features GTK_3_10 --release
+> ./target/release/gtktest
+> ./target/release/cairotest
 ```
-
-__rgtk__ should build and work on both OSX and GNU/Linux. We plan on adding windows support in the future.
-
 
 When building documentation don't forget to specify the feature set you're using:
 
@@ -54,14 +69,13 @@ When building documentation don't forget to specify the feature set you're using
 
 Your local copy can be accessed using your browser at
 
-file:///{rgtk_location}/target/doc/rgtk/index.html
+`file:///{rgtk_location}/target/doc/rgtk/index.html`
 
 You can also access a daily build of the docs via the internet:
 
 http://rust-ci.org/jeremyletang/rgtk/doc/rgtk/
 
-Including rgtk as a cargo dependency
-====================================
+## Including rgtk as a cargo dependency
 
 To include rgtk as a cargo dependency you have to add it to your Cargo.toml and specify the GTK version you want using Cargo features
 ```Toml
@@ -70,8 +84,7 @@ git = "https://github.com/jeremyletang/rgtk.git"
 features = ["GTK_3_12"]
 ```
 
-Use __rgtk__
-============
+## Use __rgtk__
 
 To implement __GTK+__ inheritance in rust, we implemented gtk superclasses as traits located in `rgtk::gtk::traits::*`. The various widgets implement these traits and live in `rgtk::gtk::*`.
 
@@ -89,15 +102,13 @@ let button = gtk::Button:new(); // You have access to the struct methods of gtk:
                                 // as the trait methods from gtk::traits::Button as GtkButtonTrait.
 ```
 
-Projects using rgtk
-===================
+## Projects using rgtk
 * [SolidOak](https://github.com/oakes/SolidOak)
 * [rrun](https://github.com/buster/rrun)
 
 If you want yours to be added to this list, please create a Pull Request for it!
 
-Contribute
-==========
+## Contribute
 
 Contributor you're welcome!
 
@@ -119,7 +130,6 @@ GtkButtonBox is a sub-class of GtkBox, the struct `gtk::ButtonBox` implements al
 
 Finally, all the gtk widgets implement the trait gtk::traits::Widget.
 
-License
-=======
+## License
 
 __rgtk__ is available under the same license term as GTK+: the LGPL (Lesser General Public license).


### PR DESCRIPTION
Also tweak formatting.
I'd also just drop the discussion of the debug symbols from the top of the Readme.